### PR TITLE
Updated: Provide Service Account as JSON for Spanner

### DIFF
--- a/docs/Spanner-batchsink.md
+++ b/docs/Spanner-batchsink.md
@@ -40,9 +40,11 @@ If the table does not exist, it will get created.
 **Primary Key**: If the table does not exist, a primary key must be provided in order to auto-create the table.
 The key can be a composite key of multiple fields in the schema. This is not required if the table already exists.
 
-**Service Account File Path**: Path on the local file system of the service account key used for
+**Service Account**  - service account key used for authorization
+* **File Path**: Path on the local file system of the service account key used for
 authorization. Can be set to 'auto-detect' when running on a Dataproc cluster.
 When running on other clusters, the file must be present on every node in the cluster.
+* **JSON**: Contents of the service account JSON file.
 
 **Write Batch Size**: Size (in number of records) of the batched writes to the Spanner table.
 Each write to Cloud Spanner contains some overhead. To maximize bulk write throughput,

--- a/docs/Spanner-batchsource.md
+++ b/docs/Spanner-batchsource.md
@@ -36,9 +36,11 @@ Spanner database is contained within a specific Spanner instance.
 Each record is composed of columns (also called fields).
 Every table is defined by a schema that describes the column names, data types, and other information.
 
-**Service Account File Path**: Path on the local file system of the service account key used for
+**Service Account**  - service account key used for authorization
+* **File Path**: Path on the local file system of the service account key used for
 authorization. Can be set to 'auto-detect' when running on a Dataproc cluster.
 When running on other clusters, the file must be present on every node in the cluster.
+* **JSON**: Contents of the service account JSON file.
 
 **Max Partitions**: Maximum number of partitions. This may be set to the number of map tasks desired.
 The maximum value is currently 200,000. This is only a hint.

