### PR TITLE
[CDAP-17061] Handle BigQuery Client Exception

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/action/BigQueryExecute.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/action/BigQueryExecute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Cask Data, Inc.
+ * Copyright © 2019-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -112,7 +112,7 @@ public final class BigQueryExecute extends Action {
     try {
       queryJob.waitFor();
     } catch (BigQueryException e) {
-      // TODO: Remove once issue in client library is fixed
+      // TODO: Remove once issue in service API is fixed
       // Minor bug with BigQuery java client causing it to prematurely throw an exception
       // Pipeline should always fail if an exception is encountered, but BigQueryErrors take priority
       // See CDAP-17061

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/action/BigQueryExecute.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/action/BigQueryExecute.java
@@ -112,11 +112,12 @@ public final class BigQueryExecute extends Action {
     try {
       queryJob.waitFor();
     } catch (BigQueryException e) {
+      // TODO: Remove once issue in client library is fixed
       // Minor bug with BigQuery java client causing it to prematurely throw an exception
       // Pipeline should always fail if an exception is encountered, but BigQueryErrors take priority
       // See CDAP-17061
-      if (queryJob == null || queryJob.getStatus() == null || queryJob.getStatus().getError() == null) {
-        throw new RuntimeException(e);
+      if (queryJob.getStatus() == null || queryJob.getStatus().getError() == null) {
+        throw e;
       }
     }
 


### PR DESCRIPTION
BigQuery java client library has a bug in which it prematurely throws an exception claiming that it is unable to find the provided jobId during the Job.waitFor() function even though it exists:
```
Exception in thread "main" com.google.cloud.bigquery.BigQueryException: Not found: Job lidennis-dev:EU.b383d452-1f18-432f-ae20-5e3ca92766da
	at com.google.cloud.bigquery.spi.v2.HttpBigQueryRpc.translate(HttpBigQueryRpc.java:106)
	at com.google.cloud.bigquery.spi.v2.HttpBigQueryRpc.getQueryResults(HttpBigQueryRpc.java:586)
	at com.google.cloud.bigquery.BigQueryImpl$34.call(BigQueryImpl.java:1208)
	at com.google.cloud.bigquery.BigQueryImpl$34.call(BigQueryImpl.java:1203)
	at com.google.api.gax.retrying.DirectRetryingExecutor.submit(DirectRetryingExecutor.java:105)
	at com.google.cloud.RetryHelper.run(RetryHelper.java:76)
	at com.google.cloud.RetryHelper.runWithRetries(RetryHelper.java:50)
	at com.google.cloud.bigquery.BigQueryImpl.getQueryResults(BigQueryImpl.java:1202)
	at com.google.cloud.bigquery.BigQueryImpl.getQueryResults(BigQueryImpl.java:1186)
	at com.google.cloud.bigquery.Job$1.call(Job.java:329)
	at com.google.cloud.bigquery.Job$1.call(Job.java:326)
	at com.google.api.gax.retrying.DirectRetryingExecutor.submit(DirectRetryingExecutor.java:105)
	at com.google.cloud.RetryHelper.run(RetryHelper.java:76)
	at com.google.cloud.RetryHelper.poll(RetryHelper.java:64)
	at com.google.cloud.bigquery.Job.waitForQueryResults(Job.java:325)
	at com.google.cloud.bigquery.Job.waitFor(Job.java:240)
	at com.app.Main.main(Main.java:28)
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 404 Not Found
GET https://www.googleapis.com/bigquery/v2/projects/lidennis-dev/queries/b383d452-1f18-432f-ae20-5e3ca92766da?location=EU&maxResults=0
{
  "code" : 404,
  "errors" : [ {
    "domain" : "global",
    "message" : "Not found: Job lidennis-dev:EU.b383d452-1f18-432f-ae20-5e3ca92766da",
    "reason" : "notFound"
  } ],
  "message" : "Not found: Job lidennis-dev:EU.b383d452-1f18-432f-ae20-5e3ca92766da",
  "status" : "NOT_FOUND"
}
```

The fix represents a workaround to prioritize BigQueryErrors since they are more user-friendly, though it ensures that an exception is still thrown if no errors are present.

This particular bug only occurs when attempting to access an US-based dataset from an EU-based BigQuery job. It does not occur when accessing an EU-based dataset from a US-based BigQuery job. The expected error should be instead:
```
Exception in thread "main" com.google.cloud.bigquery.BigQueryException: Not found: Dataset lidennis-dev:exists_in_eu was not found in location US
	at com.google.cloud.bigquery.spi.v2.HttpBigQueryRpc.translate(HttpBigQueryRpc.java:106)
	at com.google.cloud.bigquery.spi.v2.HttpBigQueryRpc.getQueryResults(HttpBigQueryRpc.java:586)
	at com.google.cloud.bigquery.BigQueryImpl$34.call(BigQueryImpl.java:1208)
	at com.google.cloud.bigquery.BigQueryImpl$34.call(BigQueryImpl.java:1203)
	at com.google.api.gax.retrying.DirectRetryingExecutor.submit(DirectRetryingExecutor.java:105)
	at com.google.cloud.RetryHelper.run(RetryHelper.java:76)
	at com.google.cloud.RetryHelper.runWithRetries(RetryHelper.java:50)
	at com.google.cloud.bigquery.BigQueryImpl.getQueryResults(BigQueryImpl.java:1202)
	at com.google.cloud.bigquery.BigQueryImpl.getQueryResults(BigQueryImpl.java:1186)
	at com.google.cloud.bigquery.Job$1.call(Job.java:329)
	at com.google.cloud.bigquery.Job$1.call(Job.java:326)
	at com.google.api.gax.retrying.DirectRetryingExecutor.submit(DirectRetryingExecutor.java:105)
	at com.google.cloud.RetryHelper.run(RetryHelper.java:76)
	at com.google.cloud.RetryHelper.poll(RetryHelper.java:64)
	at com.google.cloud.bigquery.Job.waitForQueryResults(Job.java:325)
	at com.google.cloud.bigquery.Job.waitFor(Job.java:240)
	at com.app.Main.main(Main.java:29)
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 404 Not Found
GET https://www.googleapis.com/bigquery/v2/projects/lidennis-dev/queries/dd80387e-daa6-488a-ac60-885da5144525?location=US&maxResults=0
{
  "code" : 404,
  "errors" : [ {
    "domain" : "global",
    "message" : "Not found: Dataset lidennis-dev:exists_in_eu was not found in location US",
    "reason" : "notFound"
  } ],
  "message" : "Not found: Dataset lidennis-dev:exists_in_eu was not found in location US",
  "status" : "NOT_FOUND"
}
```