### PR TITLE
CDAP-16037 add location to gcp sinks

### DIFF
--- a/docs/BigQueryMultiTable-batchsink.md
+++ b/docs/BigQueryMultiTable-batchsink.md
@@ -39,6 +39,9 @@ bucket will be created and then deleted after the run finishes.
 **Truncate Table:** Whether or not to truncate the table before writing to it.
 Should only be used with the Insert operation.
 
+**Location:** The location where the big query datasets will get created. This value is ignored
+if the dataset or temporary bucket already exist.
+
 **Split Field:** The name of the field that will be used to determine which table to write to.
 
 **Update Table Schema**: Whether the BigQuery table schema should be modified 

--- a/docs/BigQueryTable-batchsink.md
+++ b/docs/BigQueryTable-batchsink.md
@@ -51,6 +51,9 @@ Should only be used with the Insert operation.
 
 **Table Key**: List of fields that determines relation between tables during Update and Upsert operations.
 
+**Location:** The location where the big query dataset will get created. This value is ignored
+if the dataset or temporary bucket already exist.
+
 **Create Partitioned Table**: Whether to create the BigQuery table with time partitioning. This value 
 is ignored if the table already exists.
 * When this is set to true, table will be created with time partitioning. 

--- a/docs/GCS-batchsink.md
+++ b/docs/GCS-batchsink.md
@@ -41,6 +41,8 @@ The format must be one of 'json', 'avro', 'parquet', 'csv', 'tsv', or 'delimited
 **Delimiter:** Delimiter to use if the format is 'delimited'.
 The delimiter will be ignored if the format is anything other than 'delimited'.
 
+**Location:** The location where the gcs bucket will get created. This value is ignored if the bucket already exists.
+
 **Service Account File Path**: Path on the local file system of the service account key used for
 authorization. Can be set to 'auto-detect' when running on a Dataproc cluster.
 When running on other clusters, the file must be present on every node in the cluster.

--- a/docs/GCSBucketCreate-action.md
+++ b/docs/GCSBucketCreate-action.md
@@ -34,6 +34,8 @@ It can be found on the Dashboard in the Google Cloud Platform Console.
 
 **Fail if Object Exists**: Whether to fail the pipeline if an object already exists.
 
+**Location:** The location where the gcs buckets will get created. This value is ignored if the bucket already exists.
+
 **Service Account File Path**: Path on the local file system of the service account key used for
 authorization. Can be set to 'auto-detect' when running on a Dataproc cluster.
 When running on other clusters, the file must be present on every node in the cluster.

--- a/docs/GCSMultiFiles-batchsink.md
+++ b/docs/GCSMultiFiles-batchsink.md
@@ -53,6 +53,8 @@ The format must be one of 'avro', 'parquet', 'orc' or 'delimited'.
 **Delimiter:** Delimiter to use if the format is 'delimited'.
 The delimiter will be ignored if the format is anything other than 'delimited'.
 
+**Location:** The location where the gcs buckets will get created. This value is ignored if the bucket already exists.
+
 **Service Account File Path:** Path on the local file system of the service account key used for
 authorization. Can be set to 'auto-detect' when running on a Dataproc cluster.
 When running on other clusters, the file must be present on every node in the cluster.

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
@@ -40,6 +40,7 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
   public static final String NAME_DATASET = "dataset";
   public static final String NAME_BUCKET = "bucket";
   public static final String NAME_TRUNCATE_TABLE = "truncateTable";
+  public static final String NAME_LOCATION = "location";
 
   @Name(NAME_DATASET)
   @Macro
@@ -66,6 +67,18 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
   @Description("Whether or not to truncate the table before writing to it. "
     + "Should only be used with the Insert operation.")
   protected Boolean truncateTable;
+
+  @Name(NAME_LOCATION)
+  @Macro
+  @Nullable
+  @Description("The location where the big query dataset will get created. " +
+                 "This value is ignored if the dataset or temporary bucket already exist.")
+  protected String location;
+
+  @Nullable
+  public String getLocation() {
+    return location;
+  }
 
   @Nullable
   protected String getTable() {

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySource.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySource.java
@@ -18,6 +18,7 @@ package io.cdap.plugin.gcp.bigquery.source;
 
 import com.google.auth.Credentials;
 import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.FieldList;
 import com.google.cloud.bigquery.LegacySQLTypeName;
@@ -136,10 +137,12 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
       // By default, this option is false, meaning the job can not delete the bucket. So enable it only when bucket name
       // is not provided.
       configuration.setBoolean("fs.gs.bucket.delete.enable", true);
-    }
 
