### PR TITLE
[PLUGIN-204] fix gcs sink error message

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
@@ -312,7 +312,7 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
         try {
           new SimpleDateFormat(suffix);
         } catch (IllegalArgumentException e) {
-          collector.addFailure("Invalid suffix : " + e.getMessage(), null)
+          collector.addFailure("Invalid suffix.", "Ensure provided suffix is valid.")
             .withConfigProperty(NAME_SUFFIX).withStacktrace(e.getStackTrace());
         }
       }


### PR DESCRIPTION
Improving error message in gcs sink in case path suffix is not correct
![image](https://user-images.githubusercontent.com/14131070/102316691-39c09c80-3f2b-11eb-9cdb-2284763c711b.png)
