### PR TITLE
CDAP-16815 - Emit metrics for insert, update and upsert from BQSink

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
@@ -22,6 +22,10 @@ import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.DatasetInfo;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.FieldList;
+import com.google.cloud.bigquery.Job;
+import com.google.cloud.bigquery.JobConfiguration;
+import com.google.cloud.bigquery.JobId;
+import com.google.cloud.bigquery.JobStatistics;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableId;
@@ -75,12 +79,15 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, A
 
   private static final String gcsPathFormat = "gs://%s";
   private static final String temporaryBucketFormat = gcsPathFormat + "/input/%s-%s";
+  public static final String RECORDS_UPDATED_METRIC = "records.updated";
 
   // UUID for the run. Will be used as bucket name if bucket is not provided.
   // UUID is used since GCS bucket names must be globally unique.
   private final UUID uuid = UUID.randomUUID();
   protected Configuration baseConfiguration;
   private StructuredToAvroTransformer avroTransformer;
+  private final String jobId = UUID.randomUUID().toString();
+  private BigQuery bigQuery;
 
   /**
    * Executes main prepare run logic. Child classes cannot override this method,
@@ -98,10 +105,11 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, A
     Credentials credentials = serviceAccountFilePath == null ?
       null : GCPUtils.loadServiceAccountCredentials(serviceAccountFilePath);
     String project = config.getProject();
-    BigQuery bigQuery = GCPUtils.getBigQuery(project, credentials);
+    bigQuery = GCPUtils.getBigQuery(project, credentials);
     String cmekKey = context.getArguments().get(GCPUtils.CMEK_KEY);
     baseConfiguration = getBaseConfiguration(cmekKey);
     String bucket = configureBucket();
+    baseConfiguration.set(BigQueryConstants.CONFIG_JOB_ID, jobId);
     if (!context.isPreviewEnabled()) {
       createResources(bigQuery, GCPUtils.getStorage(project, credentials), config.getDataset(), bucket,
                       config.getLocation(), cmekKey);
@@ -112,6 +120,8 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, A
 
   @Override
   public final void onRunFinish(boolean succeeded, BatchSinkContext context) {
+    recordMetric(succeeded, context);
+
     if (getConfig().getBucket() == null) {
       Path gcsPath = new Path(String.format(gcsPathFormat, uuid.toString()));
       try {
@@ -124,6 +134,47 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, A
         LOG.warn("Failed to delete bucket '{}': {}", gcsPath, e.getMessage());
       }
     }
+  }
+
+  private void recordMetric(boolean succeeded, BatchSinkContext context) {
+    if (!succeeded) {
+      return;
+    }
+    Job queryJob = bigQuery.getJob(getJobId());
+    if (queryJob == null) {
+      LOG.warn("Unable to find BigQuery job. No metric will be emitted for the number of affected rows.");
+      return;
+    }
+    long totalRows = getTotalRows(queryJob);
+    LOG.info("Job {} affected {} rows", queryJob.getJobId(), totalRows);
+    //work around since StageMetrics count() only takes int as of now
+    int cap = 10000; // so the loop will not cause significant delays
+    long count = totalRows / Integer.MAX_VALUE;
+    if (count > cap) {
+      LOG.warn("Total record count is too high! Metric for the number of affected rows may not be updated correctly");
+    }
+    count = count < cap ? count : cap;
+    for (int i = 0; i <= count && totalRows > 0; i++) {
+      int rowCount = totalRows < Integer.MAX_VALUE ? (int) totalRows : Integer.MAX_VALUE;
+      context.getMetrics().count(RECORDS_UPDATED_METRIC, rowCount);
+      totalRows -= rowCount;
+    }
+  }
+
+  private JobId getJobId() {
+    String location = bigQuery.getDataset(getConfig().getDataset()).getLocation();
+    return JobId.newBuilder().setLocation(location).setJob(jobId).build();
+  }
+
+  private long getTotalRows(Job queryJob) {
+    JobConfiguration.Type type = queryJob.getConfiguration().getType();
+    if (type == JobConfiguration.Type.LOAD) {
+      return ((JobStatistics.LoadStatistics) queryJob.getStatistics()).getOutputRows();
+    } else if (type == JobConfiguration.Type.QUERY) {
+      return ((JobStatistics.QueryStatistics) queryJob.getStatistics()).getNumDmlAffectedRows();
+    }
+    LOG.warn("Unable to identify BigQuery job type. No metric will be emitted for the number of affected rows.");
+    return 0;
   }
 
   @Override

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
@@ -35,4 +35,5 @@ public interface BigQueryConstants {
   String CONFIG_TABLE_FIELDS = "cdap.bq.sink.table.fields";
   String CONFIG_FILTER = "cdap.bq.source.filter";
   String CONFIG_PARTITION_FILTER = "cdap.bq.sink.partition.filter";
+  String CONFIG_JOB_ID = "cdap.bq.sink.job.id";
 }

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/BigQuerySinkTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/BigQuerySinkTest.java
@@ -16,15 +16,34 @@
 
 package io.cdap.plugin.gcp.bigquery;
 
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.Dataset;
+import com.google.cloud.bigquery.Job;
+import com.google.cloud.bigquery.JobConfiguration;
+import com.google.cloud.bigquery.JobId;
+import com.google.cloud.bigquery.JobStatistics;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.cdap.etl.api.validation.ValidationFailure;
+import io.cdap.cdap.etl.common.AbstractStageContext;
+import io.cdap.cdap.etl.mock.common.MockStageMetrics;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
+import io.cdap.cdap.etl.spark.batch.SparkBatchSinkContext;
+import io.cdap.plugin.gcp.bigquery.sink.AbstractBigQuerySink;
 import io.cdap.plugin.gcp.bigquery.sink.BigQuerySink;
 import io.cdap.plugin.gcp.bigquery.sink.BigQuerySinkConfig;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.internal.util.reflection.FieldSetter;
 
 import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link BigQuerySink}.
@@ -59,4 +78,94 @@ public class BigQuerySinkTest {
     List<ValidationFailure> failures = collector.getValidationFailures();
     Assert.assertEquals(2, failures.size());
   }
+
+  @Test
+  public void testBigQuerySinkMetricInsert() throws Exception {
+    Job mockJob = getMockLoadJob(10L);
+    testMetric(mockJob, 10L, 1);
+  }
+
+  @Test
+  public void testBigQuerySinkMetricInsertLargeCount1() throws Exception {
+    Job mockJob = getMockLoadJob((long) Integer.MAX_VALUE + 1);
+    testMetric(mockJob, -1, 2);
+  }
+
+  @Test
+  public void testBigQuerySinkMetricInsertLargeCount2() throws Exception {
+    Job mockLoadJob = getMockLoadJob((long) Integer.MAX_VALUE);
+    testMetric(mockLoadJob, -1, 1);
+  }
+
+  @Test
+  public void testBigQuerySinkMetricUpdate() throws Exception {
+    Job mockJob = getMockQueryJob(20L);
+    testMetric(mockJob, 20L, 1);
+  }
+
+  @Test
+  public void testBigQuerySinkMetricUpsert() throws Exception {
+    Job mockJob = getMockQueryJob(1000L);
+    testMetric(mockJob, 1000L, 1);
+  }
+
+  private void testMetric(Job mockJob, long expectedCount, int invocations)
+    throws NoSuchFieldException {
+    BigQuerySink sink = getSinkToTest(mockJob);
+    MockStageMetrics mockStageMetrics = Mockito.spy(new MockStageMetrics("test"));
+    BatchSinkContext context = getContextWithMetrics(mockStageMetrics);
+    sink.onRunFinish(true, context);
+    if (expectedCount > -1) {
+      Assert.assertEquals(expectedCount, mockStageMetrics.getCount(AbstractBigQuerySink.RECORDS_UPDATED_METRIC));
+    }
+    Mockito.verify(mockStageMetrics, times(invocations)).count(anyString(), anyInt());
+  }
+
+  private static BigQuerySink getSinkToTest(Job mockJob) throws NoSuchFieldException {
+    Schema schema = Schema.recordOf("record",
+                                    Schema.Field.of("id", Schema.of(Schema.Type.LONG)),
+                                    Schema.Field.of("name", Schema.of(Schema.Type.STRING)));
+    BigQuerySinkConfig config =
+      new BigQuerySinkConfig("testmetric", "ds", "tb", "bkt", schema.toString());
+    BigQuery bigQueryMock = mock(BigQuery.class);
+    BigQuerySink sink = new BigQuerySink(config);
+    setBigQuery(sink, bigQueryMock);
+    Dataset mockDataSet = mock(Dataset.class);
+    Mockito.when(bigQueryMock.getDataset(anyString())).thenReturn(mockDataSet);
+    Mockito.when(bigQueryMock.getJob(Mockito.any(JobId.class))).thenReturn(mockJob);
+    return sink;
+  }
+
+  private static void setBigQuery(BigQuerySink sink, BigQuery bigQuery) throws NoSuchFieldException {
+    FieldSetter.setField(sink, AbstractBigQuerySink.class.getDeclaredField("bigQuery"), bigQuery);
+  }
+
+  private BatchSinkContext getContextWithMetrics(MockStageMetrics mockStageMetrics) throws NoSuchFieldException {
+    BatchSinkContext context = mock(SparkBatchSinkContext.class);
+    FieldSetter.setField(context, AbstractStageContext.class.getDeclaredField("stageMetrics"), mockStageMetrics);
+    return context;
+  }
+
+  private static Job getMockLoadJob(long count) {
+    Job job = mock(Job.class);
+    JobConfiguration jobConfiguration = mock(JobConfiguration.class);
+    when(job.getConfiguration()).thenReturn(jobConfiguration);
+    when(jobConfiguration.getType()).thenReturn(JobConfiguration.Type.LOAD);
+    JobStatistics.LoadStatistics loadStatistics = mock(JobStatistics.LoadStatistics.class);
+    when(job.getStatistics()).thenReturn(loadStatistics);
+    when(loadStatistics.getOutputRows()).thenReturn(count);
+    return job;
+  }
+
+  private static Job getMockQueryJob(long count) {
+    Job job = mock(Job.class);
+    JobConfiguration jobConfiguration = mock(JobConfiguration.class);
+    when(job.getConfiguration()).thenReturn(jobConfiguration);
+    when(jobConfiguration.getType()).thenReturn(JobConfiguration.Type.QUERY);
+    JobStatistics.QueryStatistics queryStatistics = mock(JobStatistics.QueryStatistics.class);
+    when(job.getStatistics()).thenReturn(queryStatistics);
+    when(queryStatistics.getNumDmlAffectedRows()).thenReturn(count);
+    return job;
+  }
+
 }


### PR DESCRIPTION
Fix for CDAP-16815
- Emit metric from BQ sink for insert , update and upsert
- Ensure that count is correctly captured since BQ could emit large record counts