### PR TITLE
CDAP-14655 consider bigquery datetime as string

### DIFF
--- a/src/main/java/co/cask/gcp/bigquery/BigQuerySink.java
+++ b/src/main/java/co/cask/gcp/bigquery/BigQuerySink.java
@@ -75,6 +75,7 @@ import java.util.stream.Collectors;
 public final class BigQuerySink extends BatchSink<StructuredRecord, JsonObject, NullWritable> {
   public static final String NAME = "BigQueryTable";
   private static final DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
+  private static final DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSS");
   private static final Logger LOG = LoggerFactory.getLogger(BigQuerySink.class);
 
   private final BigQuerySinkConfig config;
@@ -264,7 +265,7 @@ public final class BigQuerySink extends BatchSink<StructuredRecord, JsonObject, 
           break;
         case TIME_MILLIS:
         case TIME_MICROS:
-          json.addProperty(name, input.getTime(name).toString());
+          json.addProperty(name, timeFormatter.format(input.getTime(name)));
           break;
         case TIMESTAMP_MILLIS:
         case TIMESTAMP_MICROS:

--- a/src/main/java/co/cask/gcp/bigquery/BigQuerySource.java
+++ b/src/main/java/co/cask/gcp/bigquery/BigQuerySource.java
@@ -257,7 +257,7 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
       } else if (value == StandardSQLTypeName.INT64) {
         // int is a int64, so corresponding type becomes long
         schema = Schema.of(Schema.Type.LONG);
-      } else if (value == StandardSQLTypeName.STRING) {
+      } else if (value == StandardSQLTypeName.STRING || value == StandardSQLTypeName.DATETIME) {
         schema = Schema.of(Schema.Type.STRING);
       } else if (value == StandardSQLTypeName.BYTES) {
         schema = Schema.of(Schema.Type.BYTES);
@@ -265,7 +265,7 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
         schema = Schema.of(Schema.LogicalType.TIME_MICROS);
       } else if (value == StandardSQLTypeName.DATE) {
         schema = Schema.of(Schema.LogicalType.DATE);
-      } else if (value == StandardSQLTypeName.TIMESTAMP || value == StandardSQLTypeName.DATETIME) {
+      } else if (value == StandardSQLTypeName.TIMESTAMP) {
         schema = Schema.of(Schema.LogicalType.TIMESTAMP_MICROS);
       } else {
         // this should never happen


### PR DESCRIPTION
BigQuery type DATETIME is exported as string value. So convert DATETIME type to string when data is read from big query. 
Also format TIME field to specific ISO 8601 format `HH:mm:ss.SSSSSS`. This change is needed because LocalTime.toString() supports `HH:mm` ISO 8601 format, whereas bigquery does not support it for some reason. 

![image](https://user-images.githubusercontent.com/14131070/50184519-35c0fc00-02ca-11e9-9470-2c7c7a2c5d28.png)

![image](https://user-images.githubusercontent.com/14131070/50184510-2e99ee00-02ca-11e9-947b-9de9921baa2b.png)
