### PR TITLE
Fix lineage in BQ plugins

### DIFF
--- a/src/main/java/co/cask/gcp/bigquery/BigQuerySink.java
+++ b/src/main/java/co/cask/gcp/bigquery/BigQuerySink.java
@@ -121,8 +121,10 @@ public final class BigQuerySink extends BatchSink<StructuredRecord, JsonObject, 
       BigQueryFileFormat.NEWLINE_DELIMITED_JSON,
       TextOutputFormat.class);
 
-    setOutputFormat(context);
+    // Both emitLineage and setOutputFormat internally try to create an external dataset if it does not already exists.
+    // We call emitLineage before since it creates the dataset with schema which .
     emitLineage(context, fields);
+    setOutputFormat(context);
   }
 
   @Override

--- a/src/main/java/co/cask/gcp/bigquery/BigQuerySource.java
+++ b/src/main/java/co/cask/gcp/bigquery/BigQuerySource.java
@@ -112,8 +112,10 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
     job.setOutputKeyClass(LongWritable.class);
     job.setOutputKeyClass(Text.class);
 
-    setInputFormat(context);
+    // Both emitLineage and setOutputFormat internally try to create an external dataset if it does not already exists.
+    // We call emitLineage before since it creates the dataset with schema which .
     emitLineage(context);
+    setInputFormat(context);
   }
 
   @Override


### PR DESCRIPTION
Lineage should be emitted after `addOutput` or `setInput` because it creates an external dataset.