### PR TITLE
Refactored code such that records.updated metric applies only to BQ Sink

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
@@ -22,10 +22,6 @@ import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.DatasetInfo;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.FieldList;
-import com.google.cloud.bigquery.Job;
-import com.google.cloud.bigquery.JobConfiguration;
-import com.google.cloud.bigquery.JobId;
-import com.google.cloud.bigquery.JobStatistics;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableId;
@@ -86,8 +82,7 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, A
   private final UUID uuid = UUID.randomUUID();
   protected Configuration baseConfiguration;
   private StructuredToAvroTransformer avroTransformer;
-  private final String jobId = UUID.randomUUID().toString();
-  private BigQuery bigQuery;
+  protected BigQuery bigQuery;
 
   /**
    * Executes main prepare run logic. Child classes cannot override this method,
@@ -109,7 +104,6 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, A
     String cmekKey = context.getArguments().get(GCPUtils.CMEK_KEY);
     baseConfiguration = getBaseConfiguration(cmekKey);
     String bucket = configureBucket();
-    baseConfiguration.set(BigQueryConstants.CONFIG_JOB_ID, jobId);
     if (!context.isPreviewEnabled()) {
       createResources(bigQuery, GCPUtils.getStorage(project, credentials), config.getDataset(), bucket,
                       config.getLocation(), cmekKey);
@@ -119,9 +113,7 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, A
   }
 
   @Override
-  public final void onRunFinish(boolean succeeded, BatchSinkContext context) {
-    recordMetric(succeeded, context);
-
+  public void onRunFinish(boolean succeeded, BatchSinkContext context) {
     if (getConfig().getBucket() == null) {
       Path gcsPath = new Path(String.format(gcsPathFormat, uuid.toString()));
       try {
@@ -134,47 +126,6 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, A
         LOG.warn("Failed to delete bucket '{}': {}", gcsPath, e.getMessage());
       }
     }
-  }
-
-  private void recordMetric(boolean succeeded, BatchSinkContext context) {
-    if (!succeeded) {
-      return;
-    }
-    Job queryJob = bigQuery.getJob(getJobId());
-    if (queryJob == null) {
-      LOG.warn("Unable to find BigQuery job. No metric will be emitted for the number of affected rows.");
-      return;
-    }
-    long totalRows = getTotalRows(queryJob);
-    LOG.info("Job {} affected {} rows", queryJob.getJobId(), totalRows);
-    //work around since StageMetrics count() only takes int as of now
-    int cap = 10000; // so the loop will not cause significant delays
-    long count = totalRows / Integer.MAX_VALUE;
-    if (count > cap) {
-      LOG.warn("Total record count is too high! Metric for the number of affected rows may not be updated correctly");
-    }
-    count = count < cap ? count : cap;
-    for (int i = 0; i <= count && totalRows > 0; i++) {
-      int rowCount = totalRows < Integer.MAX_VALUE ? (int) totalRows : Integer.MAX_VALUE;
-      context.getMetrics().count(RECORDS_UPDATED_METRIC, rowCount);
-      totalRows -= rowCount;
-    }
-  }
-
-  private JobId getJobId() {
-    String location = bigQuery.getDataset(getConfig().getDataset()).getLocation();
-    return JobId.newBuilder().setLocation(location).setJob(jobId).build();
-  }
-
-  private long getTotalRows(Job queryJob) {
-    JobConfiguration.Type type = queryJob.getConfiguration().getType();
-    if (type == JobConfiguration.Type.LOAD) {
-      return ((JobStatistics.LoadStatistics) queryJob.getStatistics()).getOutputRows();
-    } else if (type == JobConfiguration.Type.QUERY) {
-      return ((JobStatistics.QueryStatistics) queryJob.getStatistics()).getNumDmlAffectedRows();
-    }
-    LOG.warn("Unable to identify BigQuery job type. No metric will be emitted for the number of affected rows.");
-    return 0;
   }
 
   @Override

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -17,6 +17,10 @@ package io.cdap.plugin.gcp.bigquery.sink;
 
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Job;
+import com.google.cloud.bigquery.JobConfiguration;
+import com.google.cloud.bigquery.JobId;
+import com.google.cloud.bigquery.JobStatistics;
 import com.google.cloud.bigquery.Table;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
@@ -37,11 +41,14 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.mapred.AvroKey;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
@@ -60,6 +67,10 @@ public final class BigQuerySink extends AbstractBigQuerySink {
   public static final String NAME = "BigQueryTable";
 
   private final BigQuerySinkConfig config;
+
+  private final String jobId = UUID.randomUUID().toString();
+
+  private static final Logger LOG = LoggerFactory.getLogger(BigQuerySink.class);
 
   public BigQuerySink(BigQuerySinkConfig config) {
     this.config = config;
@@ -105,6 +116,59 @@ public final class BigQuerySink extends AbstractBigQuerySink {
   }
 
   @Override
+  public void onRunFinish(boolean succeeded, BatchSinkContext context) {
+    super.onRunFinish(succeeded, context);
+
+    try {
+      recordMetric(succeeded, context);
+    } catch (Exception exception) {
+      LOG.warn("Exception while trying to emit metric. No metric will be emitted for the number of affected rows.",
+               exception);
+    }
+  }
+
+  private void recordMetric(boolean succeeded, BatchSinkContext context) {
+    if (!succeeded) {
+      return;
+    }
+    Job queryJob = bigQuery.getJob(getJobId());
+    if (queryJob == null) {
+      LOG.warn("Unable to find BigQuery job. No metric will be emitted for the number of affected rows.");
+      return;
+    }
+    long totalRows = getTotalRows(queryJob);
+    LOG.info("Job {} affected {} rows", queryJob.getJobId(), totalRows);
+    //work around since StageMetrics count() only takes int as of now
+    int cap = 10000; // so the loop will not cause significant delays
+    long count = totalRows / Integer.MAX_VALUE;
+    if (count > cap) {
+      LOG.warn("Total record count is too high! Metric for the number of affected rows may not be updated correctly");
+    }
+    count = count < cap ? count : cap;
+    for (int i = 0; i <= count && totalRows > 0; i++) {
+      int rowCount = totalRows < Integer.MAX_VALUE ? (int) totalRows : Integer.MAX_VALUE;
+      context.getMetrics().count(RECORDS_UPDATED_METRIC, rowCount);
+      totalRows -= rowCount;
+    }
+  }
+
+  private JobId getJobId() {
+    String location = bigQuery.getDataset(getConfig().getDataset()).getLocation();
+    return JobId.newBuilder().setLocation(location).setJob(jobId).build();
+  }
+
+  private long getTotalRows(Job queryJob) {
+    JobConfiguration.Type type = queryJob.getConfiguration().getType();
+    if (type == JobConfiguration.Type.LOAD) {
+      return ((JobStatistics.LoadStatistics) queryJob.getStatistics()).getOutputRows();
+    } else if (type == JobConfiguration.Type.QUERY) {
+      return ((JobStatistics.QueryStatistics) queryJob.getStatistics()).getNumDmlAffectedRows();
+    }
+    LOG.warn("Unable to identify BigQuery job type. No metric will be emitted for the number of affected rows.");
+    return 0;
+  }
+
+  @Override
   protected OutputFormatProvider getOutputFormatProvider(Configuration configuration,
                                                          String tableName,
                                                          Schema tableSchema) {
@@ -131,6 +195,7 @@ public final class BigQuerySink extends AbstractBigQuerySink {
    * Sets addition configuration for the AbstractBigQuerySink's Hadoop configuration
    */
   private void configureBigQuerySink() {
+    baseConfiguration.set(BigQueryConstants.CONFIG_JOB_ID, jobId);
     baseConfiguration.setBoolean(BigQueryConstants.CONFIG_CREATE_PARTITIONED_TABLE,
                                  getConfig().shouldCreatePartitionedTable());
     if (config.getPartitionByField() != null) {


### PR DESCRIPTION
Fix for https://issues.cask.co/browse/PLUGIN-379 
- Moved code for "records.updated" metric to BigQuerySink from AbstractBigQuerySink
- BigQueryOutputFormat is shared by both BigQuerySink and BigQueryMultiSink, but the job id is only set for BigQuerySink. This should ensure that a new UUID is generated for BigQueryMultiSink jobs.

Tested manually the following cases:
- BQMultiSink inserts data successfully to two target tables on a BQ dataset in different location. This was failing before the fix.
- BQ sink metric is getting updated correctly for insert/update/upsert
- BQ Multi sink does not emit "records.updated" metric