### PR TITLE
CDAP-15235: BigQuery Batch Sink / Multi Sink: Better schema management

### DIFF
--- a/docs/BigQueryMultiTable-batchsink.md
+++ b/docs/BigQueryMultiTable-batchsink.md
@@ -36,8 +36,24 @@ It will be automatically created if it does not exist, but will not be automatic
 Temporary data will be deleted after it is loaded into BigQuery. If it is not provided, a unique
 bucket will be created and then deleted after the run finishes.
 
-**Split Field:** The name of the field that will be used to determine which table to write to. 
-Defaults to `tablename`.
+**Split Field:** The name of the field that will be used to determine which table to write to.
+
+**Update Table Schema**: Whether the BigQuery table schema should be modified 
+when it does not match the schema expected by the pipeline. 
+* When this is set to false, any mismatches between the schema expected by the pipeline 
+and the schema in BigQuery will result in pipeline failure. 
+* When this is set to true, the schema in BigQuery will be updated to match the schema 
+expected by the pipeline, assuming the schemas are compatible. 
+
+Compatible changes fall under the following categories:                
+* the pipeline schema contains nullable fields that do not exist in the BigQuery schema. 
+In this case, the new fields will be added to the BigQuery schema.
+* the pipeline schema contains nullable fields that are non-nullable in the BigQuery schema. 
+In this case, the fields will be modified to become nullable in the BigQuery schema.
+* the pipeline schema does not contain fields that exist in the BigQuery schema. 
+In this case, those fields in the BigQuery schema will be modified to become nullable.
+                         
+Incompatible schema changes will result in pipeline failure.
 
 **Service Account File Path:** Path on the local file system of the service account key used for
 authorization. Can be set to 'auto-detect' when running on a Dataproc cluster.

--- a/docs/BigQueryTable-batchsink.md
+++ b/docs/BigQueryTable-batchsink.md
@@ -40,8 +40,26 @@ It will be automatically created if it does not exist, but will not be automatic
 Temporary data will be deleted after it is loaded into BigQuery. If it is not provided, a unique
 bucket will be created and then deleted after the run finishes.
 
+**Update Table Schema**: Whether the BigQuery table schema should be modified 
+when it does not match the schema expected by the pipeline. 
+* When this is set to false, any mismatches between the schema expected by the pipeline 
+and the schema in BigQuery will result in pipeline failure. 
+* When this is set to true, the schema in BigQuery will be updated to match the schema 
+expected by the pipeline, assuming the schemas are compatible. 
+
+Compatible changes fall under the following categories:                
+* the pipeline schema contains nullable fields that do not exist in the BigQuery schema. 
+In this case, the new fields will be added to the BigQuery schema.
+* the pipeline schema contains nullable fields that are non-nullable in the BigQuery schema. 
+In this case, the fields will be modified to become nullable in the BigQuery schema.
+* the pipeline schema does not contain fields that exist in the BigQuery schema.
+In this case, those fields in the BigQuery schema will be modified to become nullable.
+                         
+Incompatible schema changes will result in pipeline failure.
+
 **Service Account File Path**: Path on the local file system of the service account key used for
 authorization. Can be set to 'auto-detect' when running on a Dataproc cluster.
 When running on other clusters, the file must be present on every node in the cluster.
 
-**Schema**: Schema of the data to write. Must be compatible with the table schema.
+**Schema**: Schema of the data to write. 
+If a schema is provided, it must be compatible with the table schema in BigQuery.

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
@@ -38,9 +38,13 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
   @Nullable
   @Description("The Google Cloud Storage bucket to store temporary data in. "
     + "It will be automatically created if it does not exist, but will not be automatically deleted. "
-    + "Cloud Storage data will be deleted after it is loaded into BigQuery. " +
-    "If it is not provided, a unique bucket will be created and then deleted after the run finishes.")
+    + "Cloud Storage data will be deleted after it is loaded into BigQuery. "
+    + "If it is not provided, a unique bucket will be created and then deleted after the run finishes.")
   protected String bucket;
+
+  @Macro
+  @Description("Whether to modify the BigQuery table schema if it differs from the input schema.")
+  protected boolean allowSchemaRelaxation;
 
   public String getDataset() {
     return dataset;
@@ -59,6 +63,10 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
       }
     }
     return bucket;
+  }
+
+  public boolean isAllowSchemaRelaxation() {
+    return allowSchemaRelaxation;
   }
 
   @Override

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -76,7 +76,9 @@ public final class BigQuerySink extends AbstractBigQuerySink {
 
   @Override
   protected void prepareRunInternal(BatchSinkContext context, String bucket) throws IOException {
-    initOutput(context, config.getReferenceName(), config.getTable(), config.getSchema(), bucket);
+    Schema configSchema = config.getSchema();
+    Schema schema = configSchema == null ? context.getInputSchema() : configSchema;
+    initOutput(context, config.getReferenceName(), config.getTable(), schema, bucket);
   }
 
   @Override
@@ -107,7 +109,7 @@ public final class BigQuerySink extends AbstractBigQuerySink {
     JsonObject object = new JsonObject();
     for (Schema.Field recordField : Objects.requireNonNull(input.getSchema().getFields())) {
       // From all the fields in input record, decode only those fields that are present in output schema
-      if (schema.getField(recordField.getName()) != null) {
+      if (schema == null || schema.getField(recordField.getName()) != null) {
         decodeSimpleTypes(object, recordField.getName(), input);
       }
     }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.gcp.bigquery.sink;
 
+import com.google.common.base.Strings;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.data.schema.Schema;
@@ -37,11 +38,12 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
   private String table;
 
   @Macro
-  @Description("The schema of the data to write. Must be compatible with the table schema.")
+  @Nullable
+  @Description("The schema of the data to write. If provided, must be compatible with the table schema.")
   private String schema;
 
   public BigQuerySinkConfig(String referenceName, String dataset, String table,
-                            @Nullable String bucket, String schema) {
+                            @Nullable String bucket, @Nullable String schema) {
     this.referenceName = referenceName;
     this.dataset = dataset;
     this.table = table;
@@ -55,11 +57,11 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
 
   /**
    * @return the schema of the dataset
-   * @throws IllegalArgumentException if the schema is null or invalid
    */
+  @Nullable
   public Schema getSchema() {
-    if (schema == null) {
-      throw new IllegalArgumentException("Schema must be specified.");
+    if (Strings.isNullOrEmpty(schema)) {
+      return null;
     }
     try {
       return Schema.parseJson(schema);
@@ -72,12 +74,15 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
    * Verifies if output schema only contains simple types. It also verifies if all the output schema fields are
    * present in input schema.
    *
-   * @param inputSchema input schema to bigquery sink
+   * @param inputSchema input schema to BigQuery sink
    */
   public void validate(@Nullable Schema inputSchema) {
     super.validate();
     if (!containsMacro("schema")) {
       Schema outputSchema = getSchema();
+      if (outputSchema == null) {
+        return;
+      }
       for (Schema.Field field : outputSchema.getFields()) {
         // check if the required fields are present in the input schema.
         if (!field.getSchema().isNullable() && inputSchema != null && inputSchema.getField(field.getName()) == null) {

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+package io.cdap.plugin.gcp.bigquery.util;
+
+/**
+ * BigQuery constants.
+ */
+public interface BigQueryConstants {
+
+  String CONFIG_ALLOW_SCHEMA_RELAXATION = "mapred.bg.sink.allow_schema_relaxation";
+}

--- a/widgets/BigQueryMultiTable-batchsink.json
+++ b/widgets/BigQueryMultiTable-batchsink.json
@@ -64,6 +64,25 @@
           "widget-attributes": {
             "placeholder": "Field used to determine which table to write to"
           }
+        },
+        {
+          "widget-type": "radio-group",
+          "name": "allowSchemaRelaxation",
+          "label": "Update Table Schema",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "false",
+            "options": [
+              {
+                "id": "true",
+                "label": "True"
+              },
+              {
+                "id": "false",
+                "label": "False"
+              }
+            ]
+          }
         }
       ]
     }

--- a/widgets/BigQueryTable-batchsink.json
+++ b/widgets/BigQueryTable-batchsink.json
@@ -46,6 +46,25 @@
           "widget-attributes" : {
             "placeholder": "Google Cloud Storage bucket for temporary data"
           }
+        },
+        {
+          "widget-type": "radio-group",
+          "name": "allowSchemaRelaxation",
+          "label": "Update Table Schema",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "false",
+            "options": [
+              {
+                "id": "true",
+                "label": "True"
+              },
+              {
+                "id": "false",
+                "label": "False"
+              }
+            ]
+          }
         }
       ]
     },


### PR DESCRIPTION
1. Added 'Allow Schema Relaxation' property to handle cases when destination table does not have fields from input or when field mode relaxation is needed.
2. Made schema property optional for BigQuery Batch Sink plugin. If not provided, input schema will be used instead. If input schema is not provided, schema will be automatically inferred during data load.
3. Fixed column nullability issues described in CDAP-15295.