### PR TITLE
CDAP-15645: Added possibility choose operation type - Insert, Update, Upsert.

### DIFF
--- a/docs/BigQueryTable-batchsink.md
+++ b/docs/BigQueryTable-batchsink.md
@@ -40,6 +40,10 @@ It will be automatically created if it does not exist, but will not be automatic
 Temporary data will be deleted after it is loaded into BigQuery. If it is not provided, a unique
 bucket will be created and then deleted after the run finishes.
 
+**Operation**: Type of write operation to perform. This can be set to Insert, Update or Upsert.
+
+**Table Key**: List of fields that determines relation between tables during Update and Upsert operations.
+
 **Create Partitioned Table**: Whether to create the BigQuery table with time partitioning. This value 
 is ignored if the table already exists.
 * When this is set to true, table will be created with time partitioning. 
@@ -63,7 +67,7 @@ when it does not match the schema expected by the pipeline.
 * When this is set to false, any mismatches between the schema expected by the pipeline 
 and the schema in BigQuery will result in pipeline failure. 
 * When this is set to true, the schema in BigQuery will be updated to match the schema 
-expected by the pipeline, assuming the schemas are compatible. 
+expected by the pipeline, assuming the schemas are compatible.
 
 Compatible changes fall under the following categories:                
 * the pipeline schema contains nullable fields that do not exist in the BigQuery schema. 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
@@ -198,6 +198,10 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, J
     if (getConfig().getClusteringOrder() != null) {
       baseConfiguration.set(BigQueryConstants.CONFIG_CLUSTERING_ORDER, getConfig().getClusteringOrder());
     }
+    baseConfiguration.setStrings(BigQueryConstants.CONFIG_OPERATION, getConfig().getOperation().name());
+    if (getConfig().getRelationTableKey() != null) {
+      baseConfiguration.set(BigQueryConstants.CONFIG_TABLE_KEY, getConfig().getRelationTableKey());
+    }
     return baseConfiguration;
   }
 
@@ -238,6 +242,11 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, J
                                                 config.getTable(),
                                                 config.getServiceAccountFilePath());
     baseConfiguration.setBoolean(BigQueryConstants.CONFIG_DESTINATION_TABLE_EXISTS, table != null);
+    if (table != null) {
+      List<String> tableFieldsNames = Objects.requireNonNull(table.getDefinition().getSchema()).getFields().stream()
+        .map(Field::getName).collect(Collectors.toList());
+      baseConfiguration.set(BigQueryConstants.CONFIG_TABLE_FIELDS, String.join(",", tableFieldsNames));
+    }
   }
 
   /**

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
@@ -32,6 +32,8 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
 
   public static final String NAME_PARTITION_BY_FIELD = "partitionByField";
   public static final String NAME_CLUSTERING_ORDER = "clusteringOrder";
+  public static final String NAME_OPERATION = "operation";
+  public static final String NAME_TABLE_KEY = "relationTableKey";
 
   @Macro
   @Description("The dataset to write to. A dataset is contained within a specific project. "
@@ -62,6 +64,17 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
   @Description("Partitioning column for the BigQuery table. This should be left empty if the BigQuery table is an " +
     "ingestion-time partitioned table.")
   protected String partitionByField;
+
+  @Name(NAME_OPERATION)
+  @Macro
+  @Description("Type of write operation to perform. This can be set to Insert, Update or Upsert.")
+  protected String operation;
+
+  @Name(NAME_TABLE_KEY)
+  @Macro
+  @Nullable
+  @Description("List of fields that determines relation between tables during Update and Upsert operations.")
+  protected String relationTableKey;
 
   @Macro
   @Nullable
@@ -121,6 +134,15 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
   @Nullable
   public String getClusteringOrder() {
     return clusteringOrder;
+  }
+
+  public Operation getOperation() {
+    return Operation.valueOf(operation.toUpperCase());
+  }
+
+  @Nullable
+  public String getRelationTableKey() {
+    return relationTableKey;
   }
 
   @Override

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/Operation.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/Operation.java
@@ -1,0 +1,10 @@
+package io.cdap.plugin.gcp.bigquery.sink;
+
+/**
+ * The type of write operation.
+ */
+public enum Operation {
+  INSERT,
+  UPDATE,
+  UPSERT;
+}

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
@@ -28,6 +28,8 @@ public interface BigQueryConstants {
   String CONFIG_PARTITION_FROM_DATE = "cdap.bq.source.partition.from.date";
   String CONFIG_PARTITION_TO_DATE = "cdap.bq.source.partition.to.date";
   String CONFIG_SERVICE_ACCOUNT_FILE_PATH = "cdap.bq.service.account.file.path";
-  String CONFIG_TEMPORARY_TABLE_NAME = "cdap.bq.source.temporary.table.name";
   String CONFIG_CLUSTERING_ORDER = "cdap.bq.sink.clustering.order";
+  String CONFIG_OPERATION = "cdap.bq.sink.operation";
+  String CONFIG_TABLE_KEY = "cdap.bq.sink.table.key";
+  String CONFIG_TABLE_FIELDS = "cdap.bq.sink.table.fields";
 }

--- a/widgets/BigQueryTable-batchsink.json
+++ b/widgets/BigQueryTable-batchsink.json
@@ -48,6 +48,35 @@
           }
         },
         {
+          "widget-type": "radio-group",
+          "name" : "operation",
+          "label" : "Operation",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "insert",
+            "options": [
+              {
+                "id": "insert",
+                "label": "Insert"
+              },
+              {
+                "id": "update",
+                "label": "Update"
+              },
+              {
+                "id": "upsert",
+                "label": "Upsert"
+              }
+            ]
+          }
+        },
+        {
+          "name": "relationTableKey",
+          "widget-type": "csv",
+          "label": "Table Key",
+          "widget-attributes" : {}
+        },
+        {
           "name": "createPartitionedTable",
           "widget-type": "toggle",
           "label": "Create Partitioned Table",


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15645

In scope of this PR:

* Added possibility choose operation type (Insert, Update, Upsert) in BigQuery Sink plugin.
* For operation type Update and Upsert was added possibility choose list of fields for relation between tables.