### PR TITLE
Fix CDAP plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <bigquery.connector.hadoop2.version>hadoop2-1.0.0</bigquery.connector.hadoop2.version>
     <commons.codec.version>1.4</commons.codec.version>
     <cdap.version>6.2.0</cdap.version>
-    <cdap.plugin.version>2.4.1</cdap.plugin.version>
+    <cdap.plugin.version>2.4.2-SNAPSHOT</cdap.plugin.version>
     <dropwizard.metrics-core.version>3.2.6</dropwizard.metrics-core.version>
     <flogger.system.backend.version>0.3.1</flogger.system.backend.version>
     <gcs.connector.version>hadoop2-2.0.0</gcs.connector.version>


### PR DESCRIPTION
Cdap plugin version is 2.4.2-SNAPSHOT for 6.2.2. 