### PR TITLE
Bug Fix: service account file path set to auto-detect

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSArgumentSetter.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSArgumentSetter.java
@@ -106,12 +106,12 @@ public final class GCSArgumentSetter extends Action {
   }
 
   private static Storage getStorage(GCSArgumentSetterConfig config) throws IOException {
-    return StorageOptions.newBuilder()
-      .setProjectId(config.getProject())
-      .setCredentials(GCPUtils.loadServiceAccountCredentials(config.getServiceAccount(),
-                                                             config.isServiceAccountFilePath()))
-      .build()
-      .getService();
+    String serviceAccount = config.getServiceAccount();
+    StorageOptions.Builder builder = StorageOptions.newBuilder().setProjectId(config.getProject());
+    if (serviceAccount != null) {
+      builder.setCredentials(GCPUtils.loadServiceAccountCredentials(serviceAccount, config.isServiceAccountFilePath()));
+    }
+    return builder.build().getService();
   }
 
   public static String getContent(GCSArgumentSetterConfig config) throws IOException {

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSArgumentSetterConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSArgumentSetterConfig.java
@@ -56,7 +56,8 @@ public final class GCSArgumentSetterConfig extends GCPConfig {
       }
     }
 
-    if (isServiceAccountJson()
+    Boolean isServiceAccountJson = isServiceAccountJson();
+    if (isServiceAccountJson != null && isServiceAccountJson
       && !containsMacro(NAME_SERVICE_ACCOUNT_JSON)
       && Strings.isNullOrEmpty(getServiceAccountJson())) {
       collector


### PR DESCRIPTION
Fix issue when service account is set to filePath and the service account file path set to auto-detect.
Jira Task: https://issues.cask.co/browse/PLUGIN-481

Test scenario: 
1. Service account type filePath: with service account file provided, with service account set as auto-detect, with both as macro
2. Service account type JSON: with service account JSON provided, with service account JSON as macro, with both as macro