-    BigQueryUtil.createResources(bigQuery, GCPUtils.getStorage(config.getProject(), credentials),
-                                 config.getDataset(), bucket, cmekKey);
+      // the dataset existence is validated before, so this cannot be null
+      Dataset dataset = bigQuery.getDataset(config.getDataset());
+      GCPUtils.createBucket(GCPUtils.getStorage(config.getProject(), credentials), bucket, dataset.getLocation(),
+                            cmekKey);
+    }
 
     configuration.set("fs.gs.system.bucket", bucket);
     configuration.setBoolean("fs.gs.impl.disable.cache", true);

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
@@ -18,17 +18,12 @@ package io.cdap.plugin.gcp.bigquery.util;
 
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryException;
-import com.google.cloud.bigquery.Dataset;
-import com.google.cloud.bigquery.DatasetInfo;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.FieldList;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.hadoop.io.bigquery.BigQueryConfiguration;
-import com.google.cloud.storage.Bucket;
-import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -53,7 +48,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -154,79 +148,6 @@ public final class BigQueryUtil {
       configuration.set(BigQueryConfiguration.OUTPUT_TABLE_KMS_KEY_NAME_KEY, cmekKey);
     }
     return configuration;
-  }
-
-  /**
-   * Creates the given dataset and bucket if they do not already exist. If the dataset already exists but the
-   * bucket does not, the bucket will be created in the same location as the dataset. If the bucket already exists
-   * but the dataset does not, the dataset will attempt to be created in the same location. This may fail if the bucket
-   * is in a location that BigQuery does not yet support.
-   *
-   * @param bigQuery the bigquery client for the project
-   * @param storage the storage client for the project
-   * @param datasetName the name of the dataset
-   * @param bucketName the name of the bucket
-   * @param cmekKey the name of the cmek key
-   * @throws IOException if there was an error creating or fetching any GCP resource
-   */
-  public static void createResources(BigQuery bigQuery, Storage storage,
-                                     String datasetName, String bucketName,
-                                     @Nullable String cmekKey) throws IOException {
-    Dataset dataset = bigQuery.getDataset(datasetName);
-    Bucket bucket = storage.get(bucketName);
-
-    if (dataset == null && bucket == null) {
-      createBucket(storage, bucketName, null, cmekKey,
-                   () -> String.format("Unable to create Cloud Storage bucket '%s'", bucketName));
-      createDataset(bigQuery, datasetName, null,
-                    () -> String.format("Unable to create BigQuery dataset '%s'", datasetName));
-    } else if (bucket == null) {
-      createBucket(
-        storage, bucketName, dataset.getLocation(), cmekKey,
-        () -> String.format(
-          "Unable to create Cloud Storage bucket '%s' in the same location ('%s') as BigQuery dataset '%s'. "
-            + "Please use a bucket that is in the same location as the dataset.",
-          bucketName, dataset.getLocation(), datasetName));
-    } else if (dataset == null) {
-      createDataset(
-        bigQuery, datasetName, bucket.getLocation(),
-        () -> String.format(
-          "Unable to create BigQuery dataset '%s' in the same location ('%s') as Cloud Storage bucket '%s'. "
-            + "Please use a bucket that is in a supported location.",
-          datasetName, bucket.getLocation(), bucketName));
-    }
-  }
-
-  private static void createDataset(BigQuery bigQuery, String dataset, @Nullable String location,
-                                    Supplier<String> errorMessage) throws IOException {
-    DatasetInfo.Builder builder = DatasetInfo.newBuilder(dataset);
-    if (location != null) {
-      builder.setLocation(location);
-    }
-    try {
-      bigQuery.create(builder.build());
-    } catch (BigQueryException e) {
-      if (e.getCode() != 409) {
-        // A conflict means the dataset already exists (https://cloud.google.com/bigquery/troubleshooting-errors)
-        // This most likely means multiple stages in the same pipeline are trying to create the same dataset.
-        // Ignore this and move on, since all that matters is that the dataset exists.
-        throw new IOException(errorMessage.get(), e);
-      }
-    }
-  }
-
-  private static void createBucket(Storage storage, String bucket, @Nullable String location,
-                                   @Nullable String cmekKey, Supplier<String> errorMessage) throws IOException {
-    try {
-      GCPUtils.createBucket(storage, bucket, location, cmekKey);
-    } catch (StorageException e) {
-      if (e.getCode() != 409) {
-        // A conflict means the bucket already exists
-        // This most likely means multiple stages in the same pipeline are trying to create the same dataset.
-        // Ignore this and move on, since all that matters is that the dataset exists.
-        throw new IOException(errorMessage.get(), e);
-      }
-    }
   }
 
   /**

--- a/src/main/java/io/cdap/plugin/gcp/bigtable/sink/BigtableSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigtable/sink/BigtableSink.java
@@ -135,7 +135,8 @@ public final class BigtableSink extends BatchSink<StructuredRecord, ImmutableByt
     // Both emitLineage and setOutputFormat internally try to create an external dataset if it does not already exists.
     // We call emitLineage before since it creates the dataset with schema.
     emitLineage(context);
-    context.addOutput(Output.of(config.referenceName, new SourceOutputFormatProvider(TableOutputFormat.class, conf)));
+    context.addOutput(Output.of(config.getReferenceName(),
+                                new SourceOutputFormatProvider(TableOutputFormat.class, conf)));
   }
 
   @Override
@@ -235,7 +236,7 @@ public final class BigtableSink extends BatchSink<StructuredRecord, ImmutableByt
 
   private void emitLineage(BatchSinkContext context) {
     Schema inputSchema = context.getInputSchema();
-    LineageRecorder lineageRecorder = new LineageRecorder(context, config.referenceName);
+    LineageRecorder lineageRecorder = new LineageRecorder(context, config.getReferenceName());
     lineageRecorder.createExternalDataset(inputSchema);
 
     if (inputSchema != null) {

--- a/src/main/java/io/cdap/plugin/gcp/bigtable/sink/BigtableSinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigtable/sink/BigtableSinkConfig.java
@@ -23,7 +23,7 @@ import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.plugin.gcp.bigtable.common.HBaseColumn;
 import io.cdap.plugin.gcp.common.ConfigUtil;
-import io.cdap.plugin.gcp.common.GCPReferenceSourceConfig;
+import io.cdap.plugin.gcp.common.GCPReferenceSinkConfig;
 
 import java.io.File;
 import java.util.Collections;
@@ -34,7 +34,7 @@ import javax.annotation.Nullable;
 /**
  * Holds configuration required for configuring {@link BigtableSink}.
  */
