### PR TITLE
CDAP-14531 Fix NPE when outputschema and input record schema do not m…

### DIFF
--- a/src/test/java/co/cask/gcp/bigquery/BigQuerySinkTest.java
+++ b/src/test/java/co/cask/gcp/bigquery/BigQuerySinkTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package co.cask.gcp.bigquery;
+
+import co.cask.cdap.api.data.schema.Schema;
+import org.junit.Test;
+
+/**
+ * Tests for {@link BigQuerySink}.
+ */
+public class BigQuerySinkTest {
+
+  @Test
+  public void testBigQuerySinkConfig() {
+    Schema schema = Schema.recordOf("record",
+                                    Schema.Field.of("id", Schema.of(Schema.Type.LONG)),
+                                    Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+                                    Schema.Field.of("price", Schema.of(Schema.Type.DOUBLE)),
+                                    Schema.Field.of("dt", Schema.nullableOf(Schema.of(Schema.LogicalType.DATE))),
+                                    Schema.Field.of("bytedata", Schema.of(Schema.Type.BYTES)),
+                                    Schema.Field.of("timestamp",
+                                                    Schema.nullableOf(Schema.of(Schema.LogicalType.TIMESTAMP_MICROS))));
+
+    BigQuerySinkConfig config = new BigQuerySinkConfig("r", "ds", "tb", "bucket", schema.toString());
+    config.validate();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBigQuerySinkInvalidConfig() {
+    Schema invalidSchema = Schema.recordOf("record",
+                                    Schema.Field.of("id", Schema.of(Schema.Type.LONG)),
+                                    Schema.Field.of("record", Schema.of(Schema.Type.RECORD)));
+
+    BigQuerySinkConfig config = new BigQuerySinkConfig("r", "ds", "tb", "bucket", invalidSchema.toString());
+    config.validate();
+  }
+}


### PR DESCRIPTION
…atch

Validation for additional field in output schema which is not available in input record schema

![image](https://user-images.githubusercontent.com/14131070/47322635-8ccd8c00-d60d-11e8-88d6-979564fb86de.png)


Google plugins only support simple types or nullable simple types. So added simple type schema validation at deploy time to fail fast:
![image](https://user-images.githubusercontent.com/14131070/47312223-9bf21100-d5f0-11e8-9645-407f7fcf3f2a.png)