--- a/src/main/java/io/cdap/plugin/gcp/spanner/SpannerConstants.java
+++ b/src/main/java/io/cdap/plugin/gcp/spanner/SpannerConstants.java
@@ -23,7 +23,10 @@ public final class SpannerConstants {
   public static final String PROJECT_ID = "project.id";
   public static final String INSTANCE_ID = "instance.id";
   public static final String DATABASE = "database.name";
-  public static final String SERVICE_ACCOUNT_FILE_PATH = "service.account.path";
+  public static final String SERVICE_ACCOUNT_TYPE = "service.account.type";
+  public static final String SERVICE_ACCOUNT_TYPE_FILE_PATH = "serviceFilePath";
+  public static final String SERVICE_ACCOUNT_TYPE_JSON = "serviceJson";
+  public static final String SERVICE_ACCOUNT = "service.account.path";
   public static final String PARTITIONS_LIST = "partitions.list";
   public static final String QUERY = "query";
   public static final String SPANNER_BATCH_TRANSACTION_ID = "spanner.batch.transaction.id";

--- a/src/main/java/io/cdap/plugin/gcp/spanner/common/SpannerUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/spanner/common/SpannerUtil.java
@@ -37,10 +37,11 @@ public class SpannerUtil {
   /**
    * Construct and return the {@link Spanner} service for the provided credentials and projectId
    */
-  public static Spanner getSpannerService(String serviceAccountFilePath, String projectId) throws IOException {
+  public static Spanner getSpannerService(String serviceAccount, boolean isServiceAccountFilePath, String projectId)
+    throws IOException {
     SpannerOptions.Builder optionsBuilder = SpannerOptions.newBuilder();
-    if (serviceAccountFilePath != null) {
-      optionsBuilder.setCredentials(GCPUtils.loadServiceAccountCredentials(serviceAccountFilePath));
+    if (serviceAccount != null) {
+      optionsBuilder.setCredentials(GCPUtils.loadServiceAccountCredentials(serviceAccount, isServiceAccountFilePath));
     }
     optionsBuilder.setProjectId(projectId);
     return optionsBuilder.build().getService();

--- a/src/main/java/io/cdap/plugin/gcp/spanner/sink/SpannerOutputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/spanner/sink/SpannerOutputFormat.java
@@ -50,9 +50,12 @@ public class SpannerOutputFormat extends OutputFormat<NullWritable, Mutation> {
   public static void configure(Configuration configuration, SpannerSinkConfig config, Schema schema) {
     String projectId = config.getProject();
     configuration.set(SpannerConstants.PROJECT_ID, projectId);
-    String serviceAccountFilePath = config.getServiceAccountFilePath();
-    if (serviceAccountFilePath != null) {
-      configuration.set(SpannerConstants.SERVICE_ACCOUNT_FILE_PATH, serviceAccountFilePath);
+    String serviceAccount = config.getServiceAccount();
+    if (serviceAccount != null) {
+      String type = config.isServiceAccountFilePath() ? SpannerConstants.SERVICE_ACCOUNT_TYPE_FILE_PATH :
+        SpannerConstants.SERVICE_ACCOUNT_TYPE_JSON;
+      configuration.set(SpannerConstants.SERVICE_ACCOUNT_TYPE, type);
+      configuration.set(SpannerConstants.SERVICE_ACCOUNT, serviceAccount);
     }
     configuration.set(SpannerConstants.INSTANCE_ID, config.getInstance());
     configuration.set(SpannerConstants.DATABASE, config.getDatabase());
@@ -68,8 +71,12 @@ public class SpannerOutputFormat extends OutputFormat<NullWritable, Mutation> {
     String projectId = configuration.get(SpannerConstants.PROJECT_ID);
     String instanceId = configuration.get(SpannerConstants.INSTANCE_ID);
     String database = configuration.get(SpannerConstants.DATABASE);
-    String serviceFilePath = configuration.get(SpannerConstants.SERVICE_ACCOUNT_FILE_PATH);
-    Spanner spanner = SpannerUtil.getSpannerService(serviceFilePath, projectId);
+    String serviceAccountType = configuration.get(SpannerConstants.SERVICE_ACCOUNT_TYPE);
+    String serviceAccount = configuration.get(SpannerConstants.SERVICE_ACCOUNT);
+    Spanner spanner =
+      SpannerUtil.getSpannerService(serviceAccount,
+                                    SpannerConstants.SERVICE_ACCOUNT_TYPE_FILE_PATH.equals(serviceAccountType),
+                                    projectId);
     int batchSize = Integer.parseInt(configuration.get(SpannerConstants.SPANNER_WRITE_BATCH_SIZE));
     DatabaseId db = DatabaseId.of(projectId, instanceId, database);
     DatabaseClient client = spanner.getDatabaseClient(db);

--- a/src/main/java/io/cdap/plugin/gcp/spanner/sink/SpannerSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/spanner/sink/SpannerSink.java
@@ -101,7 +101,8 @@ public final class SpannerSink extends BatchSink<StructuredRecord, NullWritable,
 
     Schema schema = config.getSchema(collector);
     if (!context.isPreviewEnabled()) {
-      try (Spanner spanner = SpannerUtil.getSpannerService(config.getServiceAccountFilePath(), config.getProject())) {
+      try (Spanner spanner = SpannerUtil.getSpannerService(config.getServiceAccount(),
+                                                           config.isServiceAccountFilePath(), config.getProject())) {
         DatabaseId db = DatabaseId.of(config.getProject(), config.getInstance(), config.getDatabase());
         DatabaseClient dbClient = spanner.getDatabaseClient(db);
         DatabaseAdminClient dbAdminClient = spanner.getDatabaseAdminClient();

--- a/src/main/java/io/cdap/plugin/gcp/spanner/source/SpannerRecordReader.java
+++ b/src/main/java/io/cdap/plugin/gcp/spanner/source/SpannerRecordReader.java
@@ -52,7 +52,10 @@ public class SpannerRecordReader extends RecordReader<NullWritable, ResultSet> {
     PartitionInputSplit partitionInputSplit = (PartitionInputSplit) inputSplit;
     try {
       Configuration configuration = taskAttemptContext.getConfiguration();
-      Spanner spanner = SpannerUtil.getSpannerService(configuration.get(SpannerConstants.SERVICE_ACCOUNT_FILE_PATH),
+      boolean isServiceAccountFilePath = SpannerConstants.SERVICE_ACCOUNT_TYPE_FILE_PATH
+        .equals(configuration.get(SpannerConstants.SERVICE_ACCOUNT_TYPE));
+      Spanner spanner = SpannerUtil.getSpannerService(configuration.get(SpannerConstants.SERVICE_ACCOUNT),
+                                                      isServiceAccountFilePath,
                                                       configuration.get(SpannerConstants.PROJECT_ID));
       BatchClient batchClient = spanner.getBatchClient(
         DatabaseId.of(configuration.get(SpannerConstants.PROJECT_ID),

--- a/src/main/java/io/cdap/plugin/gcp/spanner/source/SpannerSource.java
+++ b/src/main/java/io/cdap/plugin/gcp/spanner/source/SpannerSource.java
@@ -97,7 +97,8 @@ public class SpannerSource extends BatchSource<NullWritable, ResultSet, Structur
     config.validate(collector);
     Schema configuredSchema = config.getSchema(collector);
 
-    if (!config.shouldConnect() || config.tryGetProject() == null || config.autoServiceAccountUnavailable()) {
+    if (!config.shouldConnect() || config.tryGetProject() == null
+      || (config.isServiceAccountFilePath() && config.autoServiceAccountUnavailable())) {
       stageConfigurer.setOutputSchema(configuredSchema);
       return;
     }
@@ -136,7 +137,8 @@ public class SpannerSource extends BatchSource<NullWritable, ResultSet, Structur
     initializeConfig(configuration, projectId);
 
     // initialize spanner
-    try (Spanner spanner = SpannerUtil.getSpannerService(config.getServiceAccountFilePath(), projectId)) {
+    try (Spanner spanner = SpannerUtil.getSpannerService(config.getServiceAccount(), config.isServiceAccountFilePath(),
+                                                         projectId)) {
       BatchClient batchClient =
         spanner.getBatchClient(DatabaseId.of(projectId, config.instance, config.database));
       Timestamp logicalStartTimeMicros =
@@ -189,7 +191,9 @@ public class SpannerSource extends BatchSource<NullWritable, ResultSet, Structur
 
   private void initializeConfig(Configuration configuration, String projectId) {
     setIfValueNotNull(configuration, SpannerConstants.PROJECT_ID, projectId);
-    setIfValueNotNull(configuration, SpannerConstants.SERVICE_ACCOUNT_FILE_PATH, config.getServiceAccountFilePath());
+    setIfValueNotNull(configuration, SpannerConstants.SERVICE_ACCOUNT_TYPE, config.isServiceAccountFilePath() ?
+      SpannerConstants.SERVICE_ACCOUNT_TYPE_FILE_PATH : SpannerConstants.SERVICE_ACCOUNT_TYPE_JSON);
+    setIfValueNotNull(configuration, SpannerConstants.SERVICE_ACCOUNT, config.getServiceAccount());
     setIfValueNotNull(configuration, SpannerConstants.INSTANCE_ID, config.instance);
     setIfValueNotNull(configuration, SpannerConstants.DATABASE, config.database);
     setIfValueNotNull(configuration, SpannerConstants.QUERY, String.format("Select * from %s;", config.table));
@@ -229,7 +233,8 @@ public class SpannerSource extends BatchSource<NullWritable, ResultSet, Structur
   private Schema getSchema(FailureCollector collector) {
     String projectId = config.getProject();
 
-    try (Spanner spanner = SpannerUtil.getSpannerService(config.getServiceAccountFilePath(), projectId)) {
+    try (Spanner spanner = SpannerUtil.getSpannerService(config.getServiceAccount(), config.isServiceAccountFilePath(),
+                                                         projectId)) {
       DatabaseClient databaseClient =
         spanner.getDatabaseClient(DatabaseId.of(projectId, config.instance, config.database));
       Statement getTableSchemaStatement = SCHEMA_STATEMENT_BUILDER.bind(TABLE_NAME).to(config.table).build();
@@ -255,7 +260,8 @@ public class SpannerSource extends BatchSource<NullWritable, ResultSet, Structur
       }
     } catch (IOException e) {
       collector.addFailure("Unable to get Spanner Client: " + e.getMessage(), null)
-        .withConfigProperty(GCPConfig.NAME_SERVICE_ACCOUNT_FILE_PATH);
+        .withConfigProperty(config.isServiceAccountFilePath() ?
+                              GCPConfig.NAME_SERVICE_ACCOUNT_FILE_PATH : GCPConfig.NAME_SERVICE_ACCOUNT_JSON);
       // if there was an error that was added, it will throw an exception.
       throw collector.getOrThrowException();
     }

--- a/widgets/Spanner-batchsink.json
+++ b/widgets/Spanner-batchsink.json
@@ -62,12 +62,36 @@
       "label" : "Credentials",
       "properties" : [
         {
+          "name": "serviceAccountType",
+          "label": "Service Account Type",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "filePath",
+            "options": [
+              {
+                "id": "filePath",
+                "label": "File Path"
+              },
+              {
+                "id": "JSON",
+                "label": "JSON"
+              }
+            ]
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Service Account File Path",
           "name": "serviceFilePath",
           "widget-attributes" : {
             "default": "auto-detect"
           }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Service Account JSON",
+          "name": "serviceAccountJSON"
         }
       ]
     },
@@ -81,6 +105,32 @@
           "widget-attributes" : {
             "placeholder": "Maximum number of records to buffer in RecordWriter before writing to spanner table."
           }
+        }
+      ]
+    }
+  ],
+  "filters": [
+    {
+      "name": "ServiceAuthenticationTypeFilePath",
+      "condition": {
+        "expression": "serviceAccountType == 'filePath'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "serviceFilePath"
+        }
+      ]
+    },
+    {
+      "name": "ServiceAuthenticationTypeJSON",
+      "condition": {
+        "expression": "serviceAccountType == 'JSON'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "serviceAccountJSON"
         }
       ]
     }

--- a/widgets/Spanner-batchsource.json
+++ b/widgets/Spanner-batchsource.json
@@ -71,12 +71,36 @@
       "label": "Credentials",
       "properties": [
         {
+          "name": "serviceAccountType",
+          "label": "Service Account Type",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "filePath",
+            "options": [
+              {
+                "id": "filePath",
+                "label": "File Path"
+              },
+              {
+                "id": "JSON",
+                "label": "JSON"
+              }
+            ]
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Service Account File Path",
           "name": "serviceFilePath",
           "widget-attributes" : {
             "default": "auto-detect"
           }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Service Account JSON",
+          "name": "serviceAccountJSON"
         }
       ]
     },
@@ -98,6 +122,32 @@
           "widget-attributes" : {
             "placeholder": "Partition size in Megabytes."
           }
+        }
+      ]
+    }
+  ],
+  "filters": [
+    {
+      "name": "ServiceAuthenticationTypeFilePath",
+      "condition": {
+        "expression": "serviceAccountType == 'filePath'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "serviceFilePath"
+        }
+      ]
+    },
+    {
+      "name": "ServiceAuthenticationTypeJSON",
+      "condition": {
+        "expression": "serviceAccountType == 'JSON'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "serviceAccountJSON"
         }
       ]
     }


### PR DESCRIPTION
added: Use JSON key for service account for Spanner plugins

Jira Ticket: https://issues.cask.co/browse/PLUGIN-170