### PR TITLE
CDAP-14951 fix bug when dataset is in a different region

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
@@ -199,7 +199,8 @@ public class BigQueryOutputFormat extends ForwardingBigQueryFileOutputFormat<Jso
       // While job is incomplete continue to poll.
       while (notDone) {
         BackOff operationBackOff = new ExponentialBackOff.Builder().build();
-        Bigquery.Jobs.Get get = bigquery.jobs().get(projectId, jobReference.getJobId());
+        Bigquery.Jobs.Get get = bigquery.jobs().get(projectId, jobReference.getJobId())
+          .setLocation(jobReference.getLocation());
 
         Job pollJob = ResilientOperation.retry(
           ResilientOperation.getGoogleRequestCallable(get),


### PR DESCRIPTION
Fixed a bug that occurs when the bigquery dataset that is being
written to is in a different region than the dataproc cluster.
This was a bug in the bigquery library that the project currently
depends on, where the wrong get job request was not setting the
job location.