### PR TITLE
fix bq in preview

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>google-cloud</artifactId>
-  <version>0.12.4</version>
+  <version>0.12.5</version>
   <name>Google Cloud Plugins</name>
   <packaging>jar</packaging>
   <description>Plugins for Google Big Query</description>

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySource.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySource.java
@@ -126,10 +126,8 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
       configuration.setBoolean("fs.gs.bucket.delete.enable", true);
     }
 
-    if (!context.isPreviewEnabled()) {
-      BigQueryUtil.createResources(bigQuery, GCPUtils.getStorage(config.getDatasetProject(), credentials),
-                                   config.getDataset(), bucket);
-    }
+    BigQueryUtil.createResources(bigQuery, GCPUtils.getStorage(config.getDatasetProject(), credentials),
+                                 config.getDataset(), bucket);
 
     configuration.set("fs.gs.system.bucket", bucket);
     configuration.setBoolean("fs.gs.impl.disable.cache", true);


### PR DESCRIPTION
this was fixed in develop in #125 but not in the release branch.
The source will need to create the GCS bucket no matter it is in preview or not. Sink does not matter since preview will not write to the sink