### PR TITLE
fix: PLUGIN-481 Write nullable array as empty array

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
@@ -527,9 +527,11 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, A
   }
 
   private Field.Mode getMode(Schema schema) {
-    if (schema.isNullable()) {
+    boolean isNullable = schema.isNullable();
+    Schema.Type nonNullableType = isNullable ? schema.getNonNullable().getType() : schema.getType();
+    if (isNullable && nonNullableType != Schema.Type.ARRAY) {
       return Field.Mode.NULLABLE;
-    } else if (schema.getType() == Schema.Type.ARRAY) {
+    } else if (nonNullableType == Schema.Type.ARRAY) {
       return Field.Mode.REPEATED;
     }
     return Field.Mode.REQUIRED;

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
@@ -406,7 +406,7 @@ public final class BigQueryUtil {
   }
 
   /**
-   * Validates schema of type array. BigQuery does not allow nullable arrays or nullable type within array.
+   * Validates schema of type array. BigQuery does not allow nullable type within array.
    *
    * @param arraySchema schema of array field
    * @param name name of the array field
@@ -415,12 +415,8 @@ public final class BigQueryUtil {
    */
   @Nullable
   public static ValidationFailure validateArraySchema(Schema arraySchema, String name, FailureCollector collector) {
-    if (arraySchema.isNullable()) {
-      return collector.addFailure(String.format("Field '%s' is of type array.", name),
-                                  "Change the field to be non-nullable.");
-    }
-
-    Schema componentSchema = arraySchema.getComponentSchema();
+    Schema nonNullableSchema = arraySchema.isNullable() ? arraySchema.getNonNullable() : arraySchema;
+    Schema componentSchema = nonNullableSchema.getComponentSchema();
     if (componentSchema.isNullable()) {
       return collector.addFailure(String.format("Field '%s' contains null values in its array.", name),
                                   "Change the array component type to be non-nullable.");


### PR DESCRIPTION
Regardless if array is nullable or not set mode to REPEATED, in case when array is null in BigQuery there will be empty array

Tests: 
   For BigQuery Sink:

1. Verify that with this dataset example pipeline fails:
```
       {"id":1,"names":["JKimiohn","Jane"]}
       {"id":2,"names":null} 
```
2. Do the code change, check in BigQuery table there are 2 rows and row with id 2 has empty value 
3. Verify also that nonnullable array is not broken  with this dataset example:
```
{"id":1,"names":["JKimiohn","Jane"]}
{"id":2,"names":["JKimiohn"]}

```
 For BigQueryMultiSink:

 1. Verify that with this dataset example pipeline fails
```
   {"id":1,"names":["JKimiohn","Jane"],"table":"table_a"}
   {"id":2,"names":null,"table":"table_b"} 
```
2. Do the code change, check in BigQuery if `table_b` has row with id 2 and names are empty 
3. Verify also that nonnullable array is not broken with this dataset example:
```
{"id":1,"names":["JKimiohn","Jane"],"table":"table_a"}
{"id":2,"names":["Jane"],"table":"table_b"}
```
   
  


JiraTicket: https://cdap.atlassian.net/browse/PLUGIN-403