### PR TITLE
[PLUGIN-368] Disregard Some Validation Failures in Deployment

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -16,7 +16,6 @@
 package io.cdap.plugin.gcp.bigquery.sink;
 
 import com.google.cloud.bigquery.BigQuery;
-import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.Table;
 import io.cdap.cdap.api.annotation.Description;
@@ -34,7 +33,6 @@ import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.cdap.etl.api.validation.InvalidConfigPropertyException;
 import io.cdap.cdap.etl.api.validation.InvalidStageException;
-import io.cdap.plugin.gcp.bigquery.source.BigQuerySource;
 import io.cdap.plugin.gcp.bigquery.source.BigQuerySourceConfig;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryConstants;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
@@ -16,7 +16,6 @@
 
 package io.cdap.plugin.gcp.bigquery.sink;
 
-import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.JobInfo;
 import com.google.cloud.bigquery.StandardTableDefinition;
 import com.google.cloud.bigquery.Table;
@@ -267,8 +266,6 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
    * Attempts to validate partition properties. Requires BigQuery connectivity to function.
    * @param inputSchema The input schema for the stage
    * @param collector The FailureCollector for the current context
-   * @throws IOException If unable to load service account credentials
-   * @throws BigQueryException If an error occurred while accessing the BigQuery table
    */
   public void validatePartitionProperties(@Nullable Schema inputSchema, @Nullable Schema outputSchema,
                                           FailureCollector collector) {

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySource.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySource.java
@@ -18,7 +18,6 @@ package io.cdap.plugin.gcp.bigquery.source;
 
 import com.google.auth.Credentials;
 import com.google.cloud.bigquery.BigQuery;
-import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.FieldList;
@@ -70,7 +69,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
-import javax.validation.constraints.Null;
 
 /**
  * Class description here.

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Cask Data, Inc.
+ * Copyright © 2018-2020 Cask Data, Inc.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
  *  use this file except in compliance with the License. You may obtain a copy of
@@ -343,45 +343,6 @@ public final class BigQueryUtil {
       table = bigQuery.getTable(tableId);
     } catch (BigQueryException e) {
       throw new InvalidStageException("Unable to get details about the BigQuery table: " + e.getMessage(), e);
-    }
-
-    return table;
-  }
-
-  /**
-   * Get BigQuery table.
-   *
-   * @param projectId BigQuery project ID
-   * @param datasetId BigQuery dataset ID
-   * @param tableName BigQuery table name
-   * @param serviceAccountPath service account file path
-   * @param collector failure collector
-   * @return BigQuery table
-   */
-  @Nullable
-  public static Table getBigQueryTable(String projectId, String datasetId, String tableName,
-                                       @Nullable String serviceAccountPath, FailureCollector collector) {
-    TableId tableId = TableId.of(projectId, datasetId, tableName);
-    com.google.auth.Credentials credentials = null;
-    if (serviceAccountPath != null) {
-      try {
-        credentials = GCPUtils.loadServiceAccountCredentials(serviceAccountPath);
-      } catch (IOException e) {
-        collector.addFailure(String.format("Unable to load credentials from %s.", serviceAccountPath),
-                             "Ensure the service account file is available on the local filesystem.")
-          .withConfigProperty(GCPConfig.NAME_SERVICE_ACCOUNT_FILE_PATH);
-        throw collector.getOrThrowException();
-      }
-    }
-    BigQuery bigQuery = GCPUtils.getBigQuery(projectId, credentials);
-
-    Table table = null;
-    try {
-      table = bigQuery.getTable(tableId);
-    } catch (BigQueryException e) {
-      collector.addFailure("Unable to get details about the BigQuery table: " + e.getMessage(), null)
-        .withConfigProperty(BigQuerySourceConfig.NAME_TABLE);
-      throw collector.getOrThrowException();
     }
 
     return table;

--- a/src/main/java/io/cdap/plugin/gcp/bigtable/sink/BigtableSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigtable/sink/BigtableSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Cask Data, Inc.
+ * Copyright © 2019-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -34,6 +34,7 @@ import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.plugin.common.LineageRecorder;
 import io.cdap.plugin.gcp.bigtable.common.HBaseColumn;
+import io.cdap.plugin.gcp.bigtable.source.BigtableSource;
 import io.cdap.plugin.gcp.common.ConfigUtil;
 import io.cdap.plugin.gcp.common.SourceOutputFormatProvider;
 import org.apache.hadoop.conf.Configuration;
@@ -48,6 +49,8 @@ import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.mapreduce.TableOutputFormat;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
@@ -65,6 +68,7 @@ import java.util.stream.Collectors;
 @Description("This sink writes data to Google Cloud Bigtable. " +
   "Cloud Bigtable is Google's NoSQL Big Data database service.")
 public final class BigtableSink extends BatchSink<StructuredRecord, ImmutableBytesWritable, Mutation> {
+  private static final Logger LOG = LoggerFactory.getLogger(BigtableSink.class);
   public static final String NAME = "Bigtable";
 
   private static final Set<Schema.Type> SUPPORTED_FIELD_TYPES = ImmutableSet.of(
@@ -103,10 +107,8 @@ public final class BigtableSink extends BatchSink<StructuredRecord, ImmutableByt
           validateExistingTable(connection, tableName, collector);
         }
       } catch (IOException e) {
-        collector.addFailure(
-          String.format("Failed to connect to BigTable : %s", e.getMessage()), null)
-          .withConfigProperty(BigtableSinkConfig.BIGTABLE_OPTIONS)
-          .withStacktrace(e.getStackTrace());
+        // Don't fail deployments due to connect failures
+        LOG.warn("Failed to connect to BigTable with error:\n", e);
       }
     }
   }
