### PR TITLE
(PLUGIN-395) - Avoid underlying BigQuery schema changes when allowSchemaRelaxation is disabled in BigQuery sink plugins

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSink.java
@@ -16,6 +16,7 @@
 package io.cdap.plugin.gcp.bigquery.sink;
 
 import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.Table;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
@@ -30,10 +31,14 @@ import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.plugin.format.avro.StructuredToAvroTransformer;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryConstants;
+
+import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.mapred.AvroKey;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -48,7 +53,6 @@ import java.util.Map;
   + "BigQuery is Google's serverless, highly scalable, enterprise data warehouse. "
   + "Data is first written to a temporary location on Google Cloud Storage, then loaded into BigQuery from there.")
 public class BigQueryMultiSink extends AbstractBigQuerySink {
-
   private static final String TABLE_PREFIX = "multisink.";
 
   private final BigQueryMultiSinkConfig config;
@@ -93,7 +97,24 @@ public class BigQueryMultiSink extends AbstractBigQuerySink {
       }
 
       try {
-        Schema tableSchema = Schema.parseJson(argument.getValue());
+        Schema configuredSchema = Schema.parseJson(argument.getValue());
+
+        Table table = BigQueryUtil.getBigQueryTable(
+          config.getProject(), config.getDataset(), tableName, config.getServiceAccountFilePath(),
+          collector);
+
+        Schema tableSchema = configuredSchema;
+        if (table != null) {
+          // if table already exists, validate schema against underlying bigquery table and
+          // override against configured schema as necessary.
+          com.google.cloud.bigquery.Schema bqSchema = table.getDefinition().getSchema();
+
+          validateSchema(tableName, bqSchema, configuredSchema, config.allowSchemaRelaxation, collector);
+
+          tableSchema = overrideOutputSchemaWithTableSchemaIfNeeded(
+            tableName, configuredSchema, bqSchema, collector);
+        }
+
         String outputName = String.format("%s-%s", config.getReferenceName(), tableName);
         initOutput(context, bigQuery, outputName, tableName, tableSchema, bucket, context.getFailureCollector());
       } catch (IOException e) {

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
@@ -287,7 +287,7 @@ public class BigQueryOutputFormat extends ForwardingBigQueryFileOutputFormat<Avr
       } else {
         loadConfig.setDestinationTable(tableRef);
 
-        //Schema update options should only be specified with WRITE_APPEND disposition,
+        // Schema update options should only be specified with WRITE_APPEND disposition,
         // or with WRITE_TRUNCATE disposition on a table partition - The logic below should change when we support
         // insertion into single partition
         if (allowSchemaRelaxation && !JobInfo.WriteDisposition.WRITE_TRUNCATE

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -111,11 +111,14 @@ public final class BigQuerySink extends AbstractBigQuerySink {
   @Override
   protected void prepareRunInternal(BatchSinkContext context, BigQuery bigQuery, String bucket) throws IOException {
     FailureCollector collector = context.getFailureCollector();
+
     Schema configSchema = config.getSchema(collector);
-    Schema schema = configSchema == null ? context.getInputSchema() : configSchema;
-    configureTable(schema);
+    Schema outputSchema = overrideOutputSchemaWithTableSchemaIfNeeded(
+      config.getTable(), configSchema == null ? context.getInputSchema() : configSchema, null, collector);
+
+    configureTable(outputSchema);
     configureBigQuerySink();
-    initOutput(context, bigQuery, config.getReferenceName(), config.getTable(), schema, bucket, collector);
+    initOutput(context, bigQuery, config.getReferenceName(), config.getTable(), outputSchema, bucket, collector);
   }
 
   @Override
@@ -253,12 +256,14 @@ public final class BigQuerySink extends AbstractBigQuerySink {
       return;
     }
 
-    Table table = BigQueryUtil.getBigQueryTable(config.getProject(), config.getDataset(), config.getTable(),
+    String tableName = config.getTable();
+    Table table = BigQueryUtil.getBigQueryTable(config.getProject(), config.getDataset(), tableName,
                                                 config.getServiceAccountFilePath(), collector);
     if (table != null) {
       // if table already exists, validate schema against underlying bigquery table
 
-      validateSchema(table, schema, config.allowSchemaRelaxation, collector);
+      com.google.cloud.bigquery.Schema bqSchema = table.getDefinition().getSchema();
+      validateSchema(tableName, bqSchema, schema, config.allowSchemaRelaxation, collector);
     }
   }
 }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
@@ -21,6 +21,7 @@ import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.FieldList;
 import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.hadoop.io.bigquery.BigQueryConfiguration;
@@ -148,6 +149,122 @@ public final class BigQueryUtil {
       configuration.set(BigQueryConfiguration.OUTPUT_TABLE_KMS_KEY_NAME_KEY, cmekKey);
     }
     return configuration;
+  }
+
+  /**
+   * Converts BigQuery Table Schema into a CDAP Schema object.
+   * @param bqSchema BigQuery Schema to be converted.
+   * @param collector Failure collector to collect failure messages for the client.
+   * @return CDAP schema object
+   */
+  public static Schema getTableSchema(com.google.cloud.bigquery.Schema bqSchema, FailureCollector collector) {
+    FieldList fields = bqSchema.getFields();
+    List<Schema.Field> schemafields = new ArrayList<>();
+
+    for (Field field : fields) {
+      Schema.Field schemaField = getSchemaField(field, collector);
+      // if schema field is null, that means that there was a validation error. We will still continue in order to
+      // collect more errors
+      if (schemaField == null) {
+        continue;
+      }
+      schemafields.add(schemaField);
+    }
+    if (schemafields.isEmpty() && !collector.getValidationFailures().isEmpty()) {
+      // throw if there was validation failure(s) added to the collector
+      collector.getOrThrowException();
+    }
+    if (schemafields.isEmpty()) {
+      return null;
+    }
+    return Schema.recordOf("output", schemafields);
+  }
+
+  /**
+   * Converts BigQuery schema field into a corresponding CDAP Schema.Field.
+   * @param field BigQuery field to be converted.
+   * @param collector Failure collector to collect failure messages for the client.
+   * @return A CDAP schema field
+   */
+  @Nullable
+  public static Schema.Field getSchemaField(Field field, FailureCollector collector) {
+    Schema schema = convertFieldType(field, collector);
+    if (schema == null) {
+      return null;
+    }
+
+    Field.Mode mode = field.getMode() == null ? Field.Mode.NULLABLE : field.getMode();
+    switch (mode) {
+      case NULLABLE:
+        return Schema.Field.of(field.getName(), Schema.nullableOf(schema));
+      case REQUIRED:
+        return Schema.Field.of(field.getName(), schema);
+      case REPEATED:
+        return Schema.Field.of(field.getName(), Schema.arrayOf(schema));
+      default:
+        // this should not happen, unless newer bigquery versions introduces new mode that is not supported by this
+        // plugin.
+        collector.addFailure(String.format("Field '%s' has unsupported mode '%s'.", field.getName(), mode), null);
+    }
+    return null;
+  }
+
+  /**
+   * Converts BiqQuery field type into a CDAP field type.
+   * @param field Bigquery field to be converted.
+   * @param collector Failure collector to collect failure messages for the client.
+   * @return A CDAP field schema
+   */
+  @Nullable
+  public static Schema convertFieldType(Field field, FailureCollector collector) {
+    LegacySQLTypeName type = field.getType();
+    Schema schema = null;
+    StandardSQLTypeName value = type.getStandardType();
+    if (value == StandardSQLTypeName.FLOAT64) {
+      // float is a float64, so corresponding type becomes double
+      schema = Schema.of(Schema.Type.DOUBLE);
+    } else if (value == StandardSQLTypeName.BOOL) {
+      schema = Schema.of(Schema.Type.BOOLEAN);
+    } else if (value == StandardSQLTypeName.INT64) {
+      // int is a int64, so corresponding type becomes long
+      schema = Schema.of(Schema.Type.LONG);
+    } else if (value == StandardSQLTypeName.STRING || value == StandardSQLTypeName.DATETIME) {
+      schema = Schema.of(Schema.Type.STRING);
+    } else if (value == StandardSQLTypeName.BYTES) {
+      schema = Schema.of(Schema.Type.BYTES);
+    } else if (value == StandardSQLTypeName.TIME) {
+      schema = Schema.of(Schema.LogicalType.TIME_MICROS);
+    } else if (value == StandardSQLTypeName.DATE) {
+      schema = Schema.of(Schema.LogicalType.DATE);
+    } else if (value == StandardSQLTypeName.TIMESTAMP) {
+      schema = Schema.of(Schema.LogicalType.TIMESTAMP_MICROS);
+    } else if (value == StandardSQLTypeName.NUMERIC) {
+      // bigquery has 38 digits of precision and 9 digits of scale.
+      // https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-avro#logical_types
+      schema = Schema.decimalOf(38, 9);
+    } else if (value == StandardSQLTypeName.STRUCT) {
+      FieldList fields = field.getSubFields();
+      List<Schema.Field> schemafields = new ArrayList<>();
+      for (Field f : fields) {
+        Schema.Field schemaField = getSchemaField(f, collector);
+        // if schema field is null, that means that there was a validation error. We will still continue in order to
+        // collect more errors
+        if (schemaField == null) {
+          continue;
+        }
+        schemafields.add(schemaField);
+      }
+      // do not return schema for the struct field if none of the nested fields are of supported types
+      if (!schemafields.isEmpty()) {
+        schema = Schema.recordOf(field.getName(), schemafields);
+      }
+    } else {
+      collector.addFailure(
+          String.format("BigQuery column '%s' is of unsupported type '%s'.", field.getName(), value.name()),
+          String.format("Supported column types are: %s.", BigQueryUtil.BQ_TYPE_MAP.keySet().stream()
+              .map(t -> t.getStandardType().name()).collect(Collectors.joining(", "))));
+    }
+    return schema;
   }
 
   /**

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkTest.java
@@ -28,6 +28,7 @@ import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.TableId;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.cdap.etl.api.validation.ValidationException;
 import io.cdap.cdap.etl.api.validation.ValidationFailure;
@@ -172,19 +173,57 @@ public class BigQuerySinkTest {
   }
 
   @Test(expected = ValidationException.class)
-  public void testSchemaValidationException() throws NoSuchFieldException {
+  public void testSchemaValidationNoTruncateNoSchemaRelaxationException() throws NoSuchFieldException {
     BigQuerySink sink = getValidationTestSink(false);
     MockFailureCollector collector = new MockFailureCollector("bqsink");
     Table table = getTestSchema();
-    sink.validateSchema(table, sink.getConfig().getSchema(collector), false, collector);
+    sink.validateSchema(
+      table.getTableId().getTable(),
+      table.getDefinition().getSchema(),
+      sink.getConfig().getSchema(collector),
+      false,
+      collector);
   }
 
-  @Test
-  public void testSchemaValidationNoException() throws NoSuchFieldException {
+  @Test(expected = ValidationException.class)
+  public void testSchemaValidationTruncateNoSchemaRelaxationException() throws NoSuchFieldException {
     BigQuerySink sink = getValidationTestSink(true);
     MockFailureCollector collector = new MockFailureCollector("bqsink");
     Table table = getTestSchema();
-    sink.validateSchema(table, sink.getConfig().getSchema(collector), false, collector);
+    sink.validateSchema(
+      table.getTableId().getTable(),
+      table.getDefinition().getSchema(),
+      sink.getConfig().getSchema(collector),
+      false,
+      collector);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+  @Test
+  public void testSchemaValidationAllowSchemaRelaxationTruncateNoException() throws NoSuchFieldException {
+    BigQuerySink sink = getValidationTestSink(true);
+    MockFailureCollector collector = new MockFailureCollector("bqsink");
+    Table table = getTestSchema();
+    sink.validateSchema(
+      table.getTableId().getTable(),
+      table.getDefinition().getSchema(),
+      sink.getConfig().getSchema(collector),
+      true,
+      collector);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+  @Test(expected = ValidationException.class)
+  public void testSchemaValidationAllowSchemaRelaxationNoTruncateException() throws NoSuchFieldException {
+    BigQuerySink sink = getValidationTestSink(false);
+    MockFailureCollector collector = new MockFailureCollector("bqsink");
+    Table table = getTestSchema();
+    sink.validateSchema(
+      table.getTableId().getTable(),
+      table.getDefinition().getSchema(),
+      sink.getConfig().getSchema(collector),
+      true,
+      collector);
     Assert.assertEquals(0, collector.getValidationFailures().size());
   }
 


### PR DESCRIPTION
1. Moved BigQuery Table Schema conversion methods from BigQuerySource to BigQueryUtil so that they can be reused by BigQuerySink classes.
2. Updated AbstractBigQuerySink#validateSchema method to 

- validate schema changes when truncate table is true but allowSchemaRelaxation is false.
- ignore required fields when both allowSchemaRelaxation/truncate table are true.
- fixed null mode checking since mode is optional and uses NULLABLE by default.

3. Update BigQuerySinkTest to as per validation changes.
4. Updated BigQuerySink/MultiSink classes to always use table schema when allowSchemaRelaxation is set to false.
5. Set table schema update options if allowSchemaRelaxation is enabled.