### PR TITLE
Fix path macro in gcs sink

### DIFF
--- a/src/main/java/co/cask/gcp/bigquery/BigQueryUtils.java
+++ b/src/main/java/co/cask/gcp/bigquery/BigQueryUtils.java
@@ -116,17 +116,25 @@ final class BigQueryUtils {
   @Nullable
   static Table getBigQueryTable(@Nullable String serviceAccountFilePath, String project,
                                 String dataset, String table) throws IOException {
-    BigQuery bigquery;
+    BigQuery bigquery = getBigQuery(serviceAccountFilePath, project);
+
+    TableId id = TableId.of(project, dataset, table);
+    return bigquery.getTable(id);
+  }
+
+  /**
+   * Get BigQuery service
+   * @param serviceAccountFilePath service account file path
+   * @param project BigQuery project ID
+   */
+  static BigQuery getBigQuery(@Nullable String serviceAccountFilePath, String project) throws IOException {
     BigQueryOptions.Builder bigqueryBuilder = BigQueryOptions.newBuilder();
     if (serviceAccountFilePath != null) {
       bigqueryBuilder.setCredentials(loadServiceAccountCredentials(serviceAccountFilePath));
     }
 
     bigqueryBuilder.setProjectId(project);
-    bigquery = bigqueryBuilder.build().getService();
-
-    TableId id = TableId.of(project, dataset, table);
-    return bigquery.getTable(id);
+    return bigqueryBuilder.build().getService();
   }
 
   /**

--- a/src/main/java/co/cask/gcp/gcs/sink/GCSBatchSink.java
+++ b/src/main/java/co/cask/gcp/gcs/sink/GCSBatchSink.java
@@ -116,7 +116,10 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
     @Override
     public void validate() {
       super.validate();
-      GCSConfigHelper.getPath(path);
+      // validate that path is valid
+      if (!containsMacro("path")) {
+        GCSConfigHelper.getPath(path);
+      }
       if (suffix != null && !containsMacro("suffix")) {
         new SimpleDateFormat(suffix);
       }


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-14488
https://issues.cask.co/browse/CDAP-14482

Before this change pipeline with macro in path was not getting deployed.

![image](https://user-images.githubusercontent.com/14131070/46564114-47455b00-c8ba-11e8-9f7f-37c8bef92fca.png)

After the fix for allowing creation of non existing bq dataset:
![image](https://user-images.githubusercontent.com/14131070/46564751-50d0c200-c8be-11e8-9a5e-ce731298773c.png)

