### PR TITLE
Feature/support write disposition

### DIFF
--- a/docs/BigQueryMultiTable-batchsink.md
+++ b/docs/BigQueryMultiTable-batchsink.md
@@ -36,9 +36,8 @@ It will be automatically created if it does not exist, but will not be automatic
 Temporary data will be deleted after it is loaded into BigQuery. If it is not provided, a unique
 bucket will be created and then deleted after the run finishes.
 
-**Truncate Table**: Whether to truncate the output table before writing to it.
-* True - Will delete all rows in the table before writing to it.
-* False - Will append the new rows to the table.
+**Truncate Table:** Whether or not to truncate the table before writing to it.
+Should only be used with the Insert operation.
 
 **Split Field:** The name of the field that will be used to determine which table to write to.
 

--- a/docs/BigQueryMultiTable-batchsink.md
+++ b/docs/BigQueryMultiTable-batchsink.md
@@ -36,6 +36,11 @@ It will be automatically created if it does not exist, but will not be automatic
 Temporary data will be deleted after it is loaded into BigQuery. If it is not provided, a unique
 bucket will be created and then deleted after the run finishes.
 
+**WriteDisposition**: Type of write disposition to use. This can be set to Empty, Truncate, or Append.
+* Empty - Job should only write to empty tables, otherwise an error is thrown.
+* Truncate - Job will truncate an existing table before writing to it.
+* Append - Job will append to an existing table.
+
 **Split Field:** The name of the field that will be used to determine which table to write to.
 
 **Update Table Schema**: Whether the BigQuery table schema should be modified 

--- a/docs/BigQueryMultiTable-batchsink.md
+++ b/docs/BigQueryMultiTable-batchsink.md
@@ -36,10 +36,9 @@ It will be automatically created if it does not exist, but will not be automatic
 Temporary data will be deleted after it is loaded into BigQuery. If it is not provided, a unique
 bucket will be created and then deleted after the run finishes.
 
-**WriteDisposition**: Type of write disposition to use. This can be set to Empty, Truncate, or Append.
-* Empty - Job should only write to empty tables, otherwise an error is thrown.
-* Truncate - Job will truncate an existing table before writing to it.
-* Append - Job will append to an existing table.
+**Truncate Table**: Whether to truncate the output table before writing to it.
+* True - Will delete all rows in the table before writing to it.
+* False - Will append the new rows to the table.
 
 **Split Field:** The name of the field that will be used to determine which table to write to.
 

--- a/docs/BigQueryTable-batchsink.md
+++ b/docs/BigQueryTable-batchsink.md
@@ -46,10 +46,9 @@ bucket will be created and then deleted after the run finishes.
 will be dropped.
 * Upsert - records that match on Table Key will be updated. Records that do not match will be inserted.
 
-**WriteDisposition**: Type of write disposition to use. This can be set to Empty, Truncate, or Append.
-* Empty - Job should only write to empty tables, otherwise an error is thrown.
-* Truncate - Job will truncate an existing table before writing to it.
-* Append - Job will append to an existing table.
+**Truncate Table**: Whether to truncate the output table before writing to it.
+* True - Will delete all rows in the table before writing to it.
+* False - Will append the new rows to the table.
 
 **Table Key**: List of fields that determines relation between tables during Update and Upsert operations.
 

--- a/docs/BigQueryTable-batchsink.md
+++ b/docs/BigQueryTable-batchsink.md
@@ -46,6 +46,11 @@ bucket will be created and then deleted after the run finishes.
 will be dropped.
 * Upsert - records that match on Table Key will be updated. Records that do not match will be inserted.
 
+**WriteDisposition**: Type of write disposition to use. This can be set to Empty, Truncate, or Append.
+* Empty - Job should only write to empty tables, otherwise an error is thrown.
+* Truncate - Job will truncate an existing table before writing to it.
+* Append - Job will append to an existing table.
+
 **Table Key**: List of fields that determines relation between tables during Update and Upsert operations.
 
 **Create Partitioned Table**: Whether to create the BigQuery table with time partitioning. This value 

