### PR TITLE
CDAP-17003  Remove unnecessary schema validations in initialize 

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQueryAvroToStructuredTransformer.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQueryAvroToStructuredTransformer.java
@@ -36,6 +36,16 @@ import javax.annotation.Nullable;
  * Create StructuredRecords from GenericRecords. Contains custom logic for BigQuery date and time types.
  */
 public class BigQueryAvroToStructuredTransformer extends RecordConverter<GenericRecord, StructuredRecord> {
+
+  private Schema genericRecordSchema;
+
+  public StructuredRecord transform(GenericRecord genericRecord) throws IOException {
+    if (genericRecordSchema == null) {
+      genericRecordSchema = Schema.parseJson(genericRecord.getSchema().toString());
+    }
+    return transform(genericRecord, genericRecordSchema);
+  }
+
   @Override
   public StructuredRecord transform(GenericRecord genericRecord, Schema structuredSchema) throws IOException {
     StructuredRecord.Builder builder = StructuredRecord.builder(structuredSchema);
@@ -109,4 +119,5 @@ public class BigQueryAvroToStructuredTransformer extends RecordConverter<Generic
   protected Object convertBytes(Object field) {
     return field instanceof ByteBuffer ? Bytes.toBytes((ByteBuffer) field) : field;
   }
+
 }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySource.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySource.java
@@ -184,8 +184,7 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
   @Override
   public void initialize(BatchRuntimeContext context) throws Exception {
     super.initialize(context);
-    FailureCollector collector = context.getFailureCollector();
-    outputSchema = getOutputSchema(collector);
+    this.outputSchema = config.getSchema(context.getFailureCollector());
   }
 
   /**
@@ -198,7 +197,9 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
   @Override
   public void transform(KeyValue<LongWritable, GenericData.Record> input, Emitter<StructuredRecord> emitter)
     throws Exception {
-    emitter.emit(transformer.transform(input.getValue(), outputSchema));
+    StructuredRecord transformed = outputSchema == null ?
+      transformer.transform(input.getValue()) : transformer.transform(input.getValue(), outputSchema);
+    emitter.emit(transformed);
   }
 
   @Override


### PR DESCRIPTION
- Removed schema validations from BQ source plugin intialize method since the schema is already validated in prepareRun
- Removed call to find schema when macro is present and configuration does not have a schema. The transform will now use the schema from the GenericRecord .
- This avoids all calls to BigQuery.getTable() in initialize method. 