### PR TITLE
feature/CDAP-14185 Add Google Cloud PubSub Streaming Source

### DIFF
--- a/docs/GoogleSubscriber-streamingsource.md
+++ b/docs/GoogleSubscriber-streamingsource.md
@@ -1,0 +1,38 @@
+# Google Cloud PubSub Streaming Source
+
+Description
+-----------
+This sources reads from a Google Cloud Pub/Sub subscription in realtime.
+Cloud Pub/Sub brings the scalability, flexibility, and reliability of enterprise message-oriented
+middleware to the cloud. By providing many-to-many, asynchronous messaging that decouples senders and receivers,
+it allows for secure and highly available communication between independently written applications.
+
+Credentials
+-----------
+If the plugin is run on a Google Cloud Dataproc cluster, the service account key does not need to be
+provided and can be set to 'auto-detect'.
+Credentials will be automatically read from the cluster environment.
+
+If the plugin is not run on a Dataproc cluster, the path to a service account key must be provided.
+The service account key can be found on the Dashboard in the Cloud Platform Console.
+Make sure the account key has permission to access Google Cloud Pub/Sub.
+The service account key file needs to be available on every node in your cluster and
+must be readable by all users running the job.
+
+Properties
+----------
+**Reference Name:** Name used to uniquely identify this sink for lineage, annotating metadata, etc.
+
+**Project ID**: Google Cloud Project ID, which uniquely identifies a project.
+It can be found on the Dashboard in the Google Cloud Platform Console.
+
+**Subscription**: Name of the Google Cloud PubSub subscription to subscribe.
+If the subscription needs to be created then the topic to which the subscription will belong must be provided.
+
+**Topic**: Name of the Google Cloud PubSub topic to subscribe to. If a topic is provided and the given subscriber
+does not exists it will be created. If a subscriber does not exists and is created only the messages arrived after
+the creation of subscriber will be received.
+
+**Service Account File Path**: Path on the local file system of the service account key used for
+authorization. Can be set to 'auto-detect' when running on a Dataproc cluster.
+When running on other clusters, the file must be present on every node in the cluster.

--- a/pom.xml
+++ b/pom.xml
@@ -396,6 +396,13 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- Start: dependency for Google PubSub Streaming Source -->
+    <dependency>
+      <groupId>org.apache.bahir</groupId>
+      <artifactId>spark-streaming-pubsub_2.11</artifactId>
+      <version>2.2.1</version>
+    </dependency>
+    <!-- End: dependency for Google PubSub Streaming Source -->
   </dependencies>
 
   <build>
@@ -445,6 +452,7 @@
                 org.apache.avro.mapreduce;
                 parquet.avro.*;
                 parquet.hadoop.*;
+                org.apache.spark.streaming.pubsub*;
               </_exportcontents>
             </instructions>
           </configuration>