-public final class BigtableSinkConfig extends GCPReferenceSourceConfig {
+public final class BigtableSinkConfig extends GCPReferenceSinkConfig {
   public static final String TABLE = "table";
   public static final String INSTANCE = "instance";
   public static final String KEY_ALIAS = "keyAlias";

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketCreate.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketCreate.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 
 /**
@@ -100,7 +101,8 @@ public final class GCSBucketCreate extends Action {
 
         // create the gcs buckets if not exist
         if (storage.get(gcsPath.getBucket()) == null) {
-          GCPUtils.createBucket(storage, gcsPath.getBucket(), null, context.getArguments().get(GCPUtils.CMEK_KEY));
+          GCPUtils.createBucket(storage, gcsPath.getBucket(), config.location,
+                                context.getArguments().get(GCPUtils.CMEK_KEY));
           undoBucket.add(bucketPath);
         } else if (gcsPath.equals(bucketPath) && config.failIfExists()) {
           // if the gcs path is just a bucket, and it exists, fail the pipeline
@@ -161,6 +163,7 @@ public final class GCSBucketCreate extends Action {
    */
   public static final class Config extends GCPConfig {
     public static final String NAME_PATHS = "paths";
+    public static final String NAME_LOCATION = "location";
 
     @Name(NAME_PATHS)
     @Description("Comma separated list of objects to be created.")
@@ -171,6 +174,13 @@ public final class GCSBucketCreate extends Action {
     @Description("Fail if path exists.")
     @Macro
     private boolean failIfExists;
+
+    @Name(NAME_LOCATION)
+    @Macro
+    @Nullable
+    @Description("The location where the gcs buckets will get created. " +
+                   "This value is ignored if the bucket already exists.")
+    protected String location;
 
     public List<String> getPaths() {
       return Arrays.stream(paths.split(",")).map(String::trim).collect(Collectors.toList());

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
@@ -69,7 +69,7 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
                                 null : GCPUtils.loadServiceAccountCredentials(config.getServiceAccountFilePath());
     Storage storage = GCPUtils.getStorage(config.getProject(), credentials);
     if (storage.get(config.getBucket()) == null) {
-      GCPUtils.createBucket(storage, config.getBucket(), null, cmekKey);
+      GCPUtils.createBucket(storage, config.getBucket(), config.getLocation(), cmekKey);
     }
   }
 
@@ -92,6 +92,7 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
     private static final String NAME_SUFFIX = "suffix";
     private static final String NAME_FORMAT = "format";
     private static final String NAME_SCHEMA = "schema";
+    private static final String NAME_LOCATION = "location";
 
     private static final String SCHEME = "gs://";
     @Name(NAME_PATH)
@@ -121,6 +122,13 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
     @Macro
     @Nullable
     private String schema;
+
+    @Name(NAME_LOCATION)
+    @Macro
+    @Nullable
+    @Description("The location where the gcs bucket will get created. " +
+                   "This value is ignored if the bucket already exists")
+    protected String location;
 
     @Override
     public void validate() {
@@ -195,6 +203,11 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
     @Nullable
     public String getDelimiter() {
       return delimiter;
+    }
+
+    @Nullable
+    public String getLocation() {
+      return location;
     }
   }
 }

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSMultiBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSMultiBatchSink.java
@@ -100,7 +100,7 @@ public class GCSMultiBatchSink extends BatchSink<StructuredRecord, NullWritable,
                                 null : GCPUtils.loadServiceAccountCredentials(config.getServiceAccountFilePath());
     Storage storage = GCPUtils.getStorage(config.getProject(), credentials);
     if (storage.get(config.getBucket()) == null) {
-      GCPUtils.createBucket(storage, config.getBucket(), null, cmekKey);
+      GCPUtils.createBucket(storage, config.getBucket(), config.getLocation(), cmekKey);
     }
 
     for (Map.Entry<String, String> argument : argumentCopy.entrySet()) {

--- a/widgets/BigQueryMultiTable-batchsink.json
+++ b/widgets/BigQueryMultiTable-batchsink.json
@@ -101,6 +101,19 @@
           }
         }
       ]
+    },
+    {
+      "label": "Auto Create",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Location",
+          "name": "location",
+          "widget-attributes": {
+            "default": "US"
+          }
+        }
+      ]
     }
   ],
   "outputs": [],

