### PR TITLE
PLUGIN-461: fix issue with backward incompatibility

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/action/BigQueryArgumentSetterConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/action/BigQueryArgumentSetterConfig.java
@@ -143,6 +143,7 @@ public final class BigQueryArgumentSetterConfig extends AbstractBigQueryActionCo
     return !containsMacro(NAME_DATASET)
       && !containsMacro(NAME_TABLE)
       && !containsMacro(NAME_DATASET_PROJECT)
+      && !containsMacro(NAME_SERVICE_ACCOUNT_TYPE)
       && !(containsMacro(NAME_SERVICE_ACCOUNT_FILE_PATH) || containsMacro(NAME_SERVICE_ACCOUNT_JSON))
       && !containsMacro(NAME_PROJECT)
       && !containsMacro(NAME_ARGUMENT_SELECTION_CONDITIONS)

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -86,7 +86,7 @@ public final class BigQuerySink extends AbstractBigQuerySink {
 
     config.validate(inputSchema, configuredSchema, collector);
 
-    if (config.tryGetProject() == null ||
+    if (config.tryGetProject() == null || config.getServiceAccountType() == null ||
       (config.isServiceAccountFilePath() && config.autoServiceAccountUnavailable())) {
       return;
     }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
@@ -611,6 +611,7 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
   boolean shouldConnect() {
     return !containsMacro(BigQuerySinkConfig.NAME_DATASET) &&
       !containsMacro(BigQuerySinkConfig.NAME_TABLE) &&
+      !containsMacro(NAME_SERVICE_ACCOUNT_TYPE) &&
       !(containsMacro(NAME_SERVICE_ACCOUNT_FILE_PATH) || containsMacro(NAME_SERVICE_ACCOUNT_JSON)) &&
       !containsMacro(BigQuerySinkConfig.NAME_PROJECT) &&
       !containsMacro(BigQuerySinkConfig.DATASET_PROJECT_ID) &&

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySourceConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySourceConfig.java
@@ -274,6 +274,7 @@ public final class BigQuerySourceConfig extends GCPReferenceSourceConfig {
   public boolean canConnect() {
     return !containsMacro(NAME_SCHEMA) && !containsMacro(NAME_DATASET) && !containsMacro(NAME_TABLE) &&
       !containsMacro(NAME_DATASET_PROJECT) &&
+      !containsMacro(NAME_SERVICE_ACCOUNT_TYPE) &&
       !(containsMacro(NAME_SERVICE_ACCOUNT_FILE_PATH) || containsMacro(NAME_SERVICE_ACCOUNT_JSON)) &&
       !containsMacro(NAME_PROJECT);
   }

--- a/src/main/java/io/cdap/plugin/gcp/bigtable/sink/BigtableSinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigtable/sink/BigtableSinkConfig.java
@@ -136,6 +136,7 @@ public final class BigtableSinkConfig extends GCPReferenceSinkConfig {
     return !containsMacro(INSTANCE) && Strings.isNullOrEmpty(instance)
       && !containsMacro(NAME_PROJECT) && Strings.isNullOrEmpty(project)
       && !containsMacro(TABLE) && Strings.isNullOrEmpty(table)
+      && !containsMacro(NAME_SERVICE_ACCOUNT_TYPE)
       && !(containsMacro(NAME_SERVICE_ACCOUNT_FILE_PATH) || containsMacro(NAME_SERVICE_ACCOUNT_JSON))
       && tryGetProject() != null
       && !autoServiceAccountUnavailable();

--- a/src/main/java/io/cdap/plugin/gcp/bigtable/source/BigtableSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigtable/source/BigtableSourceConfig.java
@@ -285,6 +285,7 @@ public final class BigtableSourceConfig extends GCPReferenceSourceConfig {
     return !containsMacro(INSTANCE) && Strings.isNullOrEmpty(instance)
       && !containsMacro(NAME_PROJECT) && Strings.isNullOrEmpty(project)
       && !containsMacro(TABLE) && Strings.isNullOrEmpty(table)
+      && !containsMacro(NAME_SERVICE_ACCOUNT_TYPE)
       && !(containsMacro(NAME_SERVICE_ACCOUNT_FILE_PATH) || containsMacro(NAME_SERVICE_ACCOUNT_JSON));
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/common/GCPConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCPConfig.java
@@ -89,18 +89,24 @@ public class GCPConfig extends PluginConfig {
     return serviceAccountJson;
   }
 
+  /**
+   * @return Service Account Type, defaults to filePath.
+   */
+  @Nullable
   public String getServiceAccountType() {
-    if (containsMacro(NAME_SERVICE_ACCOUNT_TYPE) || Strings.isNullOrEmpty(serviceAccountType)) {
+    if (containsMacro(NAME_SERVICE_ACCOUNT_TYPE)) {
       return null;
     }
-    return serviceAccountType;
+    return Strings.isNullOrEmpty(serviceAccountType) ? SERVICE_ACCOUNT_FILE_PATH : serviceAccountType;
   }
 
+  @Nullable
   public Boolean isServiceAccountJson() {
     String serviceAccountType = getServiceAccountType();
     return Strings.isNullOrEmpty(serviceAccountType) ? null : serviceAccountType.equals(SERVICE_ACCOUNT_JSON);
   }
 
+  @Nullable
   public Boolean isServiceAccountFilePath() {
     String serviceAccountType = getServiceAccountType();
     return Strings.isNullOrEmpty(serviceAccountType) ? null : serviceAccountType.equals(SERVICE_ACCOUNT_FILE_PATH);

--- a/src/main/java/io/cdap/plugin/gcp/common/GCPUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCPUtils.java
@@ -101,14 +101,19 @@ public class GCPUtils {
                                                            String serviceAccountType,
                                                            String... keyPrefix) throws IOException {
     Map<String, String> properties = new HashMap<>();
+    if (serviceAccountType == null) {
+      return properties;
+    }
     String privateKeyData = null;
     properties.put(SERVICE_ACCOUNT_TYPE, serviceAccountType);
 
     boolean isServiceAccountFilePath = SERVICE_ACCOUNT_TYPE_FILE_PATH.equals(serviceAccountType);
 
     for (String prefix : keyPrefix) {
-      if (isServiceAccountFilePath && serviceAccount != null) {
-        properties.put(String.format("%s.%s", prefix, CLOUD_JSON_KEYFILE_SUFFIX), serviceAccount);
+      if (isServiceAccountFilePath) {
+        if (serviceAccount != null) {
+          properties.put(String.format("%s.%s", prefix, CLOUD_JSON_KEYFILE_SUFFIX), serviceAccount);
+        }
         continue;
       }
       ServiceAccountCredentials credentials = loadServiceAccountCredentials(serviceAccount, false);

--- a/src/main/java/io/cdap/plugin/gcp/datastore/sink/DatastoreSinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/datastore/sink/DatastoreSinkConfig.java
@@ -402,6 +402,7 @@ public class DatastoreSinkConfig extends GCPReferenceSinkConfig {
   public boolean shouldConnect() {
     return !(containsMacro(DatastoreSourceConfig.NAME_SERVICE_ACCOUNT_FILE_PATH) ||
       containsMacro(DatastoreSourceConfig.NAME_SERVICE_ACCOUNT_JSON)) &&
+      !containsMacro(NAME_SERVICE_ACCOUNT_TYPE) &&
       !containsMacro(DatastoreSourceConfig.NAME_PROJECT) &&
       tryGetProject() != null &&
       !autoServiceAccountUnavailable();

--- a/src/main/java/io/cdap/plugin/gcp/datastore/source/DatastoreSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/datastore/source/DatastoreSourceConfig.java
@@ -559,6 +559,7 @@ public class DatastoreSourceConfig extends GCPReferenceSourceConfig {
    */
   boolean shouldConnect() {
     return !containsMacro(DatastoreSourceConstants.PROPERTY_SCHEMA) &&
+      !containsMacro(NAME_SERVICE_ACCOUNT_TYPE) &&
       !(containsMacro(DatastoreSourceConfig.NAME_SERVICE_ACCOUNT_FILE_PATH) ||
         containsMacro(DatastoreSourceConfig.NAME_SERVICE_ACCOUNT_JSON)) &&
       !containsMacro(DatastoreSourceConfig.NAME_PROJECT) &&

--- a/src/main/java/io/cdap/plugin/gcp/spanner/source/SpannerSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/spanner/source/SpannerSourceConfig.java
@@ -115,7 +115,9 @@ public class SpannerSourceConfig extends GCPReferenceSourceConfig {
   public boolean shouldConnect() {
     return !containsMacro(SpannerSourceConfig.NAME_SCHEMA) && !containsMacro(SpannerSourceConfig.NAME_DATABASE) &&
       !containsMacro(SpannerSourceConfig.NAME_TABLE) && !containsMacro(SpannerSourceConfig.NAME_INSTANCE) &&
-      !containsMacro(SpannerSourceConfig.NAME_SERVICE_ACCOUNT_FILE_PATH) &&
+      !containsMacro(NAME_SERVICE_ACCOUNT_TYPE) &&
+      !(containsMacro(SpannerSourceConfig.NAME_SERVICE_ACCOUNT_FILE_PATH) ||
+        containsMacro(SpannerSourceConfig.NAME_SERVICE_ACCOUNT_JSON)) &&
       !containsMacro(SpannerSourceConfig.NAME_PROJECT) && !containsMacro(SpannerSourceConfig.NAME_IMPORT_QUERY);
   }
 }

--- a/src/test/java/io/cdap/plugin/gcp/common/GCPConfigTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/common/GCPConfigTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.gcp.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.internal.util.reflection.FieldSetter;
+
+/**
+ * Tests for {@link GCPConfig}
+ */
+public class GCPConfigTest {
+
+  @Test
+  public void testNullServiceAccountType() throws NoSuchFieldException {
+    GCPConfig gcpConfig = new GCPConfig();
+    FieldSetter.setField(gcpConfig, GCPConfig.class.getDeclaredField("serviceAccountType"), null);
+    Assert.assertEquals(gcpConfig.getServiceAccountType(), GCPConfig.SERVICE_ACCOUNT_FILE_PATH);
+  }
+
+  @Test
+  public void testIsServiceAccountFilePath() throws NoSuchFieldException {
+    GCPConfig gcpConfig = new GCPConfig();
+    FieldSetter.setField(gcpConfig, GCPConfig.class.getDeclaredField("serviceFilePath"), "test-path");
+    Assert.assertEquals(gcpConfig.isServiceAccountFilePath(), true);
+  }
+
+  @Test
+  public void testFilePathServiceAccountWithoutAccountType() throws NoSuchFieldException {
+    GCPConfig gcpConfig = new GCPConfig();
+    FieldSetter.setField(gcpConfig, GCPConfig.class.getDeclaredField("serviceFilePath"), "test-path");
+    Assert.assertEquals(gcpConfig.getServiceAccountType(), GCPConfig.SERVICE_ACCOUNT_FILE_PATH);
+  }
+}


### PR DESCRIPTION
1. if property ``serviceAccountType`` is null and is not macro fallback to ``filePath``
2. Handle macro for serviceAccountType