### PR TITLE
CDAP-15535 Avoid using database and '.' in the table name in BigQuery.

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSink.java
@@ -81,6 +81,11 @@ public class BigQueryMultiSink extends AbstractBigQuerySink {
         continue;
       }
       String tableName = key.substring(TABLE_PREFIX.length());
+      // remove the database prefix, as BigQuery doesn't allow dots
+      String[] split = tableName.split("\\.");
+      if (split.length == 2) {
+        tableName = split[1];
+      }
       Schema tableSchema = Schema.parseJson(argument.getValue());
 
       String outputName = String.format("%s-%s", config.getReferenceName(), tableName);

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/MultiSinkOutputFormatProvider.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/MultiSinkOutputFormatProvider.java
@@ -122,7 +122,16 @@ public class MultiSinkOutputFormatProvider implements OutputFormatProvider {
     @Override
     public void write(JsonObject key, NullWritable value) throws IOException, InterruptedException {
       JsonElement jsonElement = key.get(filterField);
-      if (jsonElement == null || !filterValue.equalsIgnoreCase(jsonElement.getAsString())) {
+      if (jsonElement == null) {
+        return;
+      }
+      String name = jsonElement.getAsString();
+      // remove the database prefix, as BigQuery doesn't allow dots
+      String[] split = name.split("\\.");
+      if (split.length == 2) {
+        name = split[1];
+      }
+      if (!filterValue.equalsIgnoreCase(name)) {
         return;
       }
 


### PR DESCRIPTION
In https://github.com/data-integrations/multi-table-plugins/pull/7, the table name variable was modified to include the database name as well, resulting in an error when using oracle db as the db in MultiTableDatabase.
This removes that prefix, in order to fix that error.