### PR TITLE
bump version to 0.14.7 for cdap 6.1.4 release.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>google-cloud</artifactId>
-  <version>0.14.6</version>
+  <version>0.14.7</version>
   <name>Google Cloud Plugins</name>
   <packaging>jar</packaging>
   <description>Plugins for Google Big Query</description>


### PR DESCRIPTION
bump version to 0.14.7 for cdap 6.1.4 release.