### PR TITLE
CDAP-15896 skip validation when cant autodetect

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -79,6 +79,10 @@ public final class BigQuerySink extends AbstractBigQuerySink {
     Schema configuredSchema = config.getSchema(collector);
 
     config.validate(inputSchema, configuredSchema, collector);
+
+    if (config.tryGetProject() == null || config.autoServiceAccountUnavailable()) {
+      return;
+    }
     // validate schema with underlying table
     Schema schema = configuredSchema == null ? inputSchema : configuredSchema;
     validateConfiguredSchema(schema, collector);

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
@@ -211,6 +211,9 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
   }
 
   private void validatePartitionProperties(@Nullable Schema schema, FailureCollector collector) {
+    if (tryGetProject() == null) {
+      return;
+    }
     String project = getProject();
     String dataset = getDataset();
     String tableName = getTable();

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySource.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySource.java
@@ -92,7 +92,10 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
     config.validate(collector);
     Schema configuredSchema = config.getSchema(collector);
 
-    if (!config.canConnect()) {
+    // if any of the require properties have macros or the service account can't be auto-detected
+    // or the dataset project isn't set and the project can't be auto-detected
+    if (!config.canConnect() || config.autoServiceAccountUnavailable() ||
+      (config.tryGetProject() == null && config.getDatasetProject() == null)) {
       stageConfigurer.setOutputSchema(configuredSchema);
       return;
     }

--- a/src/main/java/io/cdap/plugin/gcp/bigtable/sink/BigtableSinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigtable/sink/BigtableSinkConfig.java
@@ -89,10 +89,6 @@ public final class BigtableSinkConfig extends GCPReferenceSourceConfig {
     if (!containsMacro(TABLE) && Strings.isNullOrEmpty(table)) {
       collector.addFailure("Table name must be specified.", null).withConfigProperty(TABLE);
     }
-    if (!containsMacro(NAME_PROJECT) && tryGetProject() == null) {
-      collector.addFailure("Could not detect Google Cloud project id from the environment.",
-                           "Specify project id.").withConfigProperty(NAME_PROJECT);
-    }
     if (!containsMacro(INSTANCE) && Strings.isNullOrEmpty(instance)) {
       collector.addFailure("Instance ID must be specified.", null).withConfigProperty(INSTANCE);
     }
@@ -136,6 +132,8 @@ public final class BigtableSinkConfig extends GCPReferenceSourceConfig {
     return !containsMacro(INSTANCE) && Strings.isNullOrEmpty(instance)
       && !containsMacro(NAME_PROJECT) && Strings.isNullOrEmpty(project)
       && !containsMacro(TABLE) && Strings.isNullOrEmpty(table)
-      && !containsMacro(NAME_SERVICE_ACCOUNT_FILE_PATH);
+      && !containsMacro(NAME_SERVICE_ACCOUNT_FILE_PATH)
+      && tryGetProject() != null
+      && !autoServiceAccountUnavailable();
   }
 }

--- a/src/main/java/io/cdap/plugin/gcp/bigtable/source/BigtableSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigtable/source/BigtableSourceConfig.java
@@ -160,10 +160,6 @@ public final class BigtableSourceConfig extends GCPReferenceSourceConfig {
     if (!containsMacro(TABLE) && Strings.isNullOrEmpty(table)) {
       collector.addFailure("Table name must be specified.", null).withConfigProperty(TABLE);
     }
-    if (!containsMacro(NAME_PROJECT) && tryGetProject() == null) {
-      collector.addFailure("Could not detect Google Cloud project id from the environment.",
-                           "Specify project id.").withConfigProperty(NAME_PROJECT);
-    }
     if (!containsMacro(INSTANCE) && Strings.isNullOrEmpty(instance)) {
       collector.addFailure("Instance ID must be specified.", null).withConfigProperty(INSTANCE);
     }

--- a/src/main/java/io/cdap/plugin/gcp/datastore/sink/DatastoreSinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/datastore/sink/DatastoreSinkConfig.java
@@ -28,6 +28,7 @@ import io.cdap.plugin.gcp.datastore.exception.DatastoreInitializationException;
 import io.cdap.plugin.gcp.datastore.sink.util.DatastoreSinkConstants;
 import io.cdap.plugin.gcp.datastore.sink.util.IndexStrategy;
 import io.cdap.plugin.gcp.datastore.sink.util.SinkKeyType;
+import io.cdap.plugin.gcp.datastore.source.DatastoreSourceConfig;
 import io.cdap.plugin.gcp.datastore.util.DatastorePropertyUtil;
 import io.cdap.plugin.gcp.datastore.util.DatastoreUtil;
 
@@ -297,8 +298,7 @@ public class DatastoreSinkConfig extends GCPReferenceSinkConfig {
 
   @VisibleForTesting
   void validateDatastoreConnection(FailureCollector collector) {
-    if (containsMacro(DatastoreSinkConstants.PROPERTY_SERVICE_FILE_PATH)
-      || containsMacro(DatastoreSinkConstants.PROPERTY_PROJECT)) {
+    if (!shouldConnect()) {
       return;
     }
     try {
@@ -394,5 +394,15 @@ public class DatastoreSinkConfig extends GCPReferenceSinkConfig {
                                          DatastoreSinkConstants.MAX_BATCH_SIZE))
         .withConfigProperty(DatastoreSinkConstants.PROPERTY_BATCH_SIZE);
     }
+  }
+
+  /**
+   * Returns true if datastore can be connected to
+   */
+  public boolean shouldConnect() {
+    return !containsMacro(DatastoreSourceConfig.NAME_SERVICE_ACCOUNT_FILE_PATH) &&
+      !containsMacro(DatastoreSourceConfig.NAME_PROJECT) &&
+      tryGetProject() != null &&
+      !autoServiceAccountUnavailable();
   }
 }

--- a/src/main/java/io/cdap/plugin/gcp/datastore/source/DatastoreSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/datastore/source/DatastoreSourceConfig.java
@@ -247,8 +247,7 @@ public class DatastoreSourceConfig extends GCPReferenceSourceConfig {
 
   @VisibleForTesting
   void validateDatastoreConnection(FailureCollector collector) {
-    if (containsMacro(DatastoreSourceConstants.PROPERTY_SERVICE_FILE_PATH)
-      || containsMacro(DatastoreSourceConstants.PROPERTY_PROJECT)) {
+    if (!shouldConnect()) {
       return;
     }
     try {
@@ -562,6 +561,8 @@ public class DatastoreSourceConfig extends GCPReferenceSourceConfig {
   public boolean shouldConnect() {
     return !containsMacro(DatastoreSourceConstants.PROPERTY_SCHEMA) &&
       !containsMacro(DatastoreSourceConfig.NAME_SERVICE_ACCOUNT_FILE_PATH) &&
-      !containsMacro(DatastoreSourceConfig.NAME_PROJECT);
+      !containsMacro(DatastoreSourceConfig.NAME_PROJECT) &&
+      tryGetProject() != null &&
+      !autoServiceAccountUnavailable();
   }
 }

--- a/src/main/java/io/cdap/plugin/gcp/spanner/source/SpannerSource.java
+++ b/src/main/java/io/cdap/plugin/gcp/spanner/source/SpannerSource.java
@@ -98,7 +98,7 @@ public class SpannerSource extends BatchSource<NullWritable, ResultSet, Structur
     config.validate(collector);
     Schema configuredSchema = config.getSchema(collector);
 
-    if (!config.shouldConnect()) {
+    if (!config.shouldConnect() || config.tryGetProject() == null || config.autoServiceAccountUnavailable()) {
       stageConfigurer.setOutputSchema(configuredSchema);
       return;
     }


### PR DESCRIPTION
Skip certain validation checks when the project or service account
cannot be auto-detected. This is done because auto-detection may
work at runtime when the pipeline is run on dataproc, so the
user needs to be able to deploy pipelines like these.