### PR TITLE
fix broken unit test for GCS paths

### DIFF
--- a/src/test/java/co/cask/gcp/gcs/GCSPathTest.java
+++ b/src/test/java/co/cask/gcp/gcs/GCSPathTest.java
@@ -63,7 +63,7 @@ public class GCSPathTest {
     for (String path : new String[] { "gs://b0/", "gs://b0", "/b0", "/b0/" }) {
       GCSPath gcsPath = GCSPath.from(path);
       Assert.assertEquals("b0", gcsPath.getBucket());
-      Assert.assertNull(gcsPath.getName());
+      Assert.assertTrue(gcsPath.getName().isEmpty());
     }
   }
 


### PR DESCRIPTION
Fixed a test case that was not changed when the GCSPath was
changed to use empty names instead of null names.