### PR TITLE
CherryPick release/0.16 for PLUGIN-520 Set Column Mapping as a required field in BigTable source

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigtable/source/BigtableSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigtable/source/BigtableSourceConfig.java
@@ -89,7 +89,6 @@ public final class BigtableSourceConfig extends GCPReferenceSourceConfig {
   @Description("Mappings from Bigtable column name to record field. " +
     "Column names must be formatted as <family>:<qualifier>.")
   @Macro
-  @Nullable
   final String columnMappings;
 
   @Name(SCAN_ROW_START)


### PR DESCRIPTION
Cherry pick of https://github.com/data-integrations/google-cloud/pull/465 into the release/0.16 branch