### PR TITLE
Added Provide Service Account as JSON for Plugins: GCS Move, GCS Copy, GCS Sink, GCS MultiSink

### DIFF
--- a/docs/GCS-batchsink.md
+++ b/docs/GCS-batchsink.md
@@ -43,9 +43,13 @@ The delimiter will be ignored if the format is anything other than 'delimited'.
 
 **Location:** The location where the gcs bucket will get created. This value is ignored if the bucket already exists.
 
-**Service Account File Path**: Path on the local file system of the service account key used for
+**Service Account**  - service account key used for authorization
+
+* **File Path**: Path on the local file system of the service account key used for
 authorization. Can be set to 'auto-detect' when running on a Dataproc cluster.
 When running on other clusters, the file must be present on every node in the cluster.
+
+* **JSON**: Contents of the service account JSON file.
 
 **Output File Prefix:** Prefix for the output file name.  
 If none is given, it will default to 'part', which means all data files written by the sink will look like 

--- a/docs/GCSCopy-action.md
+++ b/docs/GCSCopy-action.md
@@ -35,9 +35,13 @@ false and an existing file would be overwritten, the pipeline will fail. This se
 protect against race conditions. If a file is written to the destination while this plugin is
 running, that file may still get overwritten.
 
-**Service Account File Path**: Path on the local file system of the service account key used for
+**Service Account**  - service account key used for authorization
+
+* **File Path**: Path on the local file system of the service account key used for
 authorization. Can be set to 'auto-detect' when running on a Dataproc cluster.
 When running on other clusters, the file must be present on every node in the cluster.
+
+* **JSON**: Contents of the service account JSON file.
 
 Example
 -------

--- a/docs/GCSMove-action.md
+++ b/docs/GCSMove-action.md
@@ -36,9 +36,13 @@ false and an existing file would be overwritten, the pipeline will fail. This se
 protect against race conditions. If a file is written to the destination while this plugin is
 running, that file may still get overwritten.
 
-**Service Account File Path**: Path on the local file system of the service account key used for
+**Service Account**  - service account key used for authorization
+
+* **File Path**: Path on the local file system of the service account key used for
 authorization. Can be set to 'auto-detect' when running on a Dataproc cluster.
 When running on other clusters, the file must be present on every node in the cluster.
+
+* **JSON**: Contents of the service account JSON file.
 
 Example
 -------

--- a/docs/GCSMultiFiles-batchsink.md
+++ b/docs/GCSMultiFiles-batchsink.md
@@ -55,9 +55,13 @@ The delimiter will be ignored if the format is anything other than 'delimited'.
 
 **Location:** The location where the gcs buckets will get created. This value is ignored if the bucket already exists.
 
-**Service Account File Path:** Path on the local file system of the service account key used for
+**Service Account**  - service account key used for authorization
+
+* **File Path**: Path on the local file system of the service account key used for
 authorization. Can be set to 'auto-detect' when running on a Dataproc cluster.
 When running on other clusters, the file must be present on every node in the cluster.
+
+* **JSON**: Contents of the service account JSON file.
 
 **Codec:** The codec to use when writing data. Must be 'none', 'snappy', 'gzip' or 'deflate', defaults to 'none'. 
 The 'avro' supports 'snappy' and 'deflate'. The parquet supports 'snappy' and 'gzip'. 

--- a/src/main/java/io/cdap/plugin/gcp/gcs/StorageClient.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/StorageClient.java
@@ -292,10 +292,11 @@ public class StorageClient {
     return String.format("gs://%s/%s", blobId.getBucket(), blobId.getName());
   }
 
