### PR TITLE
[PLUGIN-474] Fixed BigQuery Plugins Not Deleting Temporary Files

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -131,7 +131,7 @@ public final class BigQuerySink extends AbstractBigQuerySink {
     }
   }
 
-  private void recordMetric(boolean succeeded, BatchSinkContext context) {
+  void recordMetric(boolean succeeded, BatchSinkContext context) {
     if (!succeeded) {
       return;
     }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySource.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySource.java
@@ -49,6 +49,7 @@ import io.cdap.plugin.gcp.common.GCPUtils;
 import org.apache.avro.generic.GenericData;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Job;
@@ -147,7 +148,7 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
                             cmekKey);
     }
 
-    configuration.set("fs.gs.system.bucket", bucket);
+    configuration.set("fs.default.name", String.format("gs://%s/%s/", bucket, uuid));
     configuration.setBoolean("fs.gs.impl.disable.cache", true);
     configuration.setBoolean("fs.gs.metadata.cache.enable", false);
 
@@ -171,7 +172,7 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
       configuration.set(BigQueryConstants.CONFIG_VIEW_MATERIALIZATION_DATASET, config.getViewMaterializationDataset());
     }
 
-    String temporaryGcsPath = String.format("gs://%s/hadoop/input/%s", bucket, uuid);
+    String temporaryGcsPath = String.format("gs://%s/%s/hadoop/input/%s", bucket, uuid, uuid);
     PartitionedBigQueryInputFormat.setTemporaryCloudStorageDirectory(configuration, temporaryGcsPath);
     BigQueryConfiguration.configureBigQueryInput(configuration, config.getDatasetProject(),
                                                  config.getDataset(), config.getTable());
@@ -210,16 +211,21 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
 
   @Override
   public void onRunFinish(boolean succeeded, BatchSourceContext context) {
-    org.apache.hadoop.fs.Path gcsPath = new org.apache.hadoop.fs.Path(String.format("gs://%s", uuid.toString()));
+    org.apache.hadoop.fs.Path gcsPath = null;
+    String bucket = config.getBucket();
+    if (bucket == null) {
+      gcsPath = new Path(String.format("gs://%s/%s", uuid, uuid));
+    } else {
+      gcsPath = new Path(String.format("gs://%s/%s", bucket, uuid));
+    }
     try {
-      if (config.getBucket() == null) {
-        FileSystem fs = gcsPath.getFileSystem(configuration);
-        if (fs.exists(gcsPath)) {
-          fs.delete(gcsPath, true);
-        }
+      FileSystem fs = gcsPath.getFileSystem(configuration);
+      if (fs.exists(gcsPath)) {
+        fs.delete(gcsPath, true);
+        LOG.debug("Deleted temporary directory '{}'", gcsPath);
       }
     } catch (IOException e) {
-      LOG.warn("Failed to delete bucket " + gcsPath.toUri().getPath() + ", " + e.getMessage());
+      LOG.warn("Failed to delete temporary directory '{}': {}", gcsPath, e.getMessage());
     }
   }
 

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkTest.java
@@ -28,7 +28,6 @@ import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.TableId;
 import io.cdap.cdap.api.data.schema.Schema;
-import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.cdap.etl.api.validation.ValidationException;
 import io.cdap.cdap.etl.api.validation.ValidationFailure;
@@ -120,7 +119,7 @@ public class BigQuerySinkTest {
     BigQuerySink sink = getSinkToTest(mockJob);
     MockStageMetrics mockStageMetrics = Mockito.spy(new MockStageMetrics("test"));
     BatchSinkContext context = getContextWithMetrics(mockStageMetrics);
-    sink.onRunFinish(true, context);
+    sink.recordMetric(true, context);
     if (expectedCount > -1) {
       Assert.assertEquals(expectedCount, mockStageMetrics.getCount(AbstractBigQuerySink.RECORDS_UPDATED_METRIC));
     }


### PR DESCRIPTION
See [PLUGIN-474](https://issues.cask.co/browse/PLUGIN-474) for more information.

Currently, when a user specifies a temporary bucket for BigQuery plugins, the Avro temporary files left behind are not cleaned up. This PR solves this problem by making the following changes:
 - Change from using the deprecated [`fs.gs.system.bucket`](https://storage.googleapis.com/hadoop-conf/gcs-core-default.xml) to use [`fs.default.name`](https://hadoop.apache.org/docs/r1.2.1/core-default.html) so that we can specify the subdirectory of a GCS bucket as the Hadoop FS base path
 - Create a new temporary subdirectory in the GCS bucket, whether the created temporary bucket or the user provided bucket, using the run ID as the name, and set the Hadoop base path using this temporary subdirectory
 - Delete the temporary subdirectory after all runs