### PR TITLE
Updated: Provide Service Account as JSON for GCSBucketDelete

### DIFF
--- a/docs/GCSBucketDelete-action.md
+++ b/docs/GCSBucketDelete-action.md
@@ -32,6 +32,10 @@ It can be found on the Dashboard in the Google Cloud Platform Console.
 
 **Objects to Delete**: Comma separated list of objects to delete.
 
-**Service Account File Path**: Path on the local file system of the service account key used for
+**Service Account**  - service account key used for authorization
+
+* **File Path**: Path on the local file system of the service account key used for
 authorization. Can be set to 'auto-detect' when running on a Dataproc cluster.
 When running on other clusters, the file must be present on every node in the cluster.
+
+* **JSON**: Contents of the service account JSON file.

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketDelete.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketDelete.java
@@ -16,7 +16,7 @@
 
 package io.cdap.plugin.gcp.gcs.actions;
 
-import com.google.auth.Credentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
 import io.cdap.cdap.api.annotation.Description;
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 
@@ -64,11 +65,21 @@ public final class GCSBucketDelete extends Action {
     config.validate(context.getFailureCollector());
 
     Configuration configuration = new Configuration();
-    String serviceAccountFilePath = config.getServiceAccountFilePath();
-    Credentials credentials = serviceAccountFilePath == null ?
-      null : GCPUtils.loadServiceAccountCredentials(serviceAccountFilePath);
-    if (serviceAccountFilePath != null) {
-      configuration.set("google.cloud.auth.service.account.json.keyfile", serviceAccountFilePath);
+
+    Boolean isServiceAccountFilePath = config.isServiceAccountFilePath();
+    if (isServiceAccountFilePath == null) {
+      context.getFailureCollector().addFailure("Service account type is undefined.",
+                                               "Must be `File Path` or `JSON`");
+      context.getFailureCollector().getOrThrowException();
+      return;
+    }
+    String serviceAccount = config.getServiceAccount();
+    ServiceAccountCredentials credentials = serviceAccount == null ?
+      null : GCPUtils.loadServiceAccountCredentials(serviceAccount, isServiceAccountFilePath);
+    if (serviceAccount != null) {
+      Map<String, String> map = GCPUtils.generateAuthProperties(serviceAccount, config.getServiceAccountType(),
+                                                                GCPUtils.CLOUD_JSON_KEYFILE_PREFIX);
+      map.forEach(configuration::set);
     }
     configuration.set("fs.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem");
     configuration.set("fs.AbstractFileSystem.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS");

--- a/widgets/GCSBucketDelete-action.json
+++ b/widgets/GCSBucketDelete-action.json
@@ -29,12 +29,62 @@
       "label" : "Credentials",
       "properties" : [
         {
+          "name": "serviceAccountType",
+          "label": "Service Account Type",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "filePath",
+            "options": [
+              {
+                "id": "filePath",
+                "label": "File Path"
+              },
+              {
+                "id": "JSON",
+                "label": "JSON"
+              }
+            ]
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Service Account File Path",
           "name": "serviceFilePath",
           "widget-attributes" : {
             "default": "auto-detect"
           }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Service Account JSON",
+          "name": "serviceAccountJSON"
+        }
+      ]
+    }
+  ],
+  "filters": [
+    {
+      "name": "ServiceAuthenticationTypeFilePath",
+      "condition": {
+        "expression": "serviceAccountType == 'filePath'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "serviceFilePath"
+        }
+      ]
+    },
+    {
+      "name": "ServiceAuthenticationTypeJSON",
+      "condition": {
+        "expression": "serviceAccountType == 'JSON'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "serviceAccountJSON"
         }
       ]
     }


### PR DESCRIPTION
Updated: Provide Service Account as JSON for GCS Bucket Delete plugin

Jira Ticket: https://issues.cask.co/browse/PLUGIN-170