### PR TITLE
Updated: Provide Service Account as JSON for GCSBucketCreate

### DIFF
--- a/docs/GCSBucketCreate-action.md
+++ b/docs/GCSBucketCreate-action.md
@@ -36,6 +36,10 @@ It can be found on the Dashboard in the Google Cloud Platform Console.
 
 **Location:** The location where the gcs buckets will get created. This value is ignored if the bucket already exists.
 
-**Service Account File Path**: Path on the local file system of the service account key used for
+**Service Account**  - service account key used for authorization
+
+* **File Path**: Path on the local file system of the service account key used for
 authorization. Can be set to 'auto-detect' when running on a Dataproc cluster.
 When running on other clusters, the file must be present on every node in the cluster.
+
+* **JSON**: Contents of the service account JSON file.

--- a/widgets/GCSBucketCreate-action.json
+++ b/widgets/GCSBucketCreate-action.json
@@ -48,12 +48,36 @@
       "label" : "Credentials",
       "properties" : [
         {
+          "name": "serviceAccountType",
+          "label": "Service Account Type",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "filePath",
+            "options": [
+              {
+                "id": "filePath",
+                "label": "File Path"
+              },
+              {
+                "id": "JSON",
+                "label": "JSON"
+              }
+            ]
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Service Account File Path",
           "name": "serviceFilePath",
           "widget-attributes" : {
             "default": "auto-detect"
           }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Service Account JSON",
+          "name": "serviceAccountJSON"
         }
       ]
     },
@@ -67,6 +91,32 @@
           "widget-attributes": {
             "default": "us"
           }
+        }
+      ]
+    }
+  ],
+  "filters": [
+    {
+      "name": "ServiceAuthenticationTypeFilePath",
+      "condition": {
+        "expression": "serviceAccountType == 'filePath'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "serviceFilePath"
+        }
+      ]
+    },
+    {
+      "name": "ServiceAuthenticationTypeJSON",
+      "condition": {
+        "expression": "serviceAccountType == 'JSON'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "serviceAccountJSON"
         }
       ]
     }


### PR DESCRIPTION
Updated: Provide Service Account as JSON for GCS Bucket Create plugin

Jira Ticket: https://issues.cask.co/browse/PLUGIN-170