### PR TITLE
CDAP-15763 & CDAP-15764 Big Table Sink plugin fails pipeline on Dataproc and Spanner Plugin fails with ServiceConfigurationError

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -562,6 +562,7 @@
               com.google.cloud.hadoop.*;
               org.apache.spark.streaming.pubsub*;
               org.apache.hadoop.hbase.mapreduce.*;
+              org.apache.hadoop.hbase.security.token.*;
             </_exportcontents>
           </instructions>
         </configuration>

--- a/src/main/java/io/cdap/plugin/gcp/bigtable/source/BigtableSource.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigtable/source/BigtableSource.java
@@ -36,7 +36,6 @@ import io.cdap.plugin.common.SourceInputFormatProvider;
 import io.cdap.plugin.gcp.bigtable.common.HBaseColumn;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.Result;
@@ -133,7 +132,7 @@ public final class BigtableSource extends BatchSource<ImmutableBytesWritable, Re
 
   private Configuration getConfiguration() {
     try {
-      Configuration conf = HBaseConfiguration.create();
+      Configuration conf = new Configuration();
       BigtableConfiguration.configure(conf, config.getProject(), config.instance);
       conf.setBoolean(TableInputFormat.SHUFFLE_MAPS, true);
       conf.set(TableInputFormat.INPUT_TABLE, config.table);


### PR DESCRIPTION
JIRA:
- https://issues.cask.co/browse/CDAP-15763
- https://issues.cask.co/browse/CDAP-15764

In scope of this PR:
- Fixed problems with config in Bigtable sink plugin on Dataproc
- Fixed creation of new tables in Bigtable
- Fixed Spanner Plugin fails with ServiceConfigurationError