@@ -210,7 +212,8 @@ public final class BigtableSink extends BatchSink<StructuredRecord, ImmutableByt
     }
   }
 
-  private void validateExistingTable(Connection connection, TableName tableName, FailureCollector collector) {
+  private void validateExistingTable(Connection connection, TableName tableName, FailureCollector collector)
+    throws IOException {
     try (Table table = connection.getTable(tableName)) {
       Set<String> existingFamilies = table.getTableDescriptor()
         .getFamiliesKeys()
@@ -228,9 +231,6 @@ public final class BigtableSink extends BatchSink<StructuredRecord, ImmutableByt
                                ConfigUtil.getKVPair(entry.getKey(), entry.getValue().getQualifiedName(), "="));
         }
       }
-    } catch (IOException e) {
-      collector.addFailure(String.format("Failed to connect to Bigtable : %s", e.getMessage()), null)
-        .withStacktrace(e.getStackTrace());
     }
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/bigtable/source/BigtableSource.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigtable/source/BigtableSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Cask Data, Inc.
+ * Copyright © 2019-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -85,10 +85,8 @@ public final class BigtableSource extends BatchSource<ImmutableBytesWritable, Re
         Configuration conf = getConfiguration(collector);
         validateOutputSchema(conf, collector);
       } catch (IOException e) {
-        collector.addFailure(
-          String.format("Failed to prepare configuration for job : %s", e.getMessage()), null)
-          .withConfigProperty(BigtableSourceConfig.BIGTABLE_OPTIONS)
-          .withStacktrace(e.getStackTrace());
+        // Don't fail deployment on connection failure
+        LOG.warn("Failed to validate output schema with error:\n", e);
       }
     }
 
@@ -103,14 +101,21 @@ public final class BigtableSource extends BatchSource<ImmutableBytesWritable, Re
     Configuration conf = null;
     try {
       conf = getConfiguration(collector);
-      validateOutputSchema(conf, collector);
+
     } catch (IOException e) {
       collector.addFailure(
         String.format("Failed to prepare configuration for job : %s", e.getMessage()), null)
         .withConfigProperty(BigtableSourceConfig.BIGTABLE_OPTIONS)
         .withStacktrace(e.getStackTrace());
+      collector.getOrThrowException();
     }
-    collector.getOrThrowException();
+    try {
+      validateOutputSchema(conf, collector);
+    } catch (IOException e) {
+      collector.addFailure(String.format("Failed to connect to Bigtable : %s", e.getMessage()), null)
+        .withStacktrace(e.getStackTrace());
+      collector.getOrThrowException();
+    }
 
     // Both emitLineage and setOutputFormat internally try to create an external dataset if it does not already exists.
     // We call emitLineage before since it creates the dataset with schema.
