### PR TITLE
(PLUGIN-395) - Avoid underlying BigQuery schema changes when allowSchemaRelaxation is disabled in BigQuery sink plugins.

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
@@ -317,7 +317,7 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, A
 
       if (table == null) {
         LOG.info("Table [%s] doesn't exist yet. Using input schema for writing records.",
-          config.getTable());
+          tableName);
         return null;
       }
 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
@@ -385,6 +385,7 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, A
       }
     }
 
+    // column type changes should be disallowed if either allowSchemaRelaxation or truncate table are not set.
     if (!allowSchemaRelaxation || !getConfig().isTruncateTableSet()) {
       // Match output schema field type with BigQuery column type
       for (Schema.Field field : tableSchema.getFields()) {

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
@@ -385,19 +385,22 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, A
       }
     }
 
-    // Match output schema field type with BigQuery column type
-    for (Schema.Field field : tableSchema.getFields()) {
-      String fieldName = field.getName();
-      // skip checking schema if field is missing in BigQuery
-      if (!missingBQFields.contains(fieldName)) {
-        ValidationFailure failure = BigQueryUtil.validateFieldSchemaMatches(
-          bqFields.get(field.getName()), field, getConfig().getDataset(), tableName,
-          AbstractBigQuerySinkConfig.SUPPORTED_TYPES, collector);
-        if (failure != null) {
-          failure.withInputSchemaField(fieldName).withOutputSchemaField(fieldName);
+    if (!allowSchemaRelaxation || !getConfig().isTruncateTableSet()) {
+      // Match output schema field type with BigQuery column type
+      for (Schema.Field field : tableSchema.getFields()) {
+        String fieldName = field.getName();
+        // skip checking schema if field is missing in BigQuery
+        if (!missingBQFields.contains(fieldName)) {
+          ValidationFailure failure = BigQueryUtil.validateFieldSchemaMatches(
+              bqFields.get(field.getName()), field, getConfig().getDataset(), tableName,
+              AbstractBigQuerySinkConfig.SUPPORTED_TYPES, collector);
+          if (failure != null) {
+            failure.withInputSchemaField(fieldName).withOutputSchemaField(fieldName);
+          }
         }
       }
     }
+
     collector.getOrThrowException();
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
@@ -264,6 +264,64 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, A
   }
 
   /**
+   * Adjusts output format schema depending on allowSchemaRelaxation setting to avoid unexpected
+   * schema changes to the underlying bigQuery table.
+   * @param configuredSchema Schema configured for output format.
+   * @param tableName BigQuery table name for writing record.
+   * @param collector Failure collector to report failures to the client.
+   * @return
+   */
+  protected final Schema overrideOutputSchemaWithTableSchemaIfNeeded(
+      Schema configuredSchema,
+      String tableName,
+      FailureCollector collector) {
+    AbstractBigQuerySinkConfig config = getConfig();
+
+    if (!config.isAllowSchemaRelaxation()) {
+      Schema tableSchema = getTableSchema(config.getTable(), collector);
+      // We use GCS buckets to write AVRO files and import them in BigQuery.
+      // Avro is a self describing format and BigQuery overwrites table schema with AVRO record
+      // schema.
+      // If table schema relaxation is not allowed then AVRO records will be normalized and
+      // written to GCS using table schema to avoid any table schema changes.
+      if (tableSchema != null) {
+        LOG.info("Output schema updated to use table schema");
+        return tableSchema;
+      }
+    }
+    return configuredSchema;
+  }
+
+  /**
+   * Returns Bigtable schema in a CDAP schema format.
+   * @param tableName BigQuery table name for writing record.
+   * @param collector Failure collector to report failures to the client.
+   * @return
+   */
+  @Nullable
+  private Schema getTableSchema(String tableName, FailureCollector collector) {
+    AbstractBigQuerySinkConfig config = getConfig();
+    Table table = BigQueryUtil.getBigQueryTable(
+        config.getProject(),
+        config.getDataset(), tableName,
+        config.getServiceAccountFilePath(),
+        collector);
+
+    if (table == null) {
+      LOG.info("Table [%s] doesn't exist yet. Using input schema for writing records.", config.getTable());
+      return null;
+    }
+
+    com.google.cloud.bigquery.Schema bqSchema = table.getDefinition().getSchema();
+    if (bqSchema == null || bqSchema.getFields().isEmpty()) {
+      // Table is created without schema, so no further validation is required.
+      LOG.info("Table [%s] doesn't have a valid schema. Using input schema for writing records.", config.getTable());
+      return null;
+    }
+    return BigQueryUtil.getTableSchema(bqSchema, collector);
+  }
+
+  /**
    * Validates output schema against Big Query table schema. It throws {@link IllegalArgumentException}
    * if the output schema has more fields than Big Query table or output schema field types does not match
    * Big Query column types unless schema relaxation policy is allowed.
@@ -282,32 +340,28 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, A
       return;
     }
 
-    if (getConfig().isTruncateTableSet()) {
-      //no validation required for schema if truncate table is set.
-      // BQ will overwrite the schema for normal tables when write disposition is WRITE_TRUNCATE
-      //note - If write to single partition is supported in future, schema validation will be necessary
-      return;
-    }
-
     FieldList bqFields = bqSchema.getFields();
     List<Schema.Field> outputSchemaFields = Objects.requireNonNull(tableSchema.getFields());
 
     List<String> missingBQFields = BigQueryUtil.getSchemaMinusBqFields(outputSchemaFields, bqFields);
 
     if (allowSchemaRelaxation) {
-      List<String> nonNullableFields = missingBQFields.stream()
-        .map(tableSchema::getField)
-        .filter(Objects::nonNull)
-        .filter(field -> !field.getSchema().isNullable())
-        .map(Schema.Field::getName)
-        .collect(Collectors.toList());
+      // Required fields can be added only if truncate table option is set.
+      if (!getConfig().isTruncateTableSet()) {
+        List<String> nonNullableFields = missingBQFields.stream()
+            .map(tableSchema::getField)
+            .filter(Objects::nonNull)
+            .filter(field -> !field.getSchema().isNullable())
+            .map(Schema.Field::getName)
+            .collect(Collectors.toList());
 
-      for (String nonNullableField : nonNullableFields) {
-        collector.addFailure(
-          String.format("Required field '%s' does not exist in BigQuery table '%s.%s'.",
-                        nonNullableField, getConfig().getDataset(), tableName),
-          "Change the field to be nullable.")
-          .withInputSchemaField(nonNullableField).withOutputSchemaField(nonNullableField);
+        for (String nonNullableField : nonNullableFields) {
+          collector.addFailure(
+              String.format("Required field '%s' does not exist in BigQuery table '%s.%s'.",
+                  nonNullableField, getConfig().getDataset(), tableName),
+              "Change the field to be nullable.")
+              .withInputSchemaField(nonNullableField).withOutputSchemaField(nonNullableField);
+        }
       }
     } else {
       // schema should not have fields that are not present in BigQuery table,
@@ -322,7 +376,9 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, A
       // validate the missing columns in output schema are nullable fields in BigQuery
       List<String> remainingBQFields = BigQueryUtil.getBqFieldsMinusSchema(bqFields, outputSchemaFields);
       for (String field : remainingBQFields) {
-        if (bqFields.get(field).getMode() != Field.Mode.NULLABLE) {
+        Field.Mode mode = bqFields.get(field).getMode();
+        // Mode is optional. If the mode is unspecified, the column defaults to NULLABLE.
+        if (mode != null && mode != Field.Mode.NULLABLE) {
           collector.addFailure(String.format("Required Column '%s' is not present in the schema.", field),
                                String.format("Add '%s' to the schema.", field));
         }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
@@ -303,7 +303,7 @@ public class BigQueryOutputFormat extends ForwardingBigQueryFileOutputFormat<Avr
         // or with WRITE_TRUNCATE disposition on a table partition - The logic below should change when we support
         // insertion into single partition
         if (allowSchemaRelaxation && !JobInfo.WriteDisposition.WRITE_TRUNCATE
-            .equals(JobInfo.WriteDisposition.valueOf(writeDisposition))) {
+          .equals(JobInfo.WriteDisposition.valueOf(writeDisposition))) {
           loadConfig.setSchemaUpdateOptions(Arrays.asList(
             JobInfo.SchemaUpdateOption.ALLOW_FIELD_ADDITION.name(),
             JobInfo.SchemaUpdateOption.ALLOW_FIELD_RELAXATION.name()));

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
@@ -299,8 +299,11 @@ public class BigQueryOutputFormat extends ForwardingBigQueryFileOutputFormat<Avr
       } else {
         loadConfig.setDestinationTable(tableRef);
 
-        //Schema update options should only be specified when allowSchemaRelaxation is enabled.
-        if (allowSchemaRelaxation) {
+        // Schema update options should only be specified with WRITE_APPEND disposition,
+        // or with WRITE_TRUNCATE disposition on a table partition - The logic below should change when we support
+        // insertion into single partition
+        if (allowSchemaRelaxation && !JobInfo.WriteDisposition.WRITE_TRUNCATE
+            .equals(JobInfo.WriteDisposition.valueOf(writeDisposition))) {
           loadConfig.setSchemaUpdateOptions(Arrays.asList(
             JobInfo.SchemaUpdateOption.ALLOW_FIELD_ADDITION.name(),
             JobInfo.SchemaUpdateOption.ALLOW_FIELD_RELAXATION.name()));

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
@@ -299,11 +299,8 @@ public class BigQueryOutputFormat extends ForwardingBigQueryFileOutputFormat<Avr
       } else {
         loadConfig.setDestinationTable(tableRef);
 
-        //Schema update options should only be specified with WRITE_APPEND disposition,
-        // or with WRITE_TRUNCATE disposition on a table partition - The logic below should change when we support
-        // insertion into single partition
-        if (allowSchemaRelaxation && !JobInfo.WriteDisposition.WRITE_TRUNCATE
-          .equals(JobInfo.WriteDisposition.valueOf(writeDisposition))) {
+        //Schema update options should only be specified when allowSchemaRelaxation is enabled.
+        if (allowSchemaRelaxation) {
           loadConfig.setSchemaUpdateOptions(Arrays.asList(
             JobInfo.SchemaUpdateOption.ALLOW_FIELD_ADDITION.name(),
             JobInfo.SchemaUpdateOption.ALLOW_FIELD_RELAXATION.name()));

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -41,7 +41,6 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.mapred.AvroKey;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
-import org.junit.internal.runners.statements.Fail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +50,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 
 /**
  * This class <code>BigQuerySink</code> is a plugin that would allow users
@@ -113,7 +111,7 @@ public final class BigQuerySink extends AbstractBigQuerySink {
 
     Schema configSchema = config.getSchema(collector);
     Schema outputSchema = overrideOutputSchemaWithTableSchemaIfNeeded(
-        configSchema == null ? context.getInputSchema() : configSchema, config.getTable(), collector);
+      configSchema == null ? context.getInputSchema() : configSchema, config.getTable(), collector);
 
     configureTable(outputSchema);
     configureBigQuerySink();

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -111,7 +111,7 @@ public final class BigQuerySink extends AbstractBigQuerySink {
 
     Schema configSchema = config.getSchema(collector);
     Schema outputSchema = overrideOutputSchemaWithTableSchemaIfNeeded(
-      configSchema == null ? context.getInputSchema() : configSchema, config.getTable(), collector);
+      config.getTable(), configSchema == null ? context.getInputSchema() : configSchema, null, collector);
 
     configureTable(outputSchema);
     configureBigQuerySink();
@@ -257,12 +257,14 @@ public final class BigQuerySink extends AbstractBigQuerySink {
       return;
     }
 
-    Table table = BigQueryUtil.getBigQueryTable(config.getProject(), config.getDataset(), config.getTable(),
+    String tableName = config.getTable();
+    Table table = BigQueryUtil.getBigQueryTable(config.getProject(), config.getDataset(), tableName,
                                                 config.getServiceAccountFilePath(), collector);
     if (table != null) {
       // if table already exists, validate schema against underlying bigquery table
 
-      validateSchema(table, schema, config.allowSchemaRelaxation, collector);
+      com.google.cloud.bigquery.Schema bqSchema = table.getDefinition().getSchema();
+      validateSchema(tableName, bqSchema, schema, config.allowSchemaRelaxation, collector);
     }
   }
 }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySource.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySource.java
@@ -227,26 +227,7 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
 
   public Schema getSchema(FailureCollector collector) {
     com.google.cloud.bigquery.Schema bqSchema = getBQSchema(collector);
-    FieldList fields = bqSchema.getFields();
-    List<Schema.Field> schemafields = new ArrayList<>();
-
-    for (Field field : fields) {
-      Schema.Field schemaField = getSchemaField(field, collector);
-      // if schema field is null, that means that there was a validation error. We will still continue in order to
-      // collect more errors
-      if (schemaField == null) {
-        continue;
-      }
-      schemafields.add(schemaField);
-    }
-    if (schemafields.isEmpty() && !collector.getValidationFailures().isEmpty()) {
-      // throw if there was validation failure(s) added to the collector
-      collector.getOrThrowException();
-    }
-    if (schemafields.isEmpty()) {
-      return null;
-    }
-    return Schema.recordOf("output", schemafields);
+    return BigQueryUtil.getTableSchema(bqSchema, collector);
   }
 
   /**
@@ -315,81 +296,6 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
     validatePartitionProperties(collector);
     validateConfiguredSchema(outputSchema, collector);
     return outputSchema;
-  }
-
-  @Nullable
-  private Schema.Field getSchemaField(Field field, FailureCollector collector) {
-    Schema schema = convertFieldType(field, collector);
-    if (schema == null) {
-      return null;
-    }
-
-    Field.Mode mode = field.getMode() == null ? Field.Mode.NULLABLE : field.getMode();
-    switch (mode) {
-      case NULLABLE:
-        return Schema.Field.of(field.getName(), Schema.nullableOf(schema));
-      case REQUIRED:
-        return Schema.Field.of(field.getName(), schema);
-      case REPEATED:
-        return Schema.Field.of(field.getName(), Schema.arrayOf(schema));
-      default:
-        // this should not happen, unless newer bigquery versions introduces new mode that is not supported by this
-        // plugin.
-        collector.addFailure(String.format("Field '%s' has unsupported mode '%s'.", field.getName(), mode), null);
-    }
-    return null;
-  }
-
-  @Nullable
-  private Schema convertFieldType(Field field, FailureCollector collector) {
-    LegacySQLTypeName type = field.getType();
-    Schema schema = null;
-    StandardSQLTypeName value = type.getStandardType();
-    if (value == StandardSQLTypeName.FLOAT64) {
-      // float is a float64, so corresponding type becomes double
-      schema = Schema.of(Schema.Type.DOUBLE);
-    } else if (value == StandardSQLTypeName.BOOL) {
-      schema = Schema.of(Schema.Type.BOOLEAN);
-    } else if (value == StandardSQLTypeName.INT64) {
-      // int is a int64, so corresponding type becomes long
-      schema = Schema.of(Schema.Type.LONG);
-    } else if (value == StandardSQLTypeName.STRING || value == StandardSQLTypeName.DATETIME) {
-      schema = Schema.of(Schema.Type.STRING);
-    } else if (value == StandardSQLTypeName.BYTES) {
-      schema = Schema.of(Schema.Type.BYTES);
-    } else if (value == StandardSQLTypeName.TIME) {
-      schema = Schema.of(Schema.LogicalType.TIME_MICROS);
-    } else if (value == StandardSQLTypeName.DATE) {
-      schema = Schema.of(Schema.LogicalType.DATE);
-    } else if (value == StandardSQLTypeName.TIMESTAMP) {
-      schema = Schema.of(Schema.LogicalType.TIMESTAMP_MICROS);
-    } else if (value == StandardSQLTypeName.NUMERIC) {
-      // bigquery has 38 digits of precision and 9 digits of scale.
-      // https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-avro#logical_types
-      schema = Schema.decimalOf(38, 9);
-    } else if (value == StandardSQLTypeName.STRUCT) {
-      FieldList fields = field.getSubFields();
-      List<Schema.Field> schemafields = new ArrayList<>();
-      for (Field f : fields) {
-        Schema.Field schemaField = getSchemaField(f, collector);
-        // if schema field is null, that means that there was a validation error. We will still continue in order to
-        // collect more errors
-        if (schemaField == null) {
-          continue;
-        }
-        schemafields.add(schemaField);
-      }
-      // do not return schema for the struct field if none of the nested fields are of supported types
-      if (!schemafields.isEmpty()) {
-        schema = Schema.recordOf(field.getName(), schemafields);
-      }
-    } else {
-      collector.addFailure(
-        String.format("BigQuery column '%s' is of unsupported type '%s'.", field.getName(), value.name()),
-        String.format("Supported column types are: %s.", BigQueryUtil.BQ_TYPE_MAP.keySet().stream()
-          .map(t -> t.getStandardType().name()).collect(Collectors.joining(", "))));
-    }
-    return schema;
   }
 
   private void validatePartitionProperties(FailureCollector collector) {

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
@@ -21,6 +21,7 @@ import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.FieldList;
 import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.hadoop.io.bigquery.BigQueryConfiguration;
@@ -148,6 +149,122 @@ public final class BigQueryUtil {
       configuration.set(BigQueryConfiguration.OUTPUT_TABLE_KMS_KEY_NAME_KEY, cmekKey);
     }
     return configuration;
+  }
+
+  /**
+   * Converts BigQuery Table Schema into a CDAP Schema object.
+   * @param bqSchema BigQuery Schema to be converted.
+   * @param collector Failure collector to collect failure messages for the client.
+   * @return CDAP schema object
+   */
+  public static Schema getTableSchema(com.google.cloud.bigquery.Schema bqSchema, FailureCollector collector) {
+    FieldList fields = bqSchema.getFields();
+    List<Schema.Field> schemafields = new ArrayList<>();
+
+    for (Field field : fields) {
+      Schema.Field schemaField = getSchemaField(field, collector);
+      // if schema field is null, that means that there was a validation error. We will still continue in order to
+      // collect more errors
+      if (schemaField == null) {
+        continue;
+      }
+      schemafields.add(schemaField);
+    }
+    if (schemafields.isEmpty() && !collector.getValidationFailures().isEmpty()) {
+      // throw if there was validation failure(s) added to the collector
+      collector.getOrThrowException();
+    }
+    if (schemafields.isEmpty()) {
+      return null;
+    }
+    return Schema.recordOf("output", schemafields);
+  }
+
+  /**
+   * Converts BigQuery schema field into a corresponding CDAP Schema.Field.
+   * @param field BigQuery field to be converted.
+   * @param collector Failure collector to collect failure messages for the client.
+   * @return A CDAP schema field
+   */
+  @Nullable
+  public static Schema.Field getSchemaField(Field field, FailureCollector collector) {
+    Schema schema = convertFieldType(field, collector);
+    if (schema == null) {
+      return null;
+    }
+
+    Field.Mode mode = field.getMode() == null ? Field.Mode.NULLABLE : field.getMode();
+    switch (mode) {
+      case NULLABLE:
+        return Schema.Field.of(field.getName(), Schema.nullableOf(schema));
+      case REQUIRED:
+        return Schema.Field.of(field.getName(), schema);
+      case REPEATED:
+        return Schema.Field.of(field.getName(), Schema.arrayOf(schema));
+      default:
+        // this should not happen, unless newer bigquery versions introduces new mode that is not supported by this
+        // plugin.
+        collector.addFailure(String.format("Field '%s' has unsupported mode '%s'.", field.getName(), mode), null);
+    }
+    return null;
+  }
+
+  /**
+   * Converts BiqQuery field type into a CDAP field type.
+   * @param field Bigquery field to be converted.
+   * @param collector Failure collector to collect failure messages for the client.
+   * @return A CDAP field schema
+   */
+  @Nullable
+  public static Schema convertFieldType(Field field, FailureCollector collector) {
+    LegacySQLTypeName type = field.getType();
+    Schema schema = null;
+    StandardSQLTypeName value = type.getStandardType();
+    if (value == StandardSQLTypeName.FLOAT64) {
+      // float is a float64, so corresponding type becomes double
+      schema = Schema.of(Schema.Type.DOUBLE);
+    } else if (value == StandardSQLTypeName.BOOL) {
+      schema = Schema.of(Schema.Type.BOOLEAN);
+    } else if (value == StandardSQLTypeName.INT64) {
+      // int is a int64, so corresponding type becomes long
+      schema = Schema.of(Schema.Type.LONG);
+    } else if (value == StandardSQLTypeName.STRING || value == StandardSQLTypeName.DATETIME) {
+      schema = Schema.of(Schema.Type.STRING);
+    } else if (value == StandardSQLTypeName.BYTES) {
+      schema = Schema.of(Schema.Type.BYTES);
+    } else if (value == StandardSQLTypeName.TIME) {
+      schema = Schema.of(Schema.LogicalType.TIME_MICROS);
+    } else if (value == StandardSQLTypeName.DATE) {
+      schema = Schema.of(Schema.LogicalType.DATE);
+    } else if (value == StandardSQLTypeName.TIMESTAMP) {
+      schema = Schema.of(Schema.LogicalType.TIMESTAMP_MICROS);
+    } else if (value == StandardSQLTypeName.NUMERIC) {
+      // bigquery has 38 digits of precision and 9 digits of scale.
+      // https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-avro#logical_types
+      schema = Schema.decimalOf(38, 9);
+    } else if (value == StandardSQLTypeName.STRUCT) {
+      FieldList fields = field.getSubFields();
+      List<Schema.Field> schemafields = new ArrayList<>();
+      for (Field f : fields) {
+        Schema.Field schemaField = getSchemaField(f, collector);
+        // if schema field is null, that means that there was a validation error. We will still continue in order to
+        // collect more errors
+        if (schemaField == null) {
+          continue;
+        }
+        schemafields.add(schemaField);
+      }
+      // do not return schema for the struct field if none of the nested fields are of supported types
+      if (!schemafields.isEmpty()) {
+        schema = Schema.recordOf(field.getName(), schemafields);
+      }
+    } else {
+      collector.addFailure(
+          String.format("BigQuery column '%s' is of unsupported type '%s'.", field.getName(), value.name()),
+          String.format("Supported column types are: %s.", BigQueryUtil.BQ_TYPE_MAP.keySet().stream()
+              .map(t -> t.getStandardType().name()).collect(Collectors.joining(", "))));
+    }
+    return schema;
   }
 
   /**

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkTest.java
@@ -28,6 +28,7 @@ import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.TableId;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.cdap.etl.api.validation.ValidationException;
 import io.cdap.cdap.etl.api.validation.ValidationFailure;
@@ -179,7 +180,12 @@ public class BigQuerySinkTest {
     BigQuerySink sink = getValidationTestSink(false);
     MockFailureCollector collector = new MockFailureCollector("bqsink");
     Table table = getTestSchema();
-    sink.validateSchema(table, sink.getConfig().getSchema(collector), false, collector);
+    sink.validateSchema(
+      table.getTableId().getTable(),
+      table.getDefinition().getSchema(),
+      sink.getConfig().getSchema(collector),
+      false,
+      collector);
   }
 
   @Test(expected = ValidationException.class)
@@ -187,7 +193,12 @@ public class BigQuerySinkTest {
     BigQuerySink sink = getValidationTestSink(true);
     MockFailureCollector collector = new MockFailureCollector("bqsink");
     Table table = getTestSchema();
-    sink.validateSchema(table, sink.getConfig().getSchema(collector), false, collector);
+    sink.validateSchema(
+      table.getTableId().getTable(),
+      table.getDefinition().getSchema(),
+      sink.getConfig().getSchema(collector),
+      false,
+      collector);
     Assert.assertEquals(0, collector.getValidationFailures().size());
   }
 
@@ -196,7 +207,12 @@ public class BigQuerySinkTest {
     BigQuerySink sink = getValidationTestSink(true);
     MockFailureCollector collector = new MockFailureCollector("bqsink");
     Table table = getTestSchema();
-    sink.validateSchema(table, sink.getConfig().getSchema(collector), true, collector);
+    sink.validateSchema(
+      table.getTableId().getTable(),
+      table.getDefinition().getSchema(),
+      sink.getConfig().getSchema(collector),
+      true,
+      collector);
     Assert.assertEquals(0, collector.getValidationFailures().size());
   }
 
@@ -205,7 +221,12 @@ public class BigQuerySinkTest {
     BigQuerySink sink = getValidationTestSink(false);
     MockFailureCollector collector = new MockFailureCollector("bqsink");
     Table table = getTestSchema();
-    sink.validateSchema(table, sink.getConfig().getSchema(collector), true, collector);
+    sink.validateSchema(
+      table.getTableId().getTable(),
+      table.getDefinition().getSchema(),
+      sink.getConfig().getSchema(collector),
+      true,
+      collector);
     Assert.assertEquals(0, collector.getValidationFailures().size());
   }
 

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkTest.java
@@ -175,19 +175,37 @@ public class BigQuerySinkTest {
   }
 
   @Test(expected = ValidationException.class)
-  public void testSchemaValidationException() throws NoSuchFieldException {
+  public void testSchemaValidationNoTruncateNoSchemaRelaxationException() throws NoSuchFieldException {
     BigQuerySink sink = getValidationTestSink(false);
     MockFailureCollector collector = new MockFailureCollector("bqsink");
     Table table = getTestSchema();
     sink.validateSchema(table, sink.getConfig().getSchema(collector), false, collector);
   }
 
-  @Test
-  public void testSchemaValidationNoException() throws NoSuchFieldException {
+  @Test(expected = ValidationException.class)
+  public void testSchemaValidationTruncateNoSchemaRelaxationException() throws NoSuchFieldException {
     BigQuerySink sink = getValidationTestSink(true);
     MockFailureCollector collector = new MockFailureCollector("bqsink");
     Table table = getTestSchema();
     sink.validateSchema(table, sink.getConfig().getSchema(collector), false, collector);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+  @Test
+  public void testSchemaValidationAllowSchemaRelaxationTruncateNoException() throws NoSuchFieldException {
+    BigQuerySink sink = getValidationTestSink(true);
+    MockFailureCollector collector = new MockFailureCollector("bqsink");
+    Table table = getTestSchema();
+    sink.validateSchema(table, sink.getConfig().getSchema(collector), true, collector);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+  @Test(expected = ValidationException.class)
+  public void testSchemaValidationAllowSchemaRelaxationNoTruncateException() throws NoSuchFieldException {
+    BigQuerySink sink = getValidationTestSink(false);
+    MockFailureCollector collector = new MockFailureCollector("bqsink");
+    Table table = getTestSchema();
+    sink.validateSchema(table, sink.getConfig().getSchema(collector), true, collector);
     Assert.assertEquals(0, collector.getValidationFailures().size());
   }
 


### PR DESCRIPTION
1. Moved BigQuery Table Schema conversion methods from BigQuerySource to BigQueryUtil so that they can be reused by BigQuerySink classes.
2. Updated AbstractBigQuerySink#validateSchema method to 

- validate schema changes when truncate table is true but allowSchemaRelaxation is false.
- ignore required fields when both allowSchemaRelaxation/truncate table are true.
- fixed null mode checking since mode is optional and uses NULLABLE by default.

3. Update BigQuerySinkTest to as per validation changes.
4. Updated BigQuerySink/MultiSink classes to always use table schema when allowSchemaRelaxation is set to false.
5. Set table schema update options if allowSchemaRelaxation is enabled.