-  public static StorageClient create(String project, @Nullable String serviceAccountPath) throws IOException {
+  public static StorageClient create(String project, @Nullable String serviceAccount,
+                                     Boolean isServiceAccountFilePath) throws IOException {
     StorageOptions.Builder builder = StorageOptions.newBuilder().setProjectId(project);
-    if (serviceAccountPath != null) {
-      builder.setCredentials(GCPUtils.loadServiceAccountCredentials(serviceAccountPath));
+    if (serviceAccount != null) {
+      builder.setCredentials(GCPUtils.loadServiceAccountCredentials(serviceAccount, isServiceAccountFilePath));
     }
     Storage storage = builder.build().getService();
     return new StorageClient(storage);

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSCopy.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSCopy.java
@@ -48,7 +48,15 @@ public class GCSCopy extends Action {
   public void run(ActionContext context) throws IOException {
     config.validate(context.getFailureCollector());
 
-    StorageClient storageClient = StorageClient.create(config.getProject(), config.getServiceAccountFilePath());
+    Boolean isServiceAccountFilePath = config.isServiceAccountFilePath();
+    if (isServiceAccountFilePath == null) {
+      context.getFailureCollector().addFailure("Service account type is undefined.",
+                                               "Must be `filePath` or `JSON`");
+      context.getFailureCollector().getOrThrowException();
+      return;
+    }
+    StorageClient storageClient = StorageClient.create(config.getProject(), config.getServiceAccount(),
+                                                       isServiceAccountFilePath);
     //noinspection ConstantConditions
     storageClient.copy(config.getSourcePath(), config.getDestPath(), config.recursive, config.shouldOverwrite());
   }

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
@@ -48,7 +48,15 @@ public class GCSMove extends Action {
   public void run(ActionContext context) throws IOException {
     config.validate(context.getFailureCollector());
 
-    StorageClient storageClient = StorageClient.create(config.getProject(), config.getServiceAccountFilePath());
+    Boolean isServiceAccountFilePath = config.isServiceAccountFilePath();
+    if (isServiceAccountFilePath == null) {
+      context.getFailureCollector().addFailure("Service account type is undefined.",
+                                               "Must be `filePath` or `JSON`");
+      context.getFailureCollector().getOrThrowException();
+      return;
+    }
+    StorageClient storageClient = StorageClient.create(config.getProject(), config.getServiceAccount(),
+                                                       isServiceAccountFilePath);
     //noinspection ConstantConditions
     storageClient.move(config.getSourcePath(), config.getDestPath(), config.recursive, config.shouldOverwrite());
   }

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
@@ -98,8 +98,16 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
   public void prepareRun(BatchSinkContext context) throws Exception {
     super.prepareRun(context);
     String cmekKey = context.getArguments().get(GCPUtils.CMEK_KEY);
-    Credentials credentials = config.getServiceAccountFilePath() == null ?
-                                null : GCPUtils.loadServiceAccountCredentials(config.getServiceAccountFilePath());
+
+    Boolean isServiceAccountFilePath = config.isServiceAccountFilePath();
+    if (isServiceAccountFilePath == null) {
+      context.getFailureCollector().addFailure("Service account type is undefined.",
+                                               "Must be `filePath` or `JSON`");
+      context.getFailureCollector().getOrThrowException();
+      return;
+    }
+    Credentials credentials = config.getServiceAccount() == null ?
+      null : GCPUtils.loadServiceAccountCredentials(config.getServiceAccount(), isServiceAccountFilePath);
     Storage storage = GCPUtils.getStorage(config.getProject(), credentials);
     Bucket bucket;
     try {
@@ -151,7 +159,8 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
     }
 
     try {
-      StorageClient storageClient = StorageClient.create(config.getProject(), config.getServiceAccountFilePath());
+      StorageClient storageClient = StorageClient.create(config.getProject(), config.getServiceAccount(),
+                                                         config.isServiceAccountFilePath());
       storageClient.mapMetaDataForAllBlobs(getPrefixPath(), new MetricsEmitter(context.getMetrics())::emitMetrics);
     } catch (Exception e) {
       LOG.warn("Metrics for the number of affected rows in GCS Sink maybe incorrect.", e);

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSMultiBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSMultiBatchSink.java
@@ -99,8 +99,15 @@ public class GCSMultiBatchSink extends BatchSink<StructuredRecord, NullWritable,
     Map<String, String> argumentCopy = new HashMap<>(context.getArguments().asMap());
 
     String cmekKey = context.getArguments().get(GCPUtils.CMEK_KEY);
-    Credentials credentials = config.getServiceAccountFilePath() == null ?
-      null : GCPUtils.loadServiceAccountCredentials(config.getServiceAccountFilePath());
+    Boolean isServiceAccountFilePath = config.isServiceAccountFilePath();
+    if (isServiceAccountFilePath == null) {
+      context.getFailureCollector().addFailure("Service account type is undefined.",
+                                               "Must be `filePath` or `JSON`");
+      context.getFailureCollector().getOrThrowException();
+      return;
+    }
+    Credentials credentials = config.getServiceAccount() == null ?
+      null : GCPUtils.loadServiceAccountCredentials(config.getServiceAccount(), isServiceAccountFilePath);
     Storage storage = GCPUtils.getStorage(config.getProject(), credentials);
     try {
       if (storage.get(config.getBucket()) == null) {

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSOutputFormatProvider.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSOutputFormatProvider.java
@@ -190,8 +190,16 @@ public class GCSOutputFormatProvider implements ValidatingOutputFormat {
     @VisibleForTesting
     StorageClient getStorageClient(Configuration configuration) throws IOException {
       String project = configuration.get(GCPUtils.FS_GS_PROJECT_ID);
-      String serviceAccountPath = configuration.get(GCPUtils.CLOUD_JSON_KEYFILE);
-      return StorageClient.create(project, serviceAccountPath);
+      String serviceAccount = null;
+      boolean isServiceAccountFile = GCPUtils.SERVICE_ACCOUNT_TYPE_FILE_PATH
+        .equals(configuration.get(GCPUtils.SERVICE_ACCOUNT_TYPE));
+      if (isServiceAccountFile) {
+        serviceAccount = configuration.get(GCPUtils.CLOUD_JSON_KEYFILE, null);
+      } else {
+        serviceAccount = configuration.get(String.format("%s.%s", GCPUtils.CLOUD_JSON_KEYFILE_PREFIX,
+                                                         GCPUtils.CLOUD_ACCOUNT_JSON_SUFFIX));
+      }
+      return StorageClient.create(project, serviceAccount, isServiceAccountFile);
     }
 
     @Override

--- a/widgets/GCS-batchsink.json
+++ b/widgets/GCS-batchsink.json
@@ -71,12 +71,36 @@
       "label" : "Credentials",
       "properties" : [
         {
+          "name": "serviceAccountType",
+          "label": "Service Account Type",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "filePath",
+            "options": [
+              {
+                "id": "filePath",
+                "label": "File Path"
+              },
+              {
+                "id": "JSON",
+                "label": "JSON"
+              }
+            ]
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Service Account File Path",
           "name": "serviceFilePath",
           "widget-attributes" : {
             "default": "auto-detect"
           }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Service Account JSON",
+          "name": "serviceAccountJSON"
         }
       ]
     },
@@ -125,6 +149,32 @@
         ],
         "schema-default-type": "string"
       }
+    }
+  ],
+  "filters": [
+    {
+      "name": "ServiceAuthenticationTypeFilePath",
+      "condition": {
+        "expression": "serviceAccountType == 'filePath'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "serviceFilePath"
+        }
+      ]
+    },
+    {
+      "name": "ServiceAuthenticationTypeJSON",
+      "condition": {
+        "expression": "serviceAccountType == 'JSON'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "serviceAccountJSON"
+        }
+      ]
     }
   ],
   "jump-config": {

--- a/widgets/GCSCopy-action.json
+++ b/widgets/GCSCopy-action.json
@@ -75,12 +75,62 @@
       "label" : "Credentials",
       "properties" : [
         {
+          "name": "serviceAccountType",
+          "label": "Service Account Type",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "filePath",
+            "options": [
+              {
+                "id": "filePath",
+                "label": "File Path"
+              },
+              {
+                "id": "JSON",
+                "label": "JSON"
+              }
+            ]
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Service Account File Path",
           "name": "serviceFilePath",
           "widget-attributes" : {
             "default": "auto-detect"
           }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Service Account JSON",
+          "name": "serviceAccountJSON"
+        }
+      ]
+    }
+  ],
+  "filters": [
+    {
+      "name": "ServiceAuthenticationTypeFilePath",
+      "condition": {
+        "expression": "serviceAccountType == 'filePath'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "serviceFilePath"
+        }
+      ]
+    },
+    {
+      "name": "ServiceAuthenticationTypeJSON",
+      "condition": {
+        "expression": "serviceAccountType == 'JSON'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "serviceAccountJSON"
         }
       ]
     }

--- a/widgets/GCSMove-action.json
+++ b/widgets/GCSMove-action.json
@@ -75,12 +75,62 @@
       "label" : "Credentials",
       "properties" : [
         {
+          "name": "serviceAccountType",
+          "label": "Service Account Type",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "filePath",
+            "options": [
+              {
+                "id": "filePath",
+                "label": "File Path"
+              },
+              {
+                "id": "JSON",
+                "label": "JSON"
+              }
+            ]
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Service Account File Path",
           "name": "serviceFilePath",
           "widget-attributes" : {
             "default": "auto-detect"
           }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Service Account JSON",
+          "name": "serviceAccountJSON"
+        }
+      ]
+    }
+  ],
+  "filters": [
+    {
+      "name": "ServiceAuthenticationTypeFilePath",
+      "condition": {
+        "expression": "serviceAccountType == 'filePath'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "serviceFilePath"
+        }
+      ]
+    },
+    {
+      "name": "ServiceAuthenticationTypeJSON",
+      "condition": {
+        "expression": "serviceAccountType == 'JSON'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "serviceAccountJSON"
         }
       ]
     }

--- a/widgets/GCSMultiFiles-batchsink.json
+++ b/widgets/GCSMultiFiles-batchsink.json
@@ -70,12 +70,36 @@
       "label" : "Credentials",
       "properties" : [
         {
+          "name": "serviceAccountType",
+          "label": "Service Account Type",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "filePath",
+            "options": [
+              {
+                "id": "filePath",
+                "label": "File Path"
+              },
+              {
+                "id": "JSON",
+                "label": "JSON"
+              }
+            ]
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Service Account File Path",
           "name": "serviceFilePath",
           "widget-attributes" : {
             "default": "auto-detect"
           }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Service Account JSON",
+          "name": "serviceAccountJSON"
         }
       ]
     },
@@ -146,6 +170,32 @@
         ],
         "schema-default-type": "string"
       }
+    }
+  ],
+  "filters": [
+    {
+      "name": "ServiceAuthenticationTypeFilePath",
+      "condition": {
+        "expression": "serviceAccountType == 'filePath'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "serviceFilePath"
+        }
+      ]
+    },
+    {
+      "name": "ServiceAuthenticationTypeJSON",
+      "condition": {
+        "expression": "serviceAccountType == 'JSON'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "serviceAccountJSON"
+        }
+      ]
     }
   ],
   "jump-config": {


### PR DESCRIPTION
Updated: Provide Service Account as JSON for GCS Move, GCS Copy, GCS Sink, GCS MultiSink plugins

Jira Ticket: https://issues.cask.co/browse/PLUGIN-170