### PR TITLE
CDAP-15775 allow writing to an empty BQ table using sink

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
@@ -250,7 +250,7 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, A
                                 FailureCollector collector) {
     String tableName = table.getTableId().getTable();
     com.google.cloud.bigquery.Schema bqSchema = table.getDefinition().getSchema();
-    if (bqSchema == null) {
+    if (bqSchema == null || bqSchema.getFields().isEmpty()) {
       // Table is created without schema, so no further validation is required.
       return;
     }


### PR DESCRIPTION
BigQuery tables can be created without any schema. When data is
loaded, the schema is set. Fixed the sink to allow writing to
these types of tables instead of failing during validation.