--- a/src/main/java/co/cask/gcp/publisher/source/GoogleSubscriber.java
+++ b/src/main/java/co/cask/gcp/publisher/source/GoogleSubscriber.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.gcp.publisher.source;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.streaming.StreamingContext;
+import co.cask.cdap.etl.api.streaming.StreamingSource;
+import co.cask.gcp.common.GCPReferenceSourceConfig;
+import com.google.cloud.Timestamp;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.storage.StorageLevel;
+import org.apache.spark.streaming.api.java.JavaDStream;
+import org.apache.spark.streaming.api.java.JavaReceiverInputDStream;
+import org.apache.spark.streaming.pubsub.PubsubUtils;
+import org.apache.spark.streaming.pubsub.SparkGCPCredentials;
+import org.apache.spark.streaming.pubsub.SparkGCPCredentials.Builder;
+import org.apache.spark.streaming.pubsub.SparkPubsubMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import javax.annotation.Nullable;
+
+/**
+ * Realtime source plugin to read from Google PubSub.
+ */
+@Plugin(type = StreamingSource.PLUGIN_TYPE)
+@Name("GoogleSubscriber")
+@Description("Streaming Source to read messages from Google PubSub.")
+public class GoogleSubscriber extends StreamingSource<StructuredRecord> {
+  private static final Logger LOG = LoggerFactory.getLogger(GoogleSubscriber.class);
+  private static final Schema DEFAULT_SCHEMA =
+    Schema.recordOf("event",
+                    Schema.Field.of("message", Schema.of(Schema.Type.BYTES)),
+                    Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+                    Schema.Field.of("timestamp", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS))
+    );
+
+  private SubscriberConfig config;
+
+  public GoogleSubscriber(SubscriberConfig conf) {
+    this.config = conf;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
+    super.configurePipeline(pipelineConfigurer);
+    pipelineConfigurer.getStageConfigurer().setOutputSchema(DEFAULT_SCHEMA);
+  }
+
+  @Override
+  public JavaDStream<StructuredRecord> getStream(StreamingContext streamingContext) {
+    String serviceAccountFilePath = config.getServiceAccountFilePath();
+    SparkGCPCredentials credentials;
+    if (serviceAccountFilePath != null) {
+      // if credential file is provided then use it to build SparkGCPCredentials
+      LOG.debug("Building credentials from specified service account file.");
+      credentials = new Builder().jsonServiceAccount(serviceAccountFilePath).build();
+    } else {
+      // this will use the application default credential which is available when running on google cloud
+      LOG.debug("No service account file specified. Building credentials using Application Default Credentials.");
+      credentials = new Builder().build();
+    }
+
+    JavaReceiverInputDStream<SparkPubsubMessage> pubSubMessages =
+      PubsubUtils.createStream(streamingContext.getSparkStreamingContext(), config.getProject(), config.topic,
+                               config.subscription, credentials, StorageLevel.MEMORY_ONLY());
+
+    return pubSubMessages.map((Function<SparkPubsubMessage, StructuredRecord>) pubSubMessage -> StructuredRecord.builder(DEFAULT_SCHEMA)
+      .set("message", pubSubMessage.getData())
+      .set("id", pubSubMessage.getMessageId())
+      .setTimestamp("timestamp", getTimestamp(pubSubMessage.getPublishTime())).build());
+  }
+
+  private ZonedDateTime getTimestamp(String publishTime) {
+    Timestamp timestamp = Timestamp.parseTimestamp(publishTime);
+    // https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage
+    // Google cloud pubsub message timestamp is in RFC3339 UTC "Zulu" format, accurate to nanoseconds.
+    // CDAP Schema only supports microsecond level precision so handle the case
+    Instant instant = Instant.ofEpochSecond(timestamp.getSeconds()).plusNanos(timestamp.getNanos());
+    return ZonedDateTime.ofInstant(instant, ZoneId.ofOffset("UTC", ZoneOffset.UTC));
+  }
+
+  public static class SubscriberConfig extends GCPReferenceSourceConfig {
+
+    @Description("Cloud Pub/Sub subscription to read from. If the subscription does not exist it will be " +
+      "automatically created if a topic is specified. Messages published before the subscription was created will " +
+      "not be read.")
+    @Macro
+    private String subscription;
+
+    @Description("Cloud Pub/Sub topic to subscribe messages from. If a topic is provided and the given subscription " +
+      "does not exists it will be created. Note: If a subscription does not exists and is created only the messages " +
+      "arrived after the creation of subscription will be received.")
+    @Macro
+    @Nullable
+    private String topic;
+  }
+}

--- a/widgets/GoogleSubscriber-streamingsource.json
+++ b/widgets/GoogleSubscriber-streamingsource.json
@@ -1,0 +1,91 @@
+{
+  "metadata": {
+    "spec-version": "1.5"
+  },
+  "display-name": "Google Cloud PubSub",
+  "configuration-groups": [
+    {
+      "label": "Basic",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Reference Name",
+          "name": "referenceName",
+          "widget-attributes": {
+            "placeholder": "Name used to identify this sink for lineage"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Project ID",
+          "name": "project",
+          "widget-attributes": {
+            "default": "auto-detect"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Subscription",
+          "name": "subscription",
+          "widget-attributes": {
+            "placeholder": "Subscription to read from"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Topic",
+          "name": "topic",
+          "widget-attributes": {
+            "placeholder": "Topic to create the subscription from if it does not already exist"
+          }
+        }
+      ]
+    },
+    {
+      "label": "Credentials",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Service Account File Path",
+          "name": "serviceFilePath",
+          "widget-attributes": {
+            "default": "auto-detect"
+          }
+        }
+      ]
+    }
+  ],
+  "outputs": [
+    {
+      "widget-type": "non-editable-schema-editor",
+      "schema": {
+        "name": "etlSchemaBody",
+        "type": "record",
+        "fields": [
+          {
+            "name": "message",
+            "type": "bytes"
+          },
+          {
+            "name": "id",
+            "type": "string"
+          },
+          {
+            "name": "timestamp",
+            "type": {
+              "type": "long",
+              "logicalType": "timestamp-micros"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "jump-config": {
+    "datasets": [
+      {
+        "ref-property-name": "referenceName"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Summary
- Adds Google PubSub Streaming source.
- It uses [Apache Bahir](https://github.com/apache/bahir/tree/master/streaming-pubsub) to create DStreams.
- It creates a `SparkGCPCredentials` from the service json file if one is provided and if not then it will use [Application Default Credentials](https://cloud.google.com/docs/authentication/production) Note: ADC part needs to be tested to work yet but since plugin is realtime its pending.
- FLL is not supported for Realtime Plugins so this does not include FLL.

Issue: https://issues.cask.co/browse/CDAP-14185


