### PR TITLE
Fix docs build, similar to other projects, such as https://github.com/cdapio/hydrator-plugins/pull/744.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
   </issueManagement>
 
   <properties>
+    <jee.version>7</jee.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <avro.version>1.7.7</avro.version>
     <cdap.version>6.0.0-SNAPSHOT</cdap.version>
@@ -582,6 +583,7 @@
             <artifactId>maven-javadoc-plugin</artifactId>
             <version>2.9.1</version>
             <configuration>
+              <additionalparam>-Xdoclint:none</additionalparam>
               <links>
                 <link>http://download.oracle.com/javase/${jee.version}/docs/api/</link>
               </links>


### PR DESCRIPTION
Example of failing build: https://builds.cask.co/browse/CDAP-BUT-1707/log
Caused by merging of https://github.com/data-integrations/google-cloud/pull/75 (only fails with `-Prelease`)