### PR TITLE
CDAP-14059 add spanner sink plugin

### DIFF
--- a/docs/Spanner-batchsink.md
+++ b/docs/Spanner-batchsink.md
@@ -1,3 +1,46 @@
-## Google Spanner Sink
+# Google Cloud Spanner Sink
 
-A Spanner sink to write records.
+Description
+-----------
+This sink writes to a Google Cloud Spanner table.
+Cloud Spanner is a fully managed, mission-critical, relational database service that offers transactional
+consistency at global scale, schemas, SQL (ANSI 2011 with extensions),
+and automatic, synchronous replication for high availability.
+
+Authorization
+-------------
+If the plugin is run on a Google Cloud Dataproc cluster, the service account key does not need to be provided.
+Credentials will be automatically read from the cluster environment.
+
+If the plugin is not run on a Dataproc cluster, the path to a service account key must be provided.
+The service account key can be found on the Dashboard in the Cloud Platform Console.
+Make sure the account key has permission to access Google Cloud Spanner.
+The service account key file needs to be available on every node in your cluster and
+must be readable by all users running the job.
+
+Properties
+----------
+**Project ID**: The Google Cloud Project ID, which uniquely identifies a project.
+It can be found on the Dashboard in the Google Cloud Platform Console.
+
+**Service Account File Path**: Path on the local file system of the service account key used for
+authorization. Does not need to be specified when running on a Dataproc cluster.
+When running on other clusters, the file must be present on every node in the cluster.
+
+**Instance**: The instance the Spanner database belongs to. Spanner instance is contained within a specific project.
+ Instance is an allocation of resources that is used by Cloud Spanner databases created in that instance.
+
+**Database**: The database the Spanner table belongs to.
+Spanner database is contained within a specific Spanner instance.
+
+**Table**: The table to write to. A table contains individual records organized in rows.
+Each record is composed of columns (also called fields).
+Every table is defined by a schema that describes the column names, data types, and other information.
+
+**Schema**: The schema of the data to write. Must be compatible with the table schema.
+
+**BatchSize**: Size (in number of records) of the batched writes to the Spanner table.
+Each write to Cloud Spanner contains some overhead. To maximize bulk write throughput,
+maximize the amount of data stored per write. A good technique is for each commit to mutate hundreds of rows.
+Commits with the number of mutations in the range of 1 MiB - 5 MiB rows usually provide the best performance.
+Default value is 100 mutations.

--- a/src/main/java/co/cask/spanner/SpannerConstants.java
+++ b/src/main/java/co/cask/spanner/SpannerConstants.java
@@ -27,4 +27,7 @@ public final class SpannerConstants {
   public static final String PARTITIONS_LIST = "partitions.list";
   public static final String QUERY = "query";
   public static final String SPANNER_BATCH_TRANSACTION_ID = "spanner.batch.transaction.id";
+  public static final String TABLE_NAME = "table";
+  public static final String SPANNER_WRITE_BATCH_SIZE = "spanner.write.batch.size";
+  public static final String SCHEMA = "schema";
 }

--- a/src/main/java/co/cask/spanner/common/SpannerUtil.java
+++ b/src/main/java/co/cask/spanner/common/SpannerUtil.java
@@ -20,7 +20,7 @@ import co.cask.common.GCPUtils;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerOptions;
 
-import java.net.URLEncoder;
+import java.io.IOException;
 
 /**
  * Spanner utility classs to get spanner service
@@ -29,7 +29,7 @@ public class SpannerUtil {
   /**
    * Construct and return the {@link Spanner} service for the provided credentials and projectId
    */
