### PR TITLE
CDAP-15372 fix temporary GCS bucket location

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>google-cloud</artifactId>
-  <version>0.12.2</version>
+  <version>0.12.3</version>
   <name>Google Cloud Plugins</name>
   <packaging>jar</packaging>
   <description>Plugins for Google Big Query</description>

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSink.java
@@ -15,6 +15,7 @@
  */
 package io.cdap.plugin.gcp.bigquery.sink;
 
+import com.google.cloud.bigquery.BigQuery;
 import com.google.gson.stream.JsonWriter;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
@@ -72,7 +73,7 @@ public class BigQueryMultiSink extends AbstractBigQuerySink {
   }
 
   @Override
-  protected void prepareRunInternal(BatchSinkContext context, String bucket) throws IOException {
+  protected void prepareRunInternal(BatchSinkContext context, BigQuery bigQuery, String bucket) throws IOException {
     Map<String, String> arguments = new HashMap<>(context.getArguments().asMap());
     for (Map.Entry<String, String> argument : arguments.entrySet()) {
       String key = argument.getKey();
@@ -83,7 +84,7 @@ public class BigQueryMultiSink extends AbstractBigQuerySink {
       Schema tableSchema = Schema.parseJson(argument.getValue());
 
       String outputName = String.format("%s-%s", config.getReferenceName(), tableName);
-      initOutput(context, outputName, tableName, tableSchema, bucket);
+      initOutput(context, bigQuery, outputName, tableName, tableSchema, bucket);
     }
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -15,6 +15,7 @@
  */
 package io.cdap.plugin.gcp.bigquery.sink;
 
+import com.google.cloud.bigquery.BigQuery;
 import com.google.gson.stream.JsonWriter;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
@@ -77,10 +78,10 @@ public final class BigQuerySink extends AbstractBigQuerySink {
   }
 
   @Override
-  protected void prepareRunInternal(BatchSinkContext context, String bucket) throws IOException {
+  protected void prepareRunInternal(BatchSinkContext context, BigQuery bigQuery, String bucket) throws IOException {
     Schema configSchema = config.getSchema();
     Schema schema = configSchema == null ? context.getInputSchema() : configSchema;
-    initOutput(context, config.getReferenceName(), config.getTable(), schema, bucket);
+    initOutput(context, bigQuery, config.getReferenceName(), config.getTable(), schema, bucket);
   }
 
   @Override

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySource.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySource.java
@@ -16,11 +16,15 @@
 
 package io.cdap.plugin.gcp.bigquery.source;
 
+import com.google.auth.Credentials;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.FieldList;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.TableId;
 import com.google.cloud.hadoop.io.bigquery.AvroBigQueryInputFormat;
 import com.google.cloud.hadoop.io.bigquery.BigQueryConfiguration;
 import io.cdap.cdap.api.annotation.Description;
@@ -40,6 +44,7 @@ import io.cdap.cdap.etl.api.validation.InvalidConfigPropertyException;
 import io.cdap.cdap.etl.api.validation.InvalidStageException;
 import io.cdap.plugin.common.LineageRecorder;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;
+import io.cdap.plugin.gcp.common.GCPUtils;
 import io.cdap.plugin.gcp.common.Schemas;
 import org.apache.avro.generic.GenericData;
 import org.apache.hadoop.conf.Configuration;
@@ -81,7 +86,8 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
     super.configurePipeline(configurer);
     config.validate();
 
-    if (config.containsMacro("schema") || config.containsMacro("dataset") || config.containsMacro("table")) {
+    if (config.containsMacro("schema") || config.containsMacro("dataset") || config.containsMacro("table") ||
+      config.containsMacro("datasetProject")) {
       configurer.getStageConfigurer().setOutputSchema(null);
       return;
     }
@@ -104,7 +110,11 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
   @Override
   public void prepareRun(BatchSourceContext context) throws Exception {
     config.validate();
-    validateOutputSchema();
+    String serviceAccountPath = config.getServiceAccountFilePath();
+    Credentials credentials = serviceAccountPath == null ?
+      null : GCPUtils.loadServiceAccountCredentials(serviceAccountPath);
+    BigQuery bigQuery = GCPUtils.getBigQuery(config.getDatasetProject(), credentials);
+    validateOutputSchema(bigQuery);
 
     uuid = UUID.randomUUID();
     configuration = BigQueryUtil.getBigQueryConfig(config.getServiceAccountFilePath(), config.getProject());
@@ -115,6 +125,11 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
       // By default, this option is false, meaning the job can not delete the bucket. So enable it only when bucket name
       // is not provided.
       configuration.setBoolean("fs.gs.bucket.delete.enable", true);
+    }
+
+    if (!context.isPreviewEnabled()) {
+      BigQueryUtil.createResources(bigQuery, GCPUtils.getStorage(config.getDatasetProject(), credentials),
+                                   config.getDataset(), bucket);
     }
 
     configuration.set("fs.gs.system.bucket", bucket);
@@ -171,15 +186,28 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
     }
   }
 
-
   public Schema getSchema() {
     String dataset = config.getDataset();
     String tableName = config.getTable();
     String project = config.getDatasetProject();
+    TableId tableId = TableId.of(project, dataset, tableName);
+
+    String serviceAccountPath = config.getServiceAccountFilePath();
+    Credentials credentials = null;
+    if (serviceAccountPath != null) {
+      try {
+        credentials = GCPUtils.loadServiceAccountCredentials(serviceAccountPath);
+      } catch (IOException e) {
+        throw new InvalidConfigPropertyException(
+          String.format("Unable to load credentials from %s", serviceAccountPath), "serviceFilePath");
+      }
+    }
+    BigQuery bigQuery = GCPUtils.getBigQuery(config.getDatasetProject(), credentials);
+
     Table table;
     try {
-      table = BigQueryUtil.getBigQueryTable(config.getServiceAccountFilePath(), project, dataset, tableName);
-    } catch (IOException e) {
+      table = bigQuery.getTable(tableId);
+    } catch (BigQueryException e) {
       throw new InvalidStageException("Unable to get details about the BigQuery table: " + e.getMessage(), e);
     }
     if (table == null) {
@@ -201,11 +229,12 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
    * Validate output schema. This is needed because its possible that output schema is set without using
    * {@link #getSchema()} method.
    */
-  private void validateOutputSchema() throws IOException {
+  private void validateOutputSchema(BigQuery bigQuery) {
     String dataset = config.getDataset();
     String tableName = config.getTable();
     String project = config.getDatasetProject();
-    Table table = BigQueryUtil.getBigQueryTable(config.getServiceAccountFilePath(), project, dataset, tableName);
+    TableId tableId = TableId.of(project, dataset, tableName);
+    Table table = bigQuery.getTable(tableId);
     if (table == null) {
       // Table does not exist
       throw new IllegalArgumentException(String.format("BigQuery table '%s:%s.%s' does not exist.",

--- a/src/main/java/io/cdap/plugin/gcp/common/GCPUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCPUtils.java
@@ -16,7 +16,12 @@
 
 package io.cdap.plugin.gcp.common;
 
+import com.google.auth.Credentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
 import io.cdap.plugin.gcp.gcs.GCSPath;
 import io.cdap.plugin.gcp.gcs.sink.GCSBatchSink.GCSBatchSinkConfig;
 
@@ -25,6 +30,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * GCP utility class to get service account credentials
@@ -53,5 +59,21 @@ public class GCPUtils {
     properties.put("fs.gs.working.dir", GCSPath.ROOT_DIR);
     properties.put("fs.gs.impl.disable.cache", "true");
     return properties;
+  }
+
+  public static BigQuery getBigQuery(String project, @Nullable Credentials credentials) {
+    BigQueryOptions.Builder bigqueryBuilder = BigQueryOptions.newBuilder().setProjectId(project);
+    if (credentials != null) {
+      bigqueryBuilder.setCredentials(credentials);
+    }
+    return bigqueryBuilder.build().getService();
+  }
+
+  public static Storage getStorage(String project, @Nullable Credentials credentials) {
+    StorageOptions.Builder builder = StorageOptions.newBuilder().setProjectId(project);
+    if (credentials != null) {
+      builder.setCredentials(credentials);
+    }
+    return builder.build().getService();
   }
 }


### PR DESCRIPTION
Fixed the BigQuery source and sink to create a temporary GCS
bucket in the same location as the dataset that is being read from
or written to. Without this, the GCS bucket is created in the
default location (US), which cannot write to BigQuery in a different
location.

Also did some refactoring to avoid repeatedly reading the
credentials file, which also makes error handling more clear since
it removes the possibility of throwing IOExceptions from a bunch of
places.