### PR TITLE
[CDAP-17473] Fix gcs source auto schema detection

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/gcs/source/GCSSource.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/source/GCSSource.java
@@ -94,7 +94,8 @@ public class GCSSource extends AbstractFileSource<GCSSource.GCSSourceConfig> {
   @Override
   protected boolean shouldGetSchema() {
     return !config.containsMacro(GCSSourceConfig.NAME_PROJECT) && !config.containsMacro(GCSSourceConfig.NAME_PATH) &&
-      !config.containsMacro(GCSSourceConfig.NAME_FORMAT) &&
+      !config.containsMacro(GCSSourceConfig.NAME_FORMAT) && !config.containsMacro(GCSSourceConfig.NAME_DELIMITER) &&
+      !config.containsMacro(GCSSourceConfig.NAME_FILE_SYSTEM_PROPERTIES) &&
       !config.containsMacro(GCSSourceConfig.NAME_SERVICE_ACCOUNT_FILE_PATH) &&
       !config.containsMacro(GCSSourceConfig.NAME_SERVICE_ACCOUNT_JSON);
   }
@@ -108,6 +109,7 @@ public class GCSSource extends AbstractFileSource<GCSSource.GCSSourceConfig> {
     private static final String NAME_FILE_SYSTEM_PROPERTIES = "fileSystemProperties";
     private static final String NAME_FILE_REGEX = "fileRegex";
     private static final String NAME_FORMAT = "format";
+    private static final String NAME_DELIMITER = "delimiter";
 
     private static final String DEFAULT_ENCRYPTED_METADATA_SUFFIX = ".metadata";
 

--- a/src/main/java/io/cdap/plugin/gcp/gcs/source/GCSSource.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/source/GCSSource.java
@@ -91,6 +91,14 @@ public class GCSSource extends AbstractFileSource<GCSSource.GCSSourceConfig> {
                                                      config.isEncrypted() ? " and decrypt " : " "), outputFields);
   }
 
+  @Override
+  protected boolean shouldGetSchema() {
+    return !config.containsMacro(GCSSourceConfig.NAME_PROJECT) && !config.containsMacro(GCSSourceConfig.NAME_PATH) &&
+      !config.containsMacro(GCSSourceConfig.NAME_FORMAT) &&
+      !config.containsMacro(GCSSourceConfig.NAME_SERVICE_ACCOUNT_FILE_PATH) &&
+      !config.containsMacro(GCSSourceConfig.NAME_SERVICE_ACCOUNT_JSON);
+  }
+
   /**
    * Config for the plugin.
    */


### PR DESCRIPTION
Fixing schema auto detection in GCS source when project/path is a macro

![image](https://user-images.githubusercontent.com/14131070/102454341-b4082400-3ff2-11eb-8d83-9fa4489b6131.png)


![image](https://user-images.githubusercontent.com/14131070/102454873-85d71400-3ff3-11eb-99fc-5e5ef4d66b54.png)