-  public static Spanner getSpannerService(String serviceAccountFilePath, String projectId) throws Exception {
+  public static Spanner getSpannerService(String serviceAccountFilePath, String projectId) throws IOException {
     SpannerOptions.Builder optionsBuilder = SpannerOptions.newBuilder();
     if (serviceAccountFilePath != null) {
       optionsBuilder.setCredentials(GCPUtils.loadServiceAccountCredentials(serviceAccountFilePath));

--- a/src/main/java/co/cask/spanner/sink/SpannerOutputFormat.java
+++ b/src/main/java/co/cask/spanner/sink/SpannerOutputFormat.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.spanner.sink;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.gcs.GCPUtil;
+import co.cask.spanner.SpannerConstants;
+import co.cask.spanner.common.SpannerUtil;
+import com.google.cloud.ByteArray;
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.DatabaseId;
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.Spanner;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.OutputFormat;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Spanner output format
+ */
+public class SpannerOutputFormat extends OutputFormat<NullWritable, StructuredRecord> {
+  private static final Logger LOG = LoggerFactory.getLogger(SpannerOutputFormat.class);
+
+  /**
+   * Get properties from SparkSinkConfig and store them as properties in Configuration
+   * @param configuration
+   * @param config
+   */
+  public static void configure(Configuration configuration, SpannerSinkConfig config) {
+    String projectId = GCPUtil.getProjectId(config.project);
+    configuration.set(SpannerConstants.PROJECT_ID, projectId);
+    if (config.serviceFilePath != null) {
+      configuration.set(SpannerConstants.SERVICE_ACCOUNT_FILE_PATH, config.serviceFilePath);
+    }
+    configuration.set(SpannerConstants.INSTANCE_ID, config.instance);
+    configuration.set(SpannerConstants.DATABASE, config.database);
+    configuration.set(SpannerConstants.TABLE_NAME, config.table);
+    configuration.set(SpannerConstants.SPANNER_WRITE_BATCH_SIZE, String.valueOf(config.getBatchSize()));
+    configuration.set(SpannerConstants.SCHEMA, config.getSchema().toString());
+  }
+
+  @Override
+  public RecordWriter<NullWritable, StructuredRecord> getRecordWriter(TaskAttemptContext context)
+    throws IOException, InterruptedException {
+    Configuration configuration = context.getConfiguration();
+    String projectId = configuration.get(SpannerConstants.PROJECT_ID);
+    String instanceId = configuration.get(SpannerConstants.INSTANCE_ID);
+    String database = configuration.get(SpannerConstants.DATABASE);
+    String serviceFilePath = configuration.get(SpannerConstants.SERVICE_ACCOUNT_FILE_PATH);
+    String tableName = configuration.get(SpannerConstants.TABLE_NAME);
+    Schema schema = Schema.parseJson(configuration.get(SpannerConstants.SCHEMA));
+    Spanner spanner = SpannerUtil.getSpannerService(serviceFilePath, projectId);
+    int batchSize = Integer.parseInt(configuration.get(SpannerConstants.SPANNER_WRITE_BATCH_SIZE));
+    DatabaseId db = DatabaseId.of(projectId, instanceId, database);
+    DatabaseClient client = spanner.getDatabaseClient(db);
+    return new SpannerRecordWriter(spanner, tableName, client, batchSize, schema);
+  }
+
+  /**
+   * Spanner record writer that buffers mutations and writes to spanner
+   */
+  protected static class SpannerRecordWriter extends RecordWriter<NullWritable, StructuredRecord> {
+    private final Spanner spanner;
+    private final String tableName;
+    private final DatabaseClient databaseClient;
+    private final List<Mutation> mutations;
+    private final int batchSize;
+    private final Schema schema;
+
+    public SpannerRecordWriter(Spanner spanner, String tableName, DatabaseClient client, int batchSize,
+                               Schema schema) {
+      this.spanner = spanner;
+      this.tableName = tableName;
+      this.databaseClient = client;
+      this.mutations = new ArrayList<>();
+      this.batchSize = batchSize;
+      this.schema = schema;
+    }
+
+    @Override
+    public void write(NullWritable nullWritable, StructuredRecord record) throws IOException, InterruptedException {
+      Mutation.WriteBuilder builder = Mutation.newInsertOrUpdateBuilder(tableName);
+      List<Schema.Field> fields = schema.getFields();
+      for (Schema.Field field : fields) {
+        Schema fieldSchema = field.getSchema();
+        Schema.Type type = fieldSchema.isNullable() ? fieldSchema.getNonNullable().getType() : fieldSchema.getType();
+        String name = field.getName();
+        switch(type) {
+          case BOOLEAN:
+            builder.set(name).to(record.<Boolean>get(name));
+            break;
+          case STRING:
+            builder.set(name).to(record.<String>get(name));
+            break;
+          case LONG:
+            builder.set(name).to(record.<Long>get(name));
+            break;
+          case DOUBLE:
+            builder.set(name).to(record.<Double>get(name));
+            break;
+          case BYTES:
+            byte[] byteArray = record.get(name);
+            builder.set(name).to(ByteArray.copyFrom(byteArray));
+            break;
+          // todo CDAP-14233 - add support for array, date and timestamp
+          default:
+            throw new IOException(type.name() + " : Type currently not supported.");
+        }
+      }
+      mutations.add(builder.build());
+      if (mutations.size() > batchSize) {
+        databaseClient.write(mutations);
+        mutations.clear();
+      }
+    }
+
+    @Override
+    public void close(TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
+      if (mutations.size() > 0) {
+        databaseClient.write(mutations);
+        mutations.clear();
+      }
+      spanner.close();
+    }
+  }
+
+  @Override
+  public void checkOutputSpecs(JobContext jobContext) throws IOException, InterruptedException {
+  }
+
+  /**
+   * No op output committer
+   */
+  @Override
+  public OutputCommitter getOutputCommitter(TaskAttemptContext taskAttemptContext)
+    throws IOException, InterruptedException {
+    return new OutputCommitter() {
+      @Override
+      public void setupJob(JobContext jobContext) throws IOException {
+
+      }
+
+      @Override
+      public void setupTask(TaskAttemptContext taskAttemptContext) throws IOException {
+
+      }
+
+      @Override
+      public boolean needsTaskCommit(TaskAttemptContext taskAttemptContext) throws IOException {
+        return false;
+      }
+
+      @Override
+      public void commitTask(TaskAttemptContext taskAttemptContext) throws IOException {
+
+      }
+
+      @Override
+      public void abortTask(TaskAttemptContext taskAttemptContext) throws IOException {
+
+      }
+    };
+  }
+}

--- a/src/main/java/co/cask/spanner/sink/SpannerSink.java
+++ b/src/main/java/co/cask/spanner/sink/SpannerSink.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.spanner.sink;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.batch.Output;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
+import co.cask.cdap.etl.api.batch.BatchSinkContext;
+import co.cask.gcs.GCPUtil;
+import co.cask.hydrator.common.ReferenceBatchSink;
+import co.cask.hydrator.common.batch.sink.SinkOutputFormatProvider;
+import co.cask.spanner.SpannerConstants;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.NullWritable;
+
+
+/**
+ * This class extends {@link ReferenceBatchSink} to write to Google Cloud Spanner.
+ *
+ * Uses a {@link SpannerOutputFormat} and {@link SpannerOutputFormat.SpannerRecordWriter} to configure
+ * and write to spanner. The <code>prepareRun</code> method configures the job by extracting
+ * the user provided configuration and preparing it to be passed to {@link SpannerOutputFormat}.
+ *
+ */
+@Plugin(type = "batchsink")
+@Name(SpannerSink.NAME)
+@Description("Batch sink to write to Cloud Spanner. Cloud Spanner is a fully managed, mission-critical, " +
+  "relational database service that offers transactional consistency at global scale, schemas, " +
+  "SQL (ANSI 2011 with extensions), and automatic, synchronous replication for high availability.")
+public final class SpannerSink
+  extends ReferenceBatchSink<StructuredRecord, NullWritable, StructuredRecord> {
+  public static final String NAME = "Spanner";
+  private final SpannerSinkConfig config;
+
+  /**
+   * Initializes <code>SpannerSink</code>.
+   * @param config
+   */
+  public SpannerSink(SpannerSinkConfig config) {
+    super(config);
+    this.config = config;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    config.validate();
+  }
+
+  @Override
+  public void prepareRun(BatchSinkContext context) throws Exception {
+    config.validate();
+    Configuration configuration = new Configuration();
+    SpannerOutputFormat.configure(configuration, config);
+    context.addOutput(Output.of(config.referenceName,
+                                new SinkOutputFormatProvider(SpannerOutputFormat.class, configuration)));
+  }
+
+  @Override
+  public void initialize(BatchRuntimeContext context) throws Exception {
+    super.initialize(context);
+    config.validate();
+  }
+
+  @Override
+  public void transform(StructuredRecord input,
+                        Emitter<KeyValue<NullWritable, StructuredRecord>> emitter) throws Exception {
+    emitter.emit(new KeyValue<>(null, input));
+  }
+
+  @Override
+  public void destroy() {
+    super.destroy();
+  }
+}

--- a/src/main/java/co/cask/spanner/sink/SpannerSinkConfig.java
+++ b/src/main/java/co/cask/spanner/sink/SpannerSinkConfig.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.spanner.sink;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.spanner.common.SpannerConfig;
+
+import javax.annotation.Nullable;
+
+/**
+ * Spanner sink config
+ */
+public class SpannerSinkConfig extends SpannerConfig {
+  private static final int DEFAULT_SPANNER_WRITE_BATCH_SIZE = 100;
+
+  @Name("table")
+  @Description("Cloud Spanner table id. Uniquely identifies your table within the Cloud Spanner database")
+  @Macro
+  public String table;
+
+  @Name("batchSize")
+  @Description("Size of the batched writes to the Spanner table. " +
+    "When the number of buffered mutations is greater than this batchSize, " +
+    "the mutations are written to Spanner table, Default value is 100")
+  @Macro
+  @Nullable
+  public Integer batchSize;
+
+  public SpannerSinkConfig(String referenceName) {
+    super(referenceName);
+  }
+
+  public void validate() {
+    super.validate();
+    if (!containsMacro("batchSize") && batchSize != null && batchSize < 1) {
+      throw new IllegalArgumentException("Spanner batch size for writes should be positive");
+    }
+  }
+
+  public int getBatchSize() {
+    return batchSize == null ? DEFAULT_SPANNER_WRITE_BATCH_SIZE : batchSize;
+  }
+}

--- a/widgets/Spanner-batchsink.json
+++ b/widgets/Spanner-batchsink.json
@@ -1,0 +1,92 @@
+{
+  "metadata": {
+    "spec-version": "1.5"
+  },
+  "display-name": "Google Cloud Spanner Sink",
+  "configuration-groups": [
+    {
+      "label" : "Governance",
+      "properties" : [
+        {
+          "widget-type": "textbox",
+          "label": "Reference Name",
+          "name": "referenceName"
+        }
+      ]
+    },
+    {
+      "label" : "Service Account and Project",
+      "properties" : [
+        {
+          "widget-type": "textbox",
+          "label": "Project Id",
+          "name": "project",
+          "widget-attributes" : {
+            "placeholder": "GCP Project Id."
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Service Account File Path",
+          "name": "serviceFilePath",
+          "widget-attributes" : {
+            "placeholder": "Path to service account file (Local to host running on)."
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Instance Id",
+          "name": "instance",
+          "widget-attributes" : {
+            "placeholder": "Cloud Spanner Instance Id."
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Database Name",
+          "name": "database",
+          "widget-attributes" : {
+            "placeholder": "Cloud Spanner database name."
+          }
+        }
+      ]
+    },
+    {
+      "label" : "Table Name and Properties",
+      "properties" : [
+        {
+          "widget-type": "textbox",
+          "label": "Table Name",
+          "name": "table",
+          "widget-attributes" : {
+            "placeholder": "Cloud Spanner table name."
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Write batch size",
+          "name": "batchSize",
+          "widget-attributes" : {
+            "placeholder": "Maximum number of records to buffer in RecordWriter before writing to spanner table."
+          }
+        }
+      ]
+    }
+  ],
+  "outputs": [
+    {
+      "name": "schema",
+      "widget-type": "schema",
+      "widget-attributes": {
+        "schema-types": [
+          "boolean",
+          "long",
+          "double",
+          "string",
+          "bytes"
+        ],
+        "schema-default-type": "string"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Spanner sink plugin to write to Google Cloud Spanner. 

Batch size of writes is configurable through the plugin config. The records are converted to mutations and buffered in record writer until the batch size and then written to Spanner table after it exceeds the batch size. 
