### PR TITLE
CDAP-14844 remove plugin endpoint usage

### DIFF
--- a/src/main/java/co/cask/gcp/bigquery/source/BigQuerySourceConfig.java
+++ b/src/main/java/co/cask/gcp/bigquery/source/BigQuerySourceConfig.java
@@ -19,6 +19,7 @@ package co.cask.gcp.bigquery.source;
 import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.etl.api.validation.InvalidConfigPropertyException;
 import co.cask.gcp.common.GCPConfig;
 import co.cask.gcp.common.GCPReferenceSourceConfig;
 import com.google.cloud.ServiceOptions;
@@ -51,6 +52,7 @@ public final class BigQuerySourceConfig extends GCPReferenceSourceConfig {
   private String bucket;
 
   @Macro
+  @Nullable
   @Description("The schema of the table to read.")
   private String schema;
 
@@ -83,16 +85,13 @@ public final class BigQuerySourceConfig extends GCPReferenceSourceConfig {
 
   /**
    * @return the schema of the dataset
-   * @throws IllegalArgumentException if the schema is null or invalid
    */
+  @Nullable
   public Schema getSchema() {
-    if (schema == null) {
-      throw new IllegalArgumentException("Schema must be specified.");
-    }
     try {
-      return Schema.parseJson(schema);
+      return schema == null ? null : Schema.parseJson(schema);
     } catch (IOException e) {
-      throw new IllegalArgumentException("Invalid schema: " + e.getMessage());
+      throw new InvalidConfigPropertyException("Invalid schema: " + e.getMessage(), "schema");
     }
   }
 }

--- a/src/main/java/co/cask/gcp/common/Schemas.java
+++ b/src/main/java/co/cask/gcp/common/Schemas.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.gcp.common;
+
+import co.cask.cdap.api.data.schema.Schema;
+
+/**
+ * Utility class for schemas.
+ */
+public class Schemas {
+
+  private Schemas() {
+    // no-op
+  }
+
+  /**
+   * Validate that the provided schema is compatible with the true schema. The provided schema is compatible if every
+   * field is compatible with the corresponding field in the true schema. A field is compatible if it is of the same
+   * type or is a nullable version of that type. It is assumed that both schemas are record schemas.
+   * 
+   * @param trueSchema the true schema
+   * @param providedSchema the provided schema to check compatibility
+   * @throws IllegalArgumentException if the schemas are not type compatible
+   */
+  public static void validateFieldsMatch(Schema trueSchema, Schema providedSchema) {
+    for (Schema.Field field : providedSchema.getFields()) {
+      Schema.Field trueField = trueSchema.getField(field.getName());
+      if (trueField == null) {
+        throw new IllegalArgumentException(String.format("Field '%s' does not exist", field.getName()));
+      }
+      Schema trueFieldSchema = trueField.getSchema();
+      Schema providedFieldSchema = field.getSchema();
+
+      boolean isTrueFieldNullable = trueFieldSchema.isNullable();
+      boolean isProvidedFieldNullable = providedFieldSchema.isNullable();
+
+      Schema.Type trueFieldType = isTrueFieldNullable ?
+        trueFieldSchema.getNonNullable().getType() : trueFieldSchema.getType();
+      Schema.Type providedFieldType = isProvidedFieldNullable ?
+        providedFieldSchema.getNonNullable().getType() : providedFieldSchema.getType();
+
+      if (trueFieldType != providedFieldType) {
+        throw new IllegalArgumentException(
+          String.format("Expected field '%s' to be of type '%s', but it is of type '%s'.",
+                        field.getName(), providedFieldType.name(), trueFieldType.name()));
+      }
+      if (isTrueFieldNullable && !isProvidedFieldNullable) {
+        throw new IllegalArgumentException(String.format("Field '%s' should not be nullable.", field.getName()));
+      }
+    }
+  }
+}

--- a/src/main/java/co/cask/gcp/datastore/source/DatastoreSourceConfig.java
+++ b/src/main/java/co/cask/gcp/datastore/source/DatastoreSourceConfig.java
@@ -116,6 +116,7 @@ public class DatastoreSourceConfig extends GCPReferenceSourceConfig {
 
   @Name(DatastoreSourceConstants.PROPERTY_SCHEMA)
   @Macro
+  @Nullable
   @Description("Schema of the data to read. Can be imported or fetched by clicking the `Get Schema` button.")
   private String schema;
 
@@ -154,7 +155,7 @@ public class DatastoreSourceConfig extends GCPReferenceSourceConfig {
 
   public Schema getSchema() {
     try {
-      return Schema.parseJson(schema);
+      return schema == null ? null : Schema.parseJson(schema);
     } catch (IOException e) {
       throw new InvalidConfigPropertyException("Unable to parse output schema: " +
                                                  schema, e, DatastoreSourceConstants.PROPERTY_SCHEMA);
@@ -216,9 +217,11 @@ public class DatastoreSourceConfig extends GCPReferenceSourceConfig {
     }
 
     Schema schema = getSchema();
-    validateSchema(schema);
-    validateFilters(schema);
-    validateKeyType(schema);
+    if (schema != null) {
+      validateSchema(schema);
+      validateFilters(schema);
+      validateKeyType(schema);
+    }
   }
 
   @VisibleForTesting

--- a/src/main/java/co/cask/gcp/gcs/source/GCSSource.java
+++ b/src/main/java/co/cask/gcp/gcs/source/GCSSource.java
@@ -21,7 +21,6 @@ import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.schema.Schema;
-import co.cask.cdap.api.plugin.EndpointPluginContext;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.api.batch.BatchSourceContext;
@@ -42,7 +41,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
-import javax.ws.rs.Path;
 
 /**
  * Class description here.
@@ -88,23 +86,6 @@ public class GCSSource extends AbstractFileSource<GCSSource.GCSSourceConfig> {
   @Override
   protected void recordLineage(LineageRecorder lineageRecorder, List<String> outputFields) {
     lineageRecorder.recordRead("Read", "Read from Google Cloud Storage.", outputFields);
-  }
-
-  /**
-   * Endpoint method to get the output schema of a source.
-   *
-   * @param config configuration for the source
-   * @param pluginContext context to create plugins
-   * @return schema of fields
-   */
-  @Path("getSchema")
-  public Schema getSchema(GCSSourceConfig config, EndpointPluginContext pluginContext) {
-    FileFormat fileFormat = config.getFormat();
-    if (fileFormat == null) {
-      return config.getSchema();
-    }
-    Schema schema = fileFormat.getSchema(config.getPathField());
-    return schema == null ? config.getSchema() : schema;
   }
 
   /**

--- a/src/main/java/co/cask/gcp/spanner/source/SpannerSourceConfig.java
+++ b/src/main/java/co/cask/gcp/spanner/source/SpannerSourceConfig.java
@@ -19,6 +19,7 @@ package co.cask.gcp.spanner.source;
 import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.etl.api.validation.InvalidConfigPropertyException;
 import co.cask.gcp.common.GCPReferenceSourceConfig;
 import co.cask.gcp.spanner.common.SpannerUtil;
 
@@ -55,24 +56,26 @@ public class SpannerSourceConfig extends GCPReferenceSourceConfig {
 
   @Description("Schema of the Spanner table.")
   @Macro
+  @Nullable
   public String schema;
 
   public void validate() {
     super.validate();
-    if (!containsMacro("schema")) {
+    if (!containsMacro("schema") && schema != null) {
       SpannerUtil.validateSchema(getSchema());
     }
     if (!containsMacro("maxPartitions") && maxPartitions != null && maxPartitions < 1) {
-      throw new IllegalArgumentException("Max partitions should be positive");
+      throw new InvalidConfigPropertyException("Max partitions should be positive", "maxPartitions");
     }
     if (!containsMacro("partitionSizeMB") && partitionSizeMB != null && partitionSizeMB < 1) {
-      throw new IllegalArgumentException("Partition size in mega bytes should be positive");
+      throw new InvalidConfigPropertyException("Partition size in mega bytes should be positive", "partitionSizeMB");
     }
   }
 
+  @Nullable
   public Schema getSchema() {
     try {
-      return Schema.parseJson(schema);
+      return schema == null ? null : Schema.parseJson(schema);
     } catch (IOException e) {
       throw new IllegalArgumentException("Unable to parse output schema: " + e.getMessage(), e);
     }

--- a/widgets/BigQueryTable-batchsource.json
+++ b/widgets/BigQueryTable-batchsource.json
@@ -47,14 +47,14 @@
             "placeholder": "Table to read from"
           },
           "plugin-function": {
-            "method": "POST",
             "label": "Get Schema",
             "widget": "outputSchema",
             "output-property": "schema",
-            "plugin-method": "getSchema",
-            "position": "bottom",
-            "multiple-inputs": true,
-            "button-class": "btn-hydrator"
+            "omit-properties": [
+              {
+                "name": "schema"
+              }
+            ]
           }
         },
         {

--- a/widgets/Datastore-batchsource.json
+++ b/widgets/Datastore-batchsource.json
@@ -33,10 +33,14 @@
           "label": "Kind",
           "name": "kind",
           "plugin-function": {
-            "method": "POST",
+            "label": "Get Schema",
             "widget": "outputSchema",
             "output-property": "schema",
-            "plugin-method": "getSchema"
+            "omit-properties": [
+              {
+                "name": "schema"
+              }
+            ]
           }
         },
         {

--- a/widgets/GCSFile-batchsource.json
+++ b/widgets/GCSFile-batchsource.json
@@ -47,12 +47,6 @@
               "tsv"
             ],
             "default": "text"
-          },
-          "plugin-function": {
-            "method": "POST",
-            "widget": "outputSchema",
-            "output-property": "schema",
-            "plugin-method": "getSchema"
           }
         },
         {

--- a/widgets/Spanner-batchsource.json
+++ b/widgets/Spanner-batchsource.json
@@ -47,10 +47,14 @@
             "placeholder": "Table name"
           },
           "plugin-function": {
-            "method": "POST",
+            "label": "Get Schema",
             "widget": "outputSchema",
             "output-property": "schema",
-            "plugin-method": "getSchema"
+            "omit-properties": [
+              {
+                "name": "schema"
+              }
+            ]
           }
         }
       ]

--- a/widgets/SpeechToText-transform.json
+++ b/widgets/SpeechToText-transform.json
@@ -87,11 +87,8 @@
             "default" : "transcript"
           },
           "plugin-function": {
-            "method": "POST",
             "label": "Get Schema",
             "widget": "outputSchema",
-            "output-property": "schema",
-            "plugin-method": "getSchema",
             "position": "bottom",
             "multiple-inputs": false,
             "button-class": "btn-hydrator"


### PR DESCRIPTION
Removed usage of plugin endpoints since they are replaced by the
pipeline system service. Instead, moving related logic to the
configurePipeline() method and setting the output schema directly
there. Made the schema property nullable so that the schema is
fetched from underlying storage if it is not provided.
The 'Get Schema' button is configured to not pass schema to the
plugin.