### PR TITLE
[CDAP-16670] Fix OOM for bigquery sink

### DIFF
--- a/docs/BigQueryMultiTable-batchsink.md
+++ b/docs/BigQueryMultiTable-batchsink.md
@@ -36,6 +36,8 @@ It will be automatically created if it does not exist, but will not be automatic
 Temporary data will be deleted after it is loaded into BigQuery. If it is not provided, a unique
 bucket will be created and then deleted after the run finishes.
 
+**GCS Upload Request Chunk Size**: GCS upload request chunk size in bytes. Default value is 8388608 bytes.
+
 **Truncate Table:** Whether or not to truncate the table before writing to it.
 Should only be used with the Insert operation.
 

--- a/docs/BigQueryTable-batchsink.md
+++ b/docs/BigQueryTable-batchsink.md
@@ -40,6 +40,8 @@ It will be automatically created if it does not exist, but will not be automatic
 Temporary data will be deleted after it is loaded into BigQuery. If it is not provided, a unique
 bucket will be created and then deleted after the run finishes.
 
+**GCS Upload Request Chunk Size**: GCS upload request chunk size in bytes. Default value is 8388608 bytes.
+
 **Operation**: Type of write operation to perform. This can be set to Insert, Update or Upsert.
 * Insert - all records will be inserted in destination table.
 * Update - records that match on Table Key will be updated in the table. Records that do not match 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
@@ -202,6 +202,9 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, A
                                  getConfig().isAllowSchemaRelaxation());
     baseConfiguration.setStrings(BigQueryConfiguration.OUTPUT_TABLE_WRITE_DISPOSITION_KEY,
                                  getConfig().getWriteDisposition().name());
+    // this setting is needed because gcs has default chunk size of 64MB. This is large default chunk size which can
+    // cause OOM issue if there are many tables being written. See this - CDAP-16670
+    baseConfiguration.set("fs.gs.outputstream.upload.chunk.size", "8388608");
     return baseConfiguration;
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
@@ -33,6 +33,7 @@ import com.google.cloud.hadoop.io.bigquery.output.BigQueryTableSchema;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
+import com.google.common.base.Strings;
 import io.cdap.cdap.api.data.batch.Output;
 import io.cdap.cdap.api.data.batch.OutputFormatProvider;
 import io.cdap.cdap.api.data.format.StructuredRecord;
@@ -196,15 +197,20 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, A
    * @return base configuration
    */
   private Configuration getBaseConfiguration(@Nullable String cmekKey) throws IOException {
-    Configuration baseConfiguration = BigQueryUtil.getBigQueryConfig(getConfig().getServiceAccountFilePath(),
-                                                                     getConfig().getProject(), cmekKey);
+    AbstractBigQuerySinkConfig config = getConfig();
+    Configuration baseConfiguration = BigQueryUtil.getBigQueryConfig(config.getServiceAccountFilePath(),
+                                                                     config.getProject(), cmekKey);
     baseConfiguration.setBoolean(BigQueryConstants.CONFIG_ALLOW_SCHEMA_RELAXATION,
-                                 getConfig().isAllowSchemaRelaxation());
+                                 config.isAllowSchemaRelaxation());
     baseConfiguration.setStrings(BigQueryConfiguration.OUTPUT_TABLE_WRITE_DISPOSITION_KEY,
-                                 getConfig().getWriteDisposition().name());
+                                 config.getWriteDisposition().name());
     // this setting is needed because gcs has default chunk size of 64MB. This is large default chunk size which can
     // cause OOM issue if there are many tables being written. See this - CDAP-16670
-    baseConfiguration.set("fs.gs.outputstream.upload.chunk.size", "8388608");
+    String gcsChunkSize = "8388608";
+    if (!Strings.isNullOrEmpty(config.getGcsChunkSize())) {
+      gcsChunkSize = config.getGcsChunkSize();
+    }
+    baseConfiguration.set("fs.gs.outputstream.upload.chunk.size", gcsChunkSize);
     return baseConfiguration;
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
@@ -41,6 +41,7 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
   public static final String NAME_BUCKET = "bucket";
   public static final String NAME_TRUNCATE_TABLE = "truncateTable";
   public static final String NAME_LOCATION = "location";
+  private static final String NAME_GCS_CHUNK_SIZE = "gcsChunkSize";
 
   @Name(NAME_DATASET)
   @Macro
@@ -56,6 +57,13 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
     + "Cloud Storage data will be deleted after it is loaded into BigQuery. "
     + "If it is not provided, a unique bucket will be created and then deleted after the run finishes.")
   protected String bucket;
+
+  @Name(NAME_GCS_CHUNK_SIZE)
+  @Macro
+  @Nullable
+  @Description("Optional property to tune chunk size in gcs upload request. The value of this property should be in " +
+    "number of bytes. By default, 8388608 bytes (8MB) will be used as upload request chunk size.")
+  protected String gcsChunkSize;
 
   @Macro
   @Description("Whether to modify the BigQuery table schema if it differs from the input schema.")
@@ -87,6 +95,11 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
 
   public String getDataset() {
     return dataset;
+  }
+
+  @Nullable
+  public String getGcsChunkSize() {
+    return gcsChunkSize;
   }
 
   @Nullable

--- a/widgets/BigQueryMultiTable-batchsink.json
+++ b/widgets/BigQueryMultiTable-batchsink.json
@@ -75,6 +75,14 @@
         },
         {
           "widget-type": "textbox",
+          "label": "GCS Upload Request Chunk Size",
+          "name": "gcsChunkSize",
+          "widget-attributes" : {
+            "placeholder": "GCS upload request chunk size in bytes"
+          }
+        },
+        {
+          "widget-type": "textbox",
           "label": "Split Field",
           "name": "splitField",
           "widget-attributes": {

--- a/widgets/BigQueryTable-batchsink.json
+++ b/widgets/BigQueryTable-batchsink.json
@@ -46,6 +46,14 @@
           "widget-attributes" : {
             "placeholder": "Google Cloud Storage bucket for temporary data"
           }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "GCS Upload Request Chunk Size",
+          "name": "gcsChunkSize",
+          "widget-attributes" : {
+            "placeholder": "GCS upload request chunk size in bytes"
+          }
         }
       ]
     },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14131070/80527493-47e48d00-8949-11ea-85f0-82089ebdf0bb.png)

![image](https://user-images.githubusercontent.com/14131070/80527507-4f0b9b00-8949-11ea-8a89-9a62708f2cc8.png)

![image](https://user-images.githubusercontent.com/14131070/80527544-5e8ae400-8949-11ea-9f60-c4f8b6f8f5e1.png)

Tested witH 8MB default and Mapreduce engine and following worker config:
![image](https://user-images.githubusercontent.com/14131070/80527630-85491a80-8949-11ea-95d2-9a9175830be0.png)

The pipeline reads 100 * 12000 records from 100 multiple tables from sql server and writes to bigquery using bigquery multi table.
