### PR TITLE
Emit records.updated metric from GCS sink.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <bigquery.connector.hadoop2.version>hadoop2-1.0.0</bigquery.connector.hadoop2.version>
     <commons.codec.version>1.4</commons.codec.version>
     <cdap.version>6.3.0-SNAPSHOT</cdap.version>
-    <cdap.plugin.version>2.4.0-SNAPSHOT</cdap.plugin.version>
+    <cdap.plugin.version>2.5.0-SNAPSHOT</cdap.plugin.version>
     <dropwizard.metrics-core.version>3.2.6</dropwizard.metrics-core.version>
     <flogger.system.backend.version>0.3.1</flogger.system.backend.version>
     <gcs.connector.version>hadoop2-2.0.0</gcs.connector.version>

--- a/src/main/java/io/cdap/plugin/gcp/common/GCPUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCPUtils.java
@@ -39,6 +39,8 @@ import javax.annotation.Nullable;
  */
 public class GCPUtils {
   public static final String CMEK_KEY = "gcp.cmek.key.name";
+  public static final String FS_GS_PROJECT_ID = "fs.gs.project.id";
+  public static final String CLOUD_JSON_KEYFILE = "google.cloud.auth.service.account.json.keyfile";
 
   public static ServiceAccountCredentials loadServiceAccountCredentials(String path) throws IOException {
     File credentialsPath = new File(path);
@@ -51,12 +53,12 @@ public class GCPUtils {
                                                             Map<String, String> properties) {
     String serviceAccountFilePath = config.getServiceAccountFilePath();
     if (serviceAccountFilePath != null) {
-      properties.put("google.cloud.auth.service.account.json.keyfile", serviceAccountFilePath);
+      properties.put(CLOUD_JSON_KEYFILE, serviceAccountFilePath);
     }
     properties.put("fs.gs.impl", GoogleHadoopFileSystem.class.getName());
     properties.put("fs.AbstractFileSystem.gs.impl", GoogleHadoopFS.class.getName());
     String projectId = config.getProject();
-    properties.put("fs.gs.project.id", projectId);
+    properties.put(FS_GS_PROJECT_ID, projectId);
     properties.put("fs.gs.system.bucket", GCSPath.from(path).getBucket());
     properties.put("fs.gs.path.encoding", "uri-path");
     properties.put("fs.gs.working.dir", GCSPath.ROOT_DIR);

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
@@ -28,8 +28,10 @@ import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
+import io.cdap.cdap.etl.api.StageMetrics;
 import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
+import io.cdap.cdap.etl.api.validation.ValidatingOutputFormat;
 import io.cdap.plugin.common.LineageRecorder;
 import io.cdap.plugin.format.FileFormat;
 import io.cdap.plugin.format.plugin.AbstractFileSink;
@@ -37,6 +39,9 @@ import io.cdap.plugin.format.plugin.FileSinkProperties;
 import io.cdap.plugin.gcp.common.GCPReferenceSinkConfig;
 import io.cdap.plugin.gcp.common.GCPUtils;
 import io.cdap.plugin.gcp.gcs.GCSPath;
+import io.cdap.plugin.gcp.gcs.StorageClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
@@ -52,7 +57,14 @@ import javax.annotation.Nullable;
 @Name("GCS")
 @Description("Writes records to one or more files in a directory on Google Cloud Storage.")
 public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConfig> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GCSBatchSink.class);
+  public static final String RECORD_COUNT = "recordcount";
+  private static final String RECORDS_UPDATED_METRIC = "records.updated";
+
   private final GCSBatchSinkConfig config;
+  private String outputPath;
+
 
   public GCSBatchSink(GCSBatchSinkConfig config) {
     super(config);
@@ -62,6 +74,18 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     super.configurePipeline(pipelineConfigurer);
+  }
+
+  @Override
+  public ValidatingOutputFormat getValidatingOutputFormat(PipelineConfigurer pipelineConfigurer) {
+    ValidatingOutputFormat delegate = super.getValidatingOutputFormat(pipelineConfigurer);
+    return new GCSOutputFormatProvider(delegate);
+  }
+
+  @Override
+  public ValidatingOutputFormat getOutputFormatForRun(BatchSinkContext context) throws InstantiationException {
+    ValidatingOutputFormat outputFormatForRun = super.getOutputFormatForRun(context);
+    return new GCSOutputFormatProvider(outputFormatForRun);
   }
 
   @Override
@@ -90,8 +114,66 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
   }
 
   @Override
+  protected String getOutputDir(long logicalStartTime) {
+    this.outputPath = super.getOutputDir(logicalStartTime);
+    return this.outputPath;
+  }
+
+  @Override
   protected void recordLineage(LineageRecorder lineageRecorder, List<String> outputFields) {
     lineageRecorder.recordWrite("Write", "Wrote to Google Cloud Storage.", outputFields);
+  }
+
+  @Override
+  public void onRunFinish(boolean succeeded, BatchSinkContext context) {
+    super.onRunFinish(succeeded, context);
+    emitMetrics(succeeded, context);
+  }
+
+  private void emitMetrics(boolean succeeded, BatchSinkContext context) {
+    if (!succeeded) {
+      return;
+    }
+
+    try {
+      StorageClient storageClient = StorageClient.create(config.getProject(), config.getServiceAccountFilePath());
+      storageClient.mapMetaDataForAllBlobs(outputPath, new MetricsEmitter(context.getMetrics())::emitMetrics);
+    } catch (Exception e) {
+      LOG.warn("Metrics for the number of affected rows in GCS Sink maybe incorrect.", e);
+    }
+  }
+
+  private static class MetricsEmitter {
+    private StageMetrics stageMetrics;
+
+    private MetricsEmitter(StageMetrics stageMetrics) {
+      this.stageMetrics = stageMetrics;
+    }
+
+    public void emitMetrics(Map<String, String> metaData) {
+      long totalRows = extractRecordCount(metaData);
+      if (totalRows == 0) {
+        return;
+      }
+
+      //work around since StageMetrics count() only takes int as of now
+      int cap = 10000; // so the loop will not cause significant delays
+      long count = totalRows / Integer.MAX_VALUE;
+      if (count > cap) {
+        LOG.warn("Total record count is too high! Metric for the number of affected rows may not be updated correctly");
+      }
+      count = count < cap ? count : cap;
+      for (int i = 0; i <= count && totalRows > 0; i++) {
+        int rowCount = totalRows < Integer.MAX_VALUE ? (int) totalRows : Integer.MAX_VALUE;
+        stageMetrics.count(RECORDS_UPDATED_METRIC, rowCount);
+        totalRows -= rowCount;
+      }
+    }
+
+    private long extractRecordCount(Map<String, String> metadata) {
+      String value = metadata.get(RECORD_COUNT);
+      return value == null ? 0L : Long.parseLong(value);
+    }
   }
 
   /**

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSOutputFormatProvider.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSOutputFormatProvider.java
@@ -1,0 +1,250 @@
+package io.cdap.plugin.gcp.gcs.sink;
+
+import com.google.cloud.storage.Blob;
+import com.google.common.annotations.VisibleForTesting;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.etl.api.validation.FormatContext;
+import io.cdap.cdap.etl.api.validation.ValidatingOutputFormat;
+import io.cdap.plugin.gcp.common.GCPUtils;
+import io.cdap.plugin.gcp.gcs.StorageClient;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.JobStatus;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.OutputFormat;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
+import org.apache.hadoop.util.ReflectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * OutputFormatProvider for GCSSink
+ */
+public class GCSOutputFormatProvider implements ValidatingOutputFormat {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GCSOutputFormatProvider.class);
+  private static final String DELEGATE_OUTPUTFORMAT_CLASSNAME = "gcssink.delegate.outputformat.classname";
+  private static final String OUTPUT_FOLDER = "gcssink.metric.output.folder";
+  public static final String RECORD_COUNT_FORMAT = "recordcount.%s";
+  private final ValidatingOutputFormat delegate;
+
+  public GCSOutputFormatProvider(ValidatingOutputFormat delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void validate(FormatContext context) {
+    delegate.validate(context);
+  }
+
+  @Override
+  public String getOutputFormatClassName() {
+    return GCSOutputFormat.class.getName();
+  }
+
+  @Override
+  public Map<String, String> getOutputFormatConfiguration() {
+    Map<String, String> outputFormatConfiguration = new HashMap<>(delegate.getOutputFormatConfiguration());
+    outputFormatConfiguration.put(DELEGATE_OUTPUTFORMAT_CLASSNAME, delegate.getOutputFormatClassName());
+    return outputFormatConfiguration;
+  }
+
+  /**
+   * OutputFormat for GCS Sink
+   */
+  public static class GCSOutputFormat extends OutputFormat<NullWritable, StructuredRecord> {
+    private OutputFormat delegateFormat;
+
+    private OutputFormat getDelegateFormatInstance(Configuration configuration) throws IOException {
+      if (delegateFormat != null) {
+        return delegateFormat;
+      }
+
+      String delegateClassName = configuration.get(DELEGATE_OUTPUTFORMAT_CLASSNAME);
+      try {
+        delegateFormat = (OutputFormat) ReflectionUtils
+          .newInstance(configuration.getClassByName(delegateClassName), configuration);
+        return delegateFormat;
+      } catch (ClassNotFoundException e) {
+        throw new IOException(
+          String.format("Unable to instantiate output format for class %s", delegateClassName),
+          e);
+      }
+    }
+
+    @Override
+    public RecordWriter<NullWritable, StructuredRecord> getRecordWriter(TaskAttemptContext taskAttemptContext) throws
+      IOException, InterruptedException {
+      RecordWriter originalWriter = getDelegateFormatInstance(taskAttemptContext.getConfiguration())
+        .getRecordWriter(taskAttemptContext);
+      return new GCSRecordWriter(originalWriter);
+    }
+
+    @Override
+    public void checkOutputSpecs(JobContext jobContext) throws IOException, InterruptedException {
+      getDelegateFormatInstance(jobContext.getConfiguration()).checkOutputSpecs(jobContext);
+    }
+
+    @Override
+    public OutputCommitter getOutputCommitter(TaskAttemptContext taskAttemptContext) throws IOException,
+      InterruptedException {
+      OutputCommitter delegateCommitter = getDelegateFormatInstance(taskAttemptContext.getConfiguration())
+        .getOutputCommitter(taskAttemptContext);
+      return new GCSOutputCommitter(delegateCommitter);
+    }
+  }
+
+  /**
+   * OutputCommitter for GCS
+   */
+  public static class GCSOutputCommitter extends OutputCommitter {
+
+    private final OutputCommitter delegate;
+
+    public GCSOutputCommitter(OutputCommitter delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void setupJob(JobContext jobContext) throws IOException {
+      delegate.setupJob(jobContext);
+    }
+
+    @Override
+    public void cleanupJob(JobContext jobContext) throws IOException {
+      delegate.cleanupJob(jobContext);
+    }
+
+    @Override
+    public void commitJob(JobContext jobContext) throws IOException {
+      delegate.commitJob(jobContext);
+    }
+
+    @Override
+    public void abortJob(JobContext jobContext, JobStatus.State state) throws IOException {
+      delegate.abortJob(jobContext, state);
+    }
+
+    @Override
+    public void setupTask(TaskAttemptContext taskAttemptContext) throws IOException {
+      delegate.setupTask(taskAttemptContext);
+    }
+
+    @Override
+    public boolean needsTaskCommit(TaskAttemptContext taskAttemptContext) throws IOException {
+      return delegate.needsTaskCommit(taskAttemptContext);
+    }
+
+    @Override
+    public void commitTask(TaskAttemptContext taskAttemptContext) throws IOException {
+      /*On commit task, there seems to be some inconsistency across different hadoop implementations regarding the path
+       where output file is stored. For some implementations it appears in the path returned by FileOutputCommitter
+       getCommittedTaskPath and for some it does not.Before commit, the files appear to be consistently present in path
+       returned by FileOutputCommitter getTaskAttemptPath. Hence, find the output file from taskAttemptPath and add
+       metadata before commit happens. After commit, file would have been moved out of the taskAttemptPath. */
+      try {
+        updateMetricMetaData(taskAttemptContext);
+      } catch (Exception exception) {
+        LOG.warn("Unable to record metric for task. Metric emitted for the number of affected rows may be incorrect.",
+                 exception);
+      }
+
+      delegate.commitTask(taskAttemptContext);
+    }
+
+    private void updateMetricMetaData(TaskAttemptContext taskAttemptContext) throws IOException {
+      if (!(delegate instanceof FileOutputCommitter)) {
+        return;
+      }
+
+      FileOutputCommitter fileOutputCommitter = (FileOutputCommitter) delegate;
+      Configuration configuration = taskAttemptContext.getConfiguration();
+      //Task is not yet committed, so should be available in attempt path
+      Path taskAttemptPath = fileOutputCommitter.getTaskAttemptPath(taskAttemptContext);
+      if (configuration == null || taskAttemptPath == null) {
+        return;
+      }
+
+      //read the count from configuration
+      String keyInConfig = String.format(RECORD_COUNT_FORMAT, taskAttemptContext.getTaskAttemptID());
+      Map<String, String> metaData = new HashMap<>();
+      metaData.put(GCSBatchSink.RECORD_COUNT, String.valueOf(configuration.getLong(keyInConfig, 0L)));
+      StorageClient storageClient = getStorageClient(configuration);
+      //update metadata on the output file present in the directory for this task
+      Blob blob = storageClient.pickABlob(taskAttemptPath.toString());
+      if (blob == null) {
+        LOG.info("Could not find a file in path %s to apply count metadata.", taskAttemptPath.toString());
+        return;
+      }
+      storageClient.setMetaData(blob, metaData);
+    }
+
+    @VisibleForTesting
+    StorageClient getStorageClient(Configuration configuration) throws IOException {
+      String project = configuration.get(GCPUtils.FS_GS_PROJECT_ID);
+      String serviceAccountPath = configuration.get(GCPUtils.CLOUD_JSON_KEYFILE);
+      return StorageClient.create(project, serviceAccountPath);
+    }
+
+    @Override
+    public void abortTask(TaskAttemptContext taskAttemptContext) throws IOException {
+      delegate.abortTask(taskAttemptContext);
+    }
+
+    @Override
+    public boolean isCommitJobRepeatable(JobContext jobContext) throws IOException {
+      return delegate.isCommitJobRepeatable(jobContext);
+    }
+
+    @Override
+    public boolean isRecoverySupported(JobContext jobContext) throws IOException {
+      return delegate.isRecoverySupported(jobContext);
+    }
+
+    @Override
+    public boolean isRecoverySupported() {
+      return delegate.isRecoverySupported();
+    }
+
+    @Override
+    public void recoverTask(TaskAttemptContext taskContext) throws IOException {
+      delegate.recoverTask(taskContext);
+    }
+  }
+
+  /**
+   * RecordWriter for GCSSink
+   */
+  public static class GCSRecordWriter extends RecordWriter<NullWritable, StructuredRecord> {
+
+    private final RecordWriter originalWriter;
+    private long recordCount;
+
+    public GCSRecordWriter(RecordWriter originalWriter) {
+      this.originalWriter = originalWriter;
+    }
+
+    @Override
+    public void write(NullWritable nullWritable, StructuredRecord structuredRecord) throws IOException,
+      InterruptedException {
+      originalWriter.write(nullWritable, structuredRecord);
+      recordCount++;
+    }
+
+    @Override
+    public void close(TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
+      originalWriter.close(taskAttemptContext);
+      //Since the file details are not available here, pass the value on in configuration
+      taskAttemptContext.getConfiguration()
+        .setLong(String.format(RECORD_COUNT_FORMAT, taskAttemptContext.getTaskAttemptID()), recordCount);
+    }
+  }
+}

--- a/src/test/java/io/cdap/plugin/gcp/gcs/sink/GCSOutputformatProviderTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/gcs/sink/GCSOutputformatProviderTest.java
@@ -1,0 +1,100 @@
+package io.cdap.plugin.gcp.gcs.sink;
+
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.plugin.gcp.gcs.StorageClient;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.JobStatus;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+/**
+ * Tests for GCSOutputformatProvider
+ */
+public class GCSOutputformatProviderTest {
+
+  @Test
+  public void testRecordWriter() throws IOException, InterruptedException {
+    RecordWriter mockWriter = Mockito.mock(RecordWriter.class);
+    GCSOutputFormatProvider.GCSRecordWriter recordWriterToTest = new GCSOutputFormatProvider.GCSRecordWriter(
+      mockWriter);
+    NullWritable mockWritable = Mockito.mock(NullWritable.class);
+    StructuredRecord mockRecord = Mockito.mock(StructuredRecord.class);
+    for (int i = 0; i < 5; i++) {
+      recordWriterToTest.write(mockWritable, mockRecord);
+    }
+    TaskAttemptContext mockContext = Mockito.mock(TaskAttemptContext.class);
+    Configuration configuration = new Configuration();
+    Mockito.when(mockContext.getConfiguration()).thenReturn(configuration);
+    recordWriterToTest.close(mockContext);
+    //Verify that the delegate calls are being done as expected
+    Mockito.verify(mockWriter, Mockito.times(5)).write(mockWritable, mockRecord);
+    //verify that count is being recorded as expected
+    Assert.assertTrue(configuration.getLong(
+      String.format(GCSOutputFormatProvider.RECORD_COUNT_FORMAT, mockContext.getTaskAttemptID()), 0) == 5);
+  }
+
+  @Test
+  public void testGCSOutputCommitter() throws IOException, URISyntaxException {
+    FileOutputCommitter fileOutputCommitter = Mockito.mock(FileOutputCommitter.class);
+    GCSOutputFormatProvider.GCSOutputCommitter committer = new GCSOutputFormatProvider.GCSOutputCommitter(
+      fileOutputCommitter);
+    GCSOutputFormatProvider.GCSOutputCommitter committerToTest = Mockito.spy(committer);
+    JobContext mockJobContext = Mockito.mock(JobContext.class);
+    JobStatus.State mockJobState = JobStatus.State.SUCCEEDED;
+    TaskAttemptContext mockContext = Mockito.mock(TaskAttemptContext.class);
+    //test all the delegation
+    committerToTest.abortJob(mockJobContext, mockJobState);
+    Mockito.verify(fileOutputCommitter, Mockito.times(1)).abortJob(mockJobContext, mockJobState);
+
+    committerToTest.abortTask(mockContext);
+    Mockito.verify(fileOutputCommitter, Mockito.times(1)).abortTask(mockContext);
+
+    committerToTest.cleanupJob(mockJobContext);
+    Mockito.verify(fileOutputCommitter, Mockito.times(1)).cleanupJob(mockJobContext);
+
+    committerToTest.commitJob(mockJobContext);
+    Mockito.verify(fileOutputCommitter, Mockito.times(1)).commitJob(mockJobContext);
+
+    committerToTest.isCommitJobRepeatable(mockJobContext);
+    Mockito.verify(fileOutputCommitter, Mockito.times(1)).isCommitJobRepeatable(mockJobContext);
+
+    committerToTest.isRecoverySupported();
+    Mockito.verify(fileOutputCommitter, Mockito.times(1)).isRecoverySupported();
+
+    committerToTest.isRecoverySupported(mockJobContext);
+    Mockito.verify(fileOutputCommitter, Mockito.times(1)).isRecoverySupported(mockJobContext);
+
+    committerToTest.needsTaskCommit(mockContext);
+    Mockito.verify(fileOutputCommitter, Mockito.times(1)).needsTaskCommit(mockContext);
+
+    committerToTest.recoverTask(mockContext);
+    Mockito.verify(fileOutputCommitter, Mockito.times(1)).recoverTask(mockContext);
+
+    committerToTest.setupJob(mockJobContext);
+    Mockito.verify(fileOutputCommitter, Mockito.times(1)).setupJob(mockJobContext);
+
+    committerToTest.setupTask(mockContext);
+    Mockito.verify(fileOutputCommitter, Mockito.times(1)).setupTask(mockContext);
+
+    Configuration configuration = new Configuration();
+    Mockito.when(mockContext.getConfiguration()).thenReturn(configuration);
+    Path committedTaskPathMock = Mockito.mock(Path.class);
+    Mockito.when(fileOutputCommitter.getCommittedTaskPath(mockContext)).thenReturn(committedTaskPathMock);
+    Mockito.when(committedTaskPathMock.toString()).thenReturn("gs://test");
+    StorageClient mockStorage = Mockito.mock(StorageClient.class);
+    Mockito.when(committerToTest.getStorageClient(configuration)).thenReturn(mockStorage);
+
+    committerToTest.commitTask(mockContext);
+    Mockito.verify(fileOutputCommitter, Mockito.times(1)).commitTask(mockContext);
+  }
+}


### PR DESCRIPTION
Fix for https://issues.cask.co/browse/CDAP-17123
- Emit records.updated metric for GCS sink
- Depends on hydrator-plugins fix in AbstractFileSink.java (PR - https://github.com/cdapio/hydrator-plugins/pull/1157)
- Depends on version 2.5.0-SNAPSHOT of cdap plugin due to dependency on AbstractFileSink change
- RecordWriter keeps a running counter of the fields written
- The count for each output file as calculated by the RecordWriter is updated as metadata on the file itself at the end of each task commit.
- The total is calculated at the end of run and updated in the metric.
-Using Storage API to list blobs 