--- a/widgets/BigQueryTable-batchsink.json
+++ b/widgets/BigQueryTable-batchsink.json
@@ -132,6 +132,14 @@
       "label": "Auto Create",
       "properties": [
         {
+          "widget-type": "textbox",
+          "label": "Location",
+          "name": "location",
+          "widget-attributes" : {
+            "default": "US"
+          }
+        },
+        {
           "name": "createPartitionedTable",
           "widget-type": "toggle",
           "label": "Create Partitioned Table",

--- a/widgets/GCS-batchsink.json
+++ b/widgets/GCS-batchsink.json
@@ -79,6 +79,19 @@
           }
         }
       ]
+    },
+    {
+      "label": "Auto Create",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Location",
+          "name": "location",
+          "widget-attributes": {
+            "default": "us"
+          }
+        }
+      ]
     }
   ],
   "outputs": [

--- a/widgets/GCSBucketCreate-action.json
+++ b/widgets/GCSBucketCreate-action.json
@@ -56,6 +56,19 @@
           }
         }
       ]
+    },
+    {
+      "label": "Auto Create",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Location",
+          "name": "location",
+          "widget-attributes": {
+            "default": "us"
+          }
+        }
+      ]
     }
   ],
   "outputs": []

--- a/widgets/GCSMultiFiles-batchsink.json
+++ b/widgets/GCSMultiFiles-batchsink.json
@@ -105,6 +105,19 @@
           }
         }
       ]
+    },
+    {
+      "label": "Auto Create",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Location",
+          "name": "location",
+          "widget-attributes": {
+            "default": "us"
+          }
+        }
+      ]
     }
   ],
   "outputs": [


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16037

This pr adds the location to the gcs and bq sinks that create resources.
Pubsub does not expose location.
Bigtable and Spanner only supports location at the instance level, and we do not create instance in these sinks.
DataStore we do not create non-existing instances.