### PR TITLE
[CDAP-17423] Use upsert when writing to datastore

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/datastore/sink/DatastoreRecordWriter.java
+++ b/src/main/java/io/cdap/plugin/gcp/datastore/sink/DatastoreRecordWriter.java
@@ -118,7 +118,7 @@ public class DatastoreRecordWriter extends RecordWriter<NullWritable, Entity> {
         .build();
       builder.addMutations(DatastoreHelper.makeInsert(fullEntity).build());
     } else {
-      builder.addMutations(DatastoreHelper.makeInsert(entity).build());
+      builder.addMutations(DatastoreHelper.makeUpsert(entity).build());
     }
     ++totalCount;
     ++numberOfRecordsInBatch;


### PR DESCRIPTION
Insert fails if a record with the same key already exists. Use upsert instead to handle this case.