@@ -163,7 +168,7 @@ public final class BigtableSource extends BatchSource<ImmutableBytesWritable, Re
     return conf;
   }
 
-  private void validateOutputSchema(Configuration configuration, FailureCollector collector) {
+  private void validateOutputSchema(Configuration configuration, FailureCollector collector) throws IOException {
     TableName tableName = TableName.valueOf(config.table);
     try (Connection connection = BigtableConfiguration.connect(configuration);
          Table table = connection.getTable(tableName)) {
@@ -182,9 +187,6 @@ public final class BigtableSource extends BatchSource<ImmutableBytesWritable, Re
                                ConfigUtil.getKVPair(key, columnMappings.get(key), "="));
         }
       }
-    } catch (IOException e) {
-      collector.addFailure(String.format("Failed to connect to Bigtable : %s", e.getMessage()), null)
-        .withStacktrace(e.getStackTrace());
     }
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/datastore/sink/DatastoreSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/datastore/sink/DatastoreSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Cask Data, Inc.
+ * Copyright © 2019-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -75,6 +75,7 @@ public class DatastoreSink extends BatchSink<StructuredRecord, NullWritable, Ful
     LOG.debug("DatastoreSink `prepareRun` input schema: {}", inputSchema);
     FailureCollector collector = context.getFailureCollector();
     config.validate(inputSchema, collector);
+    config.validateDatastoreConnection(collector);
     collector.getOrThrowException();
 
     String project = config.getProject();

--- a/src/main/java/io/cdap/plugin/gcp/datastore/sink/DatastoreSinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/datastore/sink/DatastoreSinkConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Cask Data, Inc.
+ * Copyright © 2019-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -202,7 +202,6 @@ public class DatastoreSinkConfig extends GCPReferenceSinkConfig {
     validateKind(collector);
     validateAncestors(collector);
     validateBatchSize(collector);
-    validateDatastoreConnection(collector);
 
     if (schema != null) {
       validateSchema(schema, collector);
@@ -296,8 +295,11 @@ public class DatastoreSinkConfig extends GCPReferenceSinkConfig {
     }
   }
 
-  @VisibleForTesting
-  void validateDatastoreConnection(FailureCollector collector) {
+  /**
+   * Validates a datastore connection.
+   * @param collector The FailureCollector to use
+   */
+  public void validateDatastoreConnection(FailureCollector collector) {
     if (!shouldConnect()) {
       return;
     }

--- a/src/main/java/io/cdap/plugin/gcp/datastore/source/DatastoreSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/datastore/source/DatastoreSourceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Cask Data, Inc.
+ * Copyright © 2019-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -229,7 +229,6 @@ public class DatastoreSourceConfig extends GCPReferenceSourceConfig {
   @Override
   public void validate(FailureCollector collector) {
     super.validate(collector);
-    validateDatastoreConnection(collector);
     validateKind(collector);
     validateAncestor(collector);
     validateNumSplits(collector);
@@ -246,8 +245,11 @@ public class DatastoreSourceConfig extends GCPReferenceSourceConfig {
     }
   }
 
-  @VisibleForTesting
-  void validateDatastoreConnection(FailureCollector collector) {
+  /**
+   * Validates a datastore connection.
+   * @param collector The FailureCollector to use
+   */
+  public void validateDatastoreConnection(FailureCollector collector) {
     if (!shouldConnect()) {
       return;
     }


### PR DESCRIPTION
See [PLUGIN-368](https://issues.cask.co/browse/PLUGIN-368) for more information.

Changes SpannerSource, Datastore source and sink, Bigtable source and sink, and BigQuery source and sink so that connection failure, resource access failure, and resource permissions failures do not inhibit deployment of a pipeline.

On another note, this highlights the need for the Validation API to be enhanced to include separate failure types, such as failures which should occur in runtime but not in deployment time or warnings.

EDIT: Seems like we need to consolidate our validation approach before we can fix these issues. Closing this PR for now.