### PR TITLE
Remove extra fields from gcsmultisink

### DIFF
--- a/widgets/GCSMultiFiles-batchsink.json
+++ b/widgets/GCSMultiFiles-batchsink.json
@@ -103,6 +103,16 @@
           "widget-attributes": {
             "default": "tablename"
           }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Output File Prefix",
+          "name": "outputFileNameBase"
+        },
+        {
+          "widget-type": "hidden",
+          "label": "File System Properties",
+          "name": "fileSystemProperties"
         }
       ]
     },


### PR DESCRIPTION
- Prevent additional fields added to GCS sink from showing up in GCS multi sink.