### PR TITLE
CDAP-17237 patch commit job performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>google-cloud</artifactId>
-  <version>0.14.7</version>
+  <version>0.14.8</version>
   <name>Google Cloud Plugins</name>
   <packaging>jar</packaging>
   <description>Plugins for Google Big Query</description>

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
@@ -473,6 +473,7 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, A
       temporaryGcsPath,
       BigQueryFileFormat.AVRO,
       AvroOutputFormat.class);
+    configuration.set("mapreduce.fileoutputcommitter.algorithm.version", "2");
 
     return configuration;
   }

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSMultiBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSMultiBatchSink.java
@@ -129,6 +129,7 @@ public class GCSMultiBatchSink extends BatchSink<StructuredRecord, NullWritable,
       outputProperties.putAll(RecordFilterOutputFormat.configure(validatingOutputFormat.getOutputFormatClassName(),
                                                                  config.splitField, name, schema));
       outputProperties.put(FileOutputFormat.OUTDIR, config.getOutputDir(context.getLogicalStartTime(), name));
+      outputProperties.put("mapreduce.fileoutputcommitter.algorithm.version", "2");
 
       context.addOutput(Output.of(
         config.getReferenceName() + "_" + name,

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSOutputFormatProvider.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSOutputFormatProvider.java
@@ -54,6 +54,7 @@ public class GCSOutputFormatProvider implements ValidatingOutputFormat {
   public Map<String, String> getOutputFormatConfiguration() {
     Map<String, String> outputFormatConfiguration = new HashMap<>(delegate.getOutputFormatConfiguration());
     outputFormatConfiguration.put(DELEGATE_OUTPUTFORMAT_CLASSNAME, delegate.getOutputFormatClassName());
+    outputFormatConfiguration.put("mapreduce.fileoutputcommitter.algorithm.version", "2");
     return outputFormatConfiguration;
   }
 


### PR DESCRIPTION
CDAP 6.1.4 has a bug that removes mapred-site defaults.
As a workaround, setting commit algo to 2 to make sure commits
don't take forever.