### PR TITLE
making credentials and project id optional

### DIFF
--- a/src/main/java/co/cask/bigquery/BigQuerySinkConfig.java
+++ b/src/main/java/co/cask/bigquery/BigQuerySinkConfig.java
@@ -21,6 +21,8 @@ import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.plugin.PluginConfig;
 
+import javax.annotation.Nullable;
+
 /**
  * This class <code>BigQuerySinkConfig</code> provides all the configuration required for
  * configuring the <code>BigQuerySink</code> plugin.
@@ -39,6 +41,7 @@ public final class BigQuerySinkConfig extends PluginConfig {
   @Name("project")
   @Description("Project ID")
   @Macro
+  @Nullable
   public String project;
 
   @Name("bucket")
@@ -49,6 +52,7 @@ public final class BigQuerySinkConfig extends PluginConfig {
   @Name("serviceFilePath")
   @Description("Service Account File Path")
   @Macro
+  @Nullable
   public String serviceAccountFilePath;
 
   @Name("schema")

--- a/src/main/java/co/cask/bigquery/BigQuerySourceConfig.java
+++ b/src/main/java/co/cask/bigquery/BigQuerySourceConfig.java
@@ -21,6 +21,8 @@ import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.plugin.PluginConfig;
 
+import javax.annotation.Nullable;
+
 /**
  * Class description here.
  */
@@ -38,6 +40,7 @@ public final class BigQuerySourceConfig extends PluginConfig {
   @Name("project")
   @Description("Project ID")
   @Macro
+  @Nullable
   public String project;
 
   @Name("bucket")
@@ -48,6 +51,7 @@ public final class BigQuerySourceConfig extends PluginConfig {
   @Name("serviceFilePath")
   @Description("Service Account File Path")
   @Macro
+  @Nullable
   public String serviceAccountFilePath;
 
   @Name("schema")

--- a/src/main/java/co/cask/gcs/GCPUtil.java
+++ b/src/main/java/co/cask/gcs/GCPUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.gcs;
+
+import com.google.cloud.ServiceOptions;
+
+import javax.annotation.Nullable;
+
+/**
+ * GCP Utility class to validate project id
+ */
+public class GCPUtil {
+
+  /**
+   * If project id is not provided and cannot be detected from environment, throw an exception indicating that else
+   * return the project id.
+   */
+  public static String getProjectId(@Nullable String project) {
+    String projectId = project == null ? ServiceOptions.getDefaultProjectId() : project;
+    if (projectId == null) {
+      throw new IllegalArgumentException(
+        "Could not detect Google Cloud project id from the environment. Please specify a project id.");
+    }
+    return projectId;
+  }
+}

--- a/src/main/java/co/cask/gcs/actions/GCSBucketDelete.java
+++ b/src/main/java/co/cask/gcs/actions/GCSBucketDelete.java
@@ -23,6 +23,8 @@ import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.etl.api.action.Action;
 import co.cask.cdap.etl.api.action.ActionContext;
+import co.cask.gcs.GCPUtil;
+import com.google.cloud.ServiceOptions;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -51,10 +53,15 @@ public final class GCSBucketDelete extends Action {
   @Override
   public void run(ActionContext context) throws Exception {
     Configuration configuration = new Configuration();
-    configuration.set("google.cloud.auth.service.account.json.keyfile", config.serviceAccountFilePath);
+    if (config.serviceAccountFilePath != null) {
+      configuration.set("google.cloud.auth.service.account.json.keyfile", config.serviceAccountFilePath);
+    }
     configuration.set("fs.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem");
     configuration.set("fs.AbstractFileSystem.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS");
-    configuration.set("fs.gs.project.id", config.project);
+    // validate project id availability
+    String projectId = GCPUtil.getProjectId(config.project);
+    configuration.set("fs.gs.project.id", projectId);
+
     configuration.set("fs.gs.system.bucket", config.bucket);
     configuration.setBoolean("fs.gs.impl.disable.cache", true);
 
@@ -99,11 +106,13 @@ public final class GCSBucketDelete extends Action {
     @Name("project")
     @Description("Project ID")
     @Macro
+    @Nullable
     public String project;
 
     @Name("serviceFilePath")
     @Description("Service account file path.")
     @Macro
+    @Nullable
     public String serviceAccountFilePath;
 
     @Name("bucket")

--- a/src/main/java/co/cask/gcs/sink/GCSAvroBatchSink.java
+++ b/src/main/java/co/cask/gcs/sink/GCSAvroBatchSink.java
@@ -29,6 +29,7 @@ import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSinkContext;
 import co.cask.common.FileSetUtil;
 import co.cask.common.StructuredToAvroTransformer;
+import com.google.cloud.ServiceOptions;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.mapred.AvroKey;
 import org.apache.avro.mapreduce.AvroKeyOutputFormat;
@@ -116,11 +117,14 @@ public class GCSAvroBatchSink extends GCSBatchSink<AvroKey<GenericRecord>, NullW
       properties.put(JobContext.OUTPUT_KEY_CLASS, AvroKey.class.getName());
       properties.put(FileOutputFormat.OUTDIR, String.format("%s/%s", config.path,
                                                       format.format(context.getLogicalStartTime())));
-      properties.put("mapred.bq.auth.service.account.json.keyfile", config.serviceAccountFilePath);
-      properties.put("google.cloud.auth.service.account.json.keyfile", config.serviceAccountFilePath);
+      if (config.serviceAccountFilePath != null) {
+        properties.put("mapred.bq.auth.service.account.json.keyfile", config.serviceAccountFilePath);
+        properties.put("google.cloud.auth.service.account.json.keyfile", config.serviceAccountFilePath);
+      }
       properties.put("fs.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem");
       properties.put("fs.AbstractFileSystem.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS");
-      properties.put("fs.gs.project.id", config.project);
+      String projectId = config.project == null ? ServiceOptions.getDefaultProjectId() : config.project;
+      properties.put("fs.gs.project.id", projectId);
       properties.put("fs.gs.system.bucket", config.bucket);
       properties.put("fs.gs.impl.disable.cache", "true");
     }

--- a/src/main/java/co/cask/gcs/sink/GCSBatchSink.java
+++ b/src/main/java/co/cask/gcs/sink/GCSBatchSink.java
@@ -26,6 +26,7 @@ import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.batch.BatchSinkContext;
 import co.cask.common.ReferenceConfig;
 import co.cask.common.ReferenceSink;
+import co.cask.gcs.GCPUtil;
 import co.cask.hydrator.common.batch.sink.SinkOutputFormatProvider;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.reflect.TypeToken;
@@ -79,6 +80,8 @@ public abstract class GCSBatchSink<KEY_OUT, VAL_OUT> extends ReferenceSink<Struc
   @Override
   public final void prepareRun(BatchSinkContext context) {
     config.validate();
+    // validate project id availability
+    GCPUtil.getProjectId(config.project);
     OutputFormatProvider outputFormatProvider = createOutputFormatProvider(context);
     Map<String, String> outputConfig = new HashMap<>(outputFormatProvider.getOutputFormatConfiguration());
 
@@ -137,11 +140,13 @@ public abstract class GCSBatchSink<KEY_OUT, VAL_OUT> extends ReferenceSink<Struc
     @Name("project")
     @Description("Project ID")
     @Macro
+    @Nullable
     protected String project;
 
     @Name("serviceFilePath")
     @Description("Service account file path.")
     @Macro
+    @Nullable
     protected String serviceAccountFilePath;
 
     @Name("bucket")

--- a/src/main/java/co/cask/gcs/sink/GCSTextBatchSink.java
+++ b/src/main/java/co/cask/gcs/sink/GCSTextBatchSink.java
@@ -27,6 +27,7 @@ import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSinkContext;
 import co.cask.cdap.format.StructuredRecordStringConverter;
+import com.google.cloud.ServiceOptions;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.JobContext;
@@ -159,11 +160,14 @@ public class GCSTextBatchSink extends GCSBatchSink<NullWritable, Text> {
       properties.put(JobContext.OUTPUT_KEY_CLASS, Text.class.getName());
       properties.put(FileOutputFormat.OUTDIR, String.format("%s/%s", config.path,
                                                       format.format(context.getLogicalStartTime())));
-      properties.put("mapred.bq.auth.service.account.json.keyfile", config.serviceAccountFilePath);
-      properties.put("google.cloud.auth.service.account.json.keyfile", config.serviceAccountFilePath);
+      if (config.serviceAccountFilePath != null) {
+        properties.put("mapred.bq.auth.service.account.json.keyfile", config.serviceAccountFilePath);
+        properties.put("google.cloud.auth.service.account.json.keyfile", config.serviceAccountFilePath);
+      }
       properties.put("fs.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem");
       properties.put("fs.AbstractFileSystem.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS");
-      properties.put("fs.gs.project.id", config.project);
+      String projectId = config.project == null ? ServiceOptions.getDefaultProjectId() : config.project;
+      properties.put("fs.gs.project.id", projectId);
       properties.put("fs.gs.system.bucket", config.bucket);
       properties.put("fs.gs.impl.disable.cache", "true");
     }


### PR DESCRIPTION
Making serviceFilePath and projectId fields optional in the configs for in GCS, BigQuery source and sinks and actions GCS path create and delete.

We will try to get the project id from environment if its not provided and if we cannot get the project id we will throw an exception during prepareRun.

Tested the above plugins, however noticed a different issue while testing GCS Avro sink and opened a JIRA for that https://issues.cask.co/browse/CDAP-14229. 
