### PR TITLE
CDAP-16880 and CDAP-16879 - Fix BQ sink validations

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
@@ -330,6 +330,13 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, A
       return;
     }
 
+    if (getConfig().isTruncateTableSet()) {
+      //no validation required for schema if truncate table is set.
+      // BQ will overwrite the schema for normal tables when write disposition is WRITE_TRUNCATE
+      //note - If write to single partition is supported in future, schema validation will be necessary
+      return;
+    }
+
     FieldList bqFields = bqSchema.getFields();
     List<Schema.Field> outputSchemaFields = Objects.requireNonNull(tableSchema.getFields());
 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
@@ -42,6 +42,7 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
   public static final String NAME_TRUNCATE_TABLE = "truncateTable";
   public static final String NAME_LOCATION = "location";
   private static final String NAME_GCS_CHUNK_SIZE = "gcsChunkSize";
+  private static final String NAME_UPDATE_SCHEMA = "allowSchemaRelaxation";
 
   @Name(NAME_DATASET)
   @Macro
@@ -65,6 +66,7 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
     "number of bytes. By default, 8388608 bytes (8MB) will be used as upload request chunk size.")
   protected String gcsChunkSize;
 
+  @Name(NAME_UPDATE_SCHEMA)
   @Macro
   @Nullable
   @Description("Whether to modify the BigQuery table schema if it differs from the input schema.")
@@ -74,7 +76,7 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
   @Macro
   @Nullable
   @Description("Whether or not to truncate the table before writing to it. "
-    + "Should only be used with the Insert operation.")
+    + "Should only be used with the Insert operation. This could overwrite the table schema")
   protected Boolean truncateTable;
 
   @Name(NAME_LOCATION)
@@ -123,8 +125,12 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
   }
 
   public JobInfo.WriteDisposition getWriteDisposition() {
-    return truncateTable != null && truncateTable ? JobInfo.WriteDisposition.WRITE_TRUNCATE
+    return isTruncateTableSet() ? JobInfo.WriteDisposition.WRITE_TRUNCATE
       : JobInfo.WriteDisposition.WRITE_APPEND;
+  }
+
+  public boolean isTruncateTableSet() {
+    return truncateTable != null && truncateTable;
   }
 
   @Override
@@ -138,5 +144,6 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
     if (!containsMacro(NAME_DATASET)) {
       BigQueryUtil.validateDataset(dataset, NAME_DATASET, collector);
     }
+
   }
 }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
@@ -255,7 +255,11 @@ public class BigQueryOutputFormat extends ForwardingBigQueryFileOutputFormat<Avr
       } else {
         loadConfig.setDestinationTable(tableRef);
 
-        if (allowSchemaRelaxation) {
+        //Schema update options should only be specified with WRITE_APPEND disposition,
+        // or with WRITE_TRUNCATE disposition on a table partition - The logic below should change when we support
+        // insertion into single partition
+        if (allowSchemaRelaxation && !JobInfo.WriteDisposition.WRITE_TRUNCATE
+          .equals(JobInfo.WriteDisposition.valueOf(writeDisposition))) {
           loadConfig.setSchemaUpdateOptions(Arrays.asList(
             JobInfo.SchemaUpdateOption.ALLOW_FIELD_ADDITION.name(),
             JobInfo.SchemaUpdateOption.ALLOW_FIELD_RELAXATION.name()));

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkTest.java
@@ -14,24 +14,27 @@
  *  the License.
  */
 
-package io.cdap.plugin.gcp.bigquery;
+package io.cdap.plugin.gcp.bigquery.sink;
 
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.Dataset;
+import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.Job;
 import com.google.cloud.bigquery.JobConfiguration;
 import com.google.cloud.bigquery.JobId;
 import com.google.cloud.bigquery.JobStatistics;
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.TableDefinition;
+import com.google.cloud.bigquery.TableId;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
+import io.cdap.cdap.etl.api.validation.ValidationException;
 import io.cdap.cdap.etl.api.validation.ValidationFailure;
 import io.cdap.cdap.etl.common.AbstractStageContext;
 import io.cdap.cdap.etl.mock.common.MockStageMetrics;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
 import io.cdap.cdap.etl.spark.batch.SparkBatchSinkContext;
-import io.cdap.plugin.gcp.bigquery.sink.AbstractBigQuerySink;
-import io.cdap.plugin.gcp.bigquery.sink.BigQuerySink;
-import io.cdap.plugin.gcp.bigquery.sink.BigQuerySinkConfig;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -166,6 +169,46 @@ public class BigQuerySinkTest {
     when(job.getStatistics()).thenReturn(queryStatistics);
     when(queryStatistics.getNumDmlAffectedRows()).thenReturn(count);
     return job;
+  }
+
+  @Test(expected = ValidationException.class)
+  public void testSchemaValidationException() throws NoSuchFieldException {
+    BigQuerySink sink = getValidationTestSink(false);
+    MockFailureCollector collector = new MockFailureCollector("bqsink");
+    Table table = getTestSchema();
+    sink.validateSchema(table, sink.getConfig().getSchema(collector), false, collector);
+  }
+
+  @Test
+  public void testSchemaValidationNoException() throws NoSuchFieldException {
+    BigQuerySink sink = getValidationTestSink(true);
+    MockFailureCollector collector = new MockFailureCollector("bqsink");
+    Table table = getTestSchema();
+    sink.validateSchema(table, sink.getConfig().getSchema(collector), false, collector);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+  private Table getTestSchema() {
+    Table table = mock(Table.class);
+    TableId tableId = TableId.of("test", "testds", "testtab");
+    when(table.getTableId()).thenReturn(tableId);
+    TableDefinition mock = mock(TableDefinition.class);
+    when(table.getDefinition()).thenReturn(mock);
+    Field field = Field.of("Field1", LegacySQLTypeName.STRING);
+    when(mock.getSchema()).thenReturn(com.google.cloud.bigquery.Schema.of(field));
+    return table;
+  }
+
+  private BigQuerySink getValidationTestSink(boolean truncateTable) throws NoSuchFieldException {
+    Schema schema = Schema.recordOf("record",
+                                    Schema.Field.of("id", Schema.of(Schema.Type.LONG)),
+                                    Schema.Field.of("name", Schema.of(Schema.Type.STRING)));
+    BigQuerySinkConfig config =
+      new BigQuerySinkConfig("testmetric", "ds", "tb", "bkt", schema.toString());
+    FieldSetter.setField(config, AbstractBigQuerySinkConfig.class.getDeclaredField("truncateTable"),
+                         truncateTable);
+    BigQuery bigQueryMock = mock(BigQuery.class);
+    return new BigQuerySink(config);
   }
 
 }


### PR DESCRIPTION
- Fixes for CDAP-16880 and CDAP-16879
- If truncate table is set, do not validate for schema. This will work currently for partitioned tables since we are not allowing insertion into specific partitions
- Truncate table and update schema should not be set together 
