### PR TITLE
Make 'serviceFilePath' field nullable, consistent with other GCP plugins.

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/speech/SpeechToTextTransform.java
+++ b/src/main/java/io/cdap/plugin/gcp/speech/SpeechToTextTransform.java
@@ -258,15 +258,16 @@ public class SpeechToTextTransform extends Transform<StructuredRecord, Structure
 
     @Macro
     @Nullable
-    @Description("If a field name is specified then the transcription with highest confidence score will be stored as" +
+    @Description("If a field name is specified then the transcription with highest confidence score will be stored as " +
       "text.")
     private String transcriptionTextField;
 
+    @Macro
+    @Nullable
     @Name("serviceFilePath")
     @Description("Path on the local file system of the service account key used for authorization. Can be set to " +
       "'auto-detect' when running on a Dataproc cluster. When running on other clusters, the file must be present on " +
       "every node in the cluster.")
-    @Macro
     private String serviceAccountFilePath;
 
     @Nullable


### PR DESCRIPTION
Also fixes the typo:
![image](https://user-images.githubusercontent.com/2440977/59073548-79a9bc80-887c-11e9-8a8f-0749ad7016a8.png)
