### PR TITLE
CDAP-15724 Spanner plugins fixed

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/spanner/common/SpannerUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/spanner/common/SpannerUtil.java
@@ -106,7 +106,7 @@ public class SpannerUtil {
       Schema.Type type = fieldSchema.getType();
       switch (type) {
         case BOOLEAN:
-          spannerType = "BOOLEAN";
+          spannerType = "BOOL";
           break;
         case STRING:
           spannerType = "STRING(MAX)";

--- a/src/main/java/io/cdap/plugin/gcp/spanner/source/SpannerSource.java
+++ b/src/main/java/io/cdap/plugin/gcp/spanner/source/SpannerSource.java
@@ -156,7 +156,7 @@ public class SpannerSource extends BatchSource<NullWritable, ResultSet, Structur
     if (schema != null) {
       if (schema.getFields() != null) {
         lineageRecorder.recordRead("Read", "Read from Spanner table.",
-                                   config.getSchema().getFields().stream().map(Schema.Field::getName)
+                                   schema.getFields().stream().map(Schema.Field::getName)
                                      .collect(Collectors.toList()));
       }
     }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15724

In the scope of this PR:
* Source fixed to avoid NPE when no schema provided
* `SpannerUtil` changed to use valid `BOOL` type name