--- a/docs/BigQueryTable-batchsink.md
+++ b/docs/BigQueryTable-batchsink.md
@@ -46,9 +46,8 @@ bucket will be created and then deleted after the run finishes.
 will be dropped.
 * Upsert - records that match on Table Key will be updated. Records that do not match will be inserted.
 
-**Truncate Table**: Whether to truncate the output table before writing to it.
-* True - Will delete all rows in the table before writing to it.
-* False - Will append the new rows to the table.
+**Truncate Table**: Whether or not to truncate the table before writing to it.
+Should only be used with the Insert operation.
 
 **Table Key**: List of fields that determines relation between tables during Update and Upsert operations.
 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
@@ -22,6 +22,7 @@ import com.google.cloud.bigquery.FieldList;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableId;
+import com.google.cloud.hadoop.io.bigquery.BigQueryConfiguration;
 import com.google.cloud.hadoop.io.bigquery.BigQueryFileFormat;
 import com.google.cloud.hadoop.io.bigquery.output.BigQueryOutputConfiguration;
 import com.google.cloud.hadoop.io.bigquery.output.BigQueryTableFieldSchema;
@@ -199,6 +200,8 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, J
       baseConfiguration.set(BigQueryConstants.CONFIG_CLUSTERING_ORDER, getConfig().getClusteringOrder());
     }
     baseConfiguration.setStrings(BigQueryConstants.CONFIG_OPERATION, getConfig().getOperation().name());
+    baseConfiguration.setStrings(BigQueryConfiguration.OUTPUT_TABLE_WRITE_DISPOSITION_KEY,
+        getConfig().getWriteDisposition().name());
     if (getConfig().getRelationTableKey() != null) {
       baseConfiguration.set(BigQueryConstants.CONFIG_TABLE_KEY, getConfig().getRelationTableKey());
     }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
@@ -200,7 +200,7 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, J
     }
     baseConfiguration.setStrings(BigQueryConstants.CONFIG_OPERATION, getConfig().getOperation().name());
     baseConfiguration.setStrings(BigQueryConfiguration.OUTPUT_TABLE_WRITE_DISPOSITION_KEY,
-        getConfig().getWriteDisposition().name());
+      getConfig().getWriteDisposition().name());
     if (getConfig().getRelationTableKey() != null) {
       baseConfiguration.set(BigQueryConstants.CONFIG_TABLE_KEY, getConfig().getRelationTableKey());
     }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
@@ -34,7 +34,7 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
   public static final String NAME_PARTITION_BY_FIELD = "partitionByField";
   public static final String NAME_CLUSTERING_ORDER = "clusteringOrder";
   public static final String NAME_OPERATION = "operation";
-  public static final String NAME_WRITE_DISPOSITION = "writeDisposition";
+  public static final String NAME_TRUNCATE_TABLE = "truncateTable";
   public static final String NAME_TABLE_KEY = "relationTableKey";
 
   @Macro
@@ -72,10 +72,11 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
   @Description("Type of write operation to perform. This can be set to Insert, Update or Upsert.")
   protected String operation;
 
-  @Name(NAME_WRITE_DISPOSITION)
+  @Name(NAME_TRUNCATE_TABLE)
   @Macro
-  @Description("Type of write disposition to use. This can be set to Empty, Truncate, or Append.")
-  protected String writeDisposition;
+  @Description("Whether or not to truncate the table before writing to it."
+      + "Should only be used with the Insert operation.")
+  protected boolean truncateTable;
 
   @Name(NAME_TABLE_KEY)
   @Macro
@@ -148,7 +149,7 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
   }
 
   public WriteDisposition getWriteDisposition() {
-    return WriteDisposition.valueOf(writeDisposition.toUpperCase());
+    return truncateTable ? WriteDisposition.WRITE_TRUNCATE : WriteDisposition.WRITE_APPEND;
   }
 
   @Nullable
@@ -167,6 +168,10 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
         throw new InvalidConfigPropertyException("Bucket names can only contain lowercase characters, numbers, " +
                                                    "'.', '_', and '-'.", "bucket");
       }
+    }
+
+    if (getWriteDisposition().equals(WriteDisposition.WRITE_TRUNCATE) && !getOperation().equals(Operation.INSERT)) {
+      throw new InvalidConfigPropertyException("Truncate may only be used with operation Insert", NAME_TRUNCATE_TABLE);
     }
   }
 }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
@@ -74,9 +74,10 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
 
   @Name(NAME_TRUNCATE_TABLE)
   @Macro
+  @Nullable
   @Description("Whether or not to truncate the table before writing to it. "
     + "Should only be used with the Insert operation.")
-  protected boolean truncateTable;
+  protected Boolean truncateTable;
 
   @Name(NAME_TABLE_KEY)
   @Macro
@@ -149,7 +150,7 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
   }
 
   public WriteDisposition getWriteDisposition() {
-    return truncateTable ? WriteDisposition.WRITE_TRUNCATE : WriteDisposition.WRITE_APPEND;
+    return truncateTable != null && truncateTable ? WriteDisposition.WRITE_TRUNCATE : WriteDisposition.WRITE_APPEND;
   }
 
   @Nullable

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
@@ -74,7 +74,7 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
 
   @Name(NAME_TRUNCATE_TABLE)
   @Macro
-  @Description("Whether or not to truncate the table before writing to it."
+  @Description("Whether or not to truncate the table before writing to it. "
     + "Should only be used with the Insert operation.")
   protected boolean truncateTable;
 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
@@ -15,6 +15,7 @@
  */
 package io.cdap.plugin.gcp.bigquery.sink;
 
+import com.google.cloud.bigquery.JobInfo.WriteDisposition;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
@@ -33,6 +34,7 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
   public static final String NAME_PARTITION_BY_FIELD = "partitionByField";
   public static final String NAME_CLUSTERING_ORDER = "clusteringOrder";
   public static final String NAME_OPERATION = "operation";
+  public static final String NAME_WRITE_DISPOSITION = "writeDisposition";
   public static final String NAME_TABLE_KEY = "relationTableKey";
 
   @Macro
@@ -69,6 +71,11 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
   @Macro
   @Description("Type of write operation to perform. This can be set to Insert, Update or Upsert.")
   protected String operation;
+
+  @Name(NAME_WRITE_DISPOSITION)
+  @Macro
+  @Description("Type of write disposition to use. This can be set to Empty, Truncate, or Append.")
+  protected String writeDisposition;
 
   @Name(NAME_TABLE_KEY)
   @Macro
@@ -138,6 +145,10 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
 
   public Operation getOperation() {
     return Operation.valueOf(operation.toUpperCase());
+  }
+
+  public WriteDisposition getWriteDisposition() {
+    return WriteDisposition.valueOf(writeDisposition.toUpperCase());
   }
 
   @Nullable

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
@@ -75,7 +75,7 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
   @Name(NAME_TRUNCATE_TABLE)
   @Macro
   @Description("Whether or not to truncate the table before writing to it."
-      + "Should only be used with the Insert operation.")
+    + "Should only be used with the Insert operation.")
   protected boolean truncateTable;
 
   @Name(NAME_TABLE_KEY)

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
@@ -16,7 +16,6 @@
 
 package io.cdap.plugin.gcp.bigquery.sink;
 
-import com.google.cloud.bigquery.JobInfo.WriteDisposition;
 import com.google.cloud.bigquery.StandardTableDefinition;
 import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TimePartitioning;
@@ -99,7 +98,6 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
       validatePartitionProperties(schema);
       validateClusteringOrder(schema);
       validateOperationProperties(schema);
-      validateWriteDisposition();
       if (outputSchema == null) {
         return;
       }
@@ -251,16 +249,6 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
     if (!result.isEmpty()) {
       throw new InvalidConfigPropertyException(String.format(
         "Fields %s are in the table key, but not in the input schema.", result), NAME_TABLE_KEY);
-    }
-  }
-
-  private void validateWriteDisposition() {
-    if (Arrays.stream(WriteDisposition.values()).map(Enum::name).noneMatch(writeDisposition.toUpperCase()::equals)) {
-      throw new InvalidConfigPropertyException(
-          String.format("'%s' is incorrect value for field 'WriteDisposition'. " +
-              "This field should contain one of the next values: " +
-              "'WRITE_APPEND', 'WRITE_EMPTY' or 'WRITE_TRUNCATE'.", writeDisposition),
-          NAME_OPERATION);
     }
   }
 }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.gcp.bigquery.sink;
 
+import com.google.cloud.bigquery.JobInfo.WriteDisposition;
 import com.google.cloud.bigquery.StandardTableDefinition;
 import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TimePartitioning;
@@ -98,6 +99,7 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
       validatePartitionProperties(schema);
       validateClusteringOrder(schema);
       validateOperationProperties(schema);
+      validateWriteDisposition();
       if (outputSchema == null) {
         return;
       }
@@ -249,6 +251,16 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
     if (!result.isEmpty()) {
       throw new InvalidConfigPropertyException(String.format(
         "Fields %s are in the table key, but not in the input schema.", result), NAME_TABLE_KEY);
+    }
+  }
+
+  private void validateWriteDisposition() {
+    if (Arrays.stream(WriteDisposition.values()).map(Enum::name).noneMatch(writeDisposition.toUpperCase()::equals)) {
+      throw new InvalidConfigPropertyException(
+          String.format("'%s' is incorrect value for field 'WriteDisposition'. " +
+              "This field should contain one of the next values: " +
+              "'WRITE_APPEND', 'WRITE_EMPTY' or 'WRITE_TRUNCATE'.", writeDisposition),
+          NAME_OPERATION);
     }
   }
 }

--- a/widgets/BigQueryMultiTable-batchsink.json
+++ b/widgets/BigQueryMultiTable-batchsink.json
@@ -33,23 +33,19 @@
         },
         {
           "widget-type": "radio-group",
-          "name": "writeDisposition",
-          "label": "Write Disposition",
+          "name": "truncateTable",
+          "label": "Truncate Table",
           "widget-attributes": {
             "layout": "inline",
             "default": "WRITE_APPEND",
             "options": [
               {
-                "id": "WRITE_APPEND",
-                "label": "Append"
-              },
-              {
-                "id": "WRITE_EMPTY",
-                "label": "Empty"
-              },
-              {
                 "id": "WRITE_TRUNCATE",
-                "label": "Truncate"
+                "label": "True"
+              },
+              {
+                "id": "WRITE_APPEND",
+                "label": "False"
               }
             ]
           }

--- a/widgets/BigQueryMultiTable-batchsink.json
+++ b/widgets/BigQueryMultiTable-batchsink.json
@@ -32,22 +32,19 @@
           }
         },
         {
-          "widget-type": "radio-group",
+          "widget-type": "toggle",
           "name": "truncateTable",
           "label": "Truncate Table",
           "widget-attributes": {
-            "layout": "inline",
-            "default": "WRITE_APPEND",
-            "options": [
-              {
-                "id": "WRITE_TRUNCATE",
-                "label": "True"
-              },
-              {
-                "id": "WRITE_APPEND",
-                "label": "False"
-              }
-            ]
+            "default": "false",
+            "on": {
+              "value": "true",
+              "label": "True"
+            },
+            "off": {
+              "value": "false",
+              "label": "False"
+            }
           }
         }
       ]

--- a/widgets/BigQueryMultiTable-batchsink.json
+++ b/widgets/BigQueryMultiTable-batchsink.json
@@ -30,6 +30,29 @@
           "widget-attributes" : {
             "placeholder": "Dataset the tables belong to"
           }
+        },
+        {
+          "widget-type": "radio-group",
+          "name": "writeDisposition",
+          "label": "Write Disposition",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "WRITE_APPEND",
+            "options": [
+              {
+                "id": "WRITE_APPEND",
+                "label": "Append"
+              },
+              {
+                "id": "WRITE_EMPTY",
+                "label": "Empty"
+              },
+              {
+                "id": "WRITE_TRUNCATE",
+                "label": "Truncate"
+              }
+            ]
+          }
         }
       ]
     },

--- a/widgets/BigQueryTable-batchsink.json
+++ b/widgets/BigQueryTable-batchsink.json
@@ -71,22 +71,19 @@
           }
         },
         {
-          "widget-type": "radio-group",
+          "widget-type": "toggle",
           "name": "truncateTable",
           "label": "Truncate Table",
           "widget-attributes": {
-            "layout": "inline",
-            "default": "WRITE_APPEND",
-            "options": [
-              {
-                "id": "WRITE_TRUNCATE",
-                "label": "True"
-              },
-              {
-                "id": "WRITE_APPEND",
-                "label": "False"
-              }
-            ]
+            "default": "false",
+            "on": {
+              "value": "true",
+              "label": "True"
+            },
+            "off": {
+              "value": "false",
+              "label": "False"
+            }
           }
         },
         {

--- a/widgets/BigQueryTable-batchsink.json
+++ b/widgets/BigQueryTable-batchsink.json
@@ -71,6 +71,29 @@
           }
         },
         {
+          "widget-type": "radio-group",
+          "name" : "writeDisposition",
+          "label" : "Write Disposition",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "WRITE_APPEND",
+            "options": [
+              {
+                "id": "WRITE_APPEND",
+                "label": "Append"
+              },
+              {
+                "id": "WRITE_EMPTY",
+                "label": "Empty"
+              },
+              {
+                "id": "WRITE_TRUNCATE",
+                "label": "Truncate"
+              }
+            ]
+          }
+        },
+        {
           "name": "relationTableKey",
           "widget-type": "csv",
           "label": "Table Key",

--- a/widgets/BigQueryTable-batchsink.json
+++ b/widgets/BigQueryTable-batchsink.json
@@ -72,23 +72,19 @@
         },
         {
           "widget-type": "radio-group",
-          "name" : "writeDisposition",
-          "label" : "Write Disposition",
+          "name": "truncateTable",
+          "label": "Truncate Table",
           "widget-attributes": {
             "layout": "inline",
             "default": "WRITE_APPEND",
             "options": [
               {
-                "id": "WRITE_APPEND",
-                "label": "Append"
-              },
-              {
-                "id": "WRITE_EMPTY",
-                "label": "Empty"
-              },
-              {
                 "id": "WRITE_TRUNCATE",
-                "label": "Truncate"
+                "label": "True"
+              },
+              {
+                "id": "WRITE_APPEND",
+                "label": "False"
               }
             ]
           }


### PR DESCRIPTION
Modified the BigQuery Sink (singular and multi) to support WriteDisposition when writing to BigQuery.

Ref: https://cloud.google.com/bigquery/docs/reference/auditlogs/rest/Shared.Types/WriteDisposition

This modification supports three options:
1. Append - Appends the data to the BigQuery tables.
2. Empty - Only write the data to empty BigQuery tables, otherwise fail.
3. Truncate - Truncate the BigQuery table before writing to it.

Additionally, resolved a bug causing NullPointerExceptions when using the BigQuery Multi Sink.

Tested using CDAP Sandbox and Cloud Data Fusion. Test Cases:
- Single Sink Append
- Single Sink Truncate
- Single Sink Fail to Create
- Multi Sink Append
- Multi Sink Truncate
- Multi Sink Fail to Create

Resolves:
https://issues.cask.co/browse/CDAP-15784
https://issues.cask.co/browse/CDAP-15616