### PR TITLE
CDAP-15962 fix AvroKey not found error in some environments

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -39,14 +39,12 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.mapred.AvroKey;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
-import org.apache.hadoop.mapred.JobContext;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 
 /**
  * This class <code>BigQuerySink</code> is a plugin that would allow users
@@ -121,9 +119,7 @@ public final class BigQuerySink extends AbstractBigQuerySink {
 
       @Override
       public Map<String, String> getOutputFormatConfiguration() {
-        Map<String, String> map = BigQueryUtil.configToMap(configuration);
-        map.put(JobContext.OUTPUT_KEY_CLASS, AvroKey.class.getName());
-        return map;
+        return BigQueryUtil.configToMap(configuration);
       }
     };
   }


### PR DESCRIPTION
There is no need to set the mapred output key class to AvroKey,
as the object will get cast at runtime. Doing so requires the
program to have access to the AvroKey class, which would require
the plugin to export it, which would easily cause clashes.