### PR TITLE
CDAP-15878 remove datastore source schema check

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/datastore/source/DatastoreSource.java
+++ b/src/main/java/io/cdap/plugin/gcp/datastore/source/DatastoreSource.java
@@ -102,12 +102,7 @@ public class DatastoreSource extends BatchSource<NullWritable, Entity, Structure
       return;
     }
 
-    try {
-      Schemas.validateFieldsMatch(schema, configuredSchema);
-      pipelineConfigurer.getStageConfigurer().setOutputSchema(configuredSchema);
-    } catch (IllegalArgumentException e) {
-      throw new InvalidConfigPropertyException(e.getMessage(), e, "schema");
-    }
+    pipelineConfigurer.getStageConfigurer().setOutputSchema(configuredSchema);
   }
 
   @Override


### PR DESCRIPTION
Removed the schema validation check because it is often incorrect,
due to the fact that the source tries to generate a schema based
on a data point that it gets. It is impossible to generate schema
like that, so change the source to just trust the schema given
by the user.