### PR TITLE
[PLUGIN-518] Datastore namespace doc fix

### DIFF
--- a/docs/Datastore-batchsink.md
+++ b/docs/Datastore-batchsink.md
@@ -21,7 +21,7 @@ Properties
 **Reference Name:** Name used to uniquely identify this sink for lineage, annotating metadata, etc.
 
 **Namespace:** Namespace of the entities to write. A namespace partitions entities into a subset of Cloud Datastore. 
-If no value is provided, the `[default]` namespace will be used. 
+If no value is provided, the `default` namespace will be used. 
 
 **Kind:** Kind of entities to write. Kinds are used to categorize entities in Cloud Datastore. 
 A kind is equivalent to the relational database table notion.

--- a/docs/Datastore-batchsource.md
+++ b/docs/Datastore-batchsource.md
@@ -21,7 +21,7 @@ Properties
 **Reference Name:** Name used to uniquely identify this source for lineage, annotating metadata, etc.
 
 **Namespace:** Namespace of the entities to read. A namespace partitions entities into a subset of Cloud Datastore. 
-If no value is provided, the `[default]` namespace will be used.
+If no value is provided, the `default` namespace will be used.
 
 **Kind:** Kind of entities to read. Kinds are used to categorize entities in Cloud Datastore. 
 A kind is equivalent to the relational database table notion.

--- a/src/main/java/io/cdap/plugin/gcp/datastore/sink/DatastoreSinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/datastore/sink/DatastoreSinkConfig.java
@@ -29,6 +29,7 @@ import io.cdap.plugin.gcp.datastore.sink.util.DatastoreSinkConstants;
 import io.cdap.plugin.gcp.datastore.sink.util.IndexStrategy;
 import io.cdap.plugin.gcp.datastore.sink.util.SinkKeyType;
 import io.cdap.plugin.gcp.datastore.source.DatastoreSourceConfig;
+import io.cdap.plugin.gcp.datastore.source.util.DatastoreSourceConstants;
 import io.cdap.plugin.gcp.datastore.util.DatastorePropertyUtil;
 import io.cdap.plugin.gcp.datastore.util.DatastoreUtil;
 
@@ -50,7 +51,7 @@ public class DatastoreSinkConfig extends GCPReferenceSinkConfig {
   @Macro
   @Nullable
   @Description("Namespace of the entities to write. A namespace partitions entities into a subset of Cloud Datastore."
-    + "If no value is provided, the [default] namespace will be used.")
+    + "If no value is provided, the `default` namespace will be used.")
   private String namespace;
 
   @Name(DatastoreSinkConstants.PROPERTY_KIND)
@@ -404,6 +405,9 @@ public class DatastoreSinkConfig extends GCPReferenceSinkConfig {
       containsMacro(DatastoreSourceConfig.NAME_SERVICE_ACCOUNT_JSON)) &&
       !containsMacro(NAME_SERVICE_ACCOUNT_TYPE) &&
       !containsMacro(DatastoreSourceConfig.NAME_PROJECT) &&
+      !containsMacro(DatastoreSourceConstants.PROPERTY_KIND) &&
+      !containsMacro(DatastoreSourceConstants.PROPERTY_NAMESPACE) &&
+      !containsMacro(DatastoreSourceConstants.PROPERTY_ANCESTOR) &&
       tryGetProject() != null &&
       !autoServiceAccountUnavailable();
   }

--- a/src/main/java/io/cdap/plugin/gcp/datastore/source/DatastoreSource.java
+++ b/src/main/java/io/cdap/plugin/gcp/datastore/source/DatastoreSource.java
@@ -105,9 +105,9 @@ public class DatastoreSource extends BatchSource<NullWritable, Entity, Structure
       return;
     }
 
-    Schema schema = getSchema(collector);
     if (configuredSchema == null) {
-      stageConfigurer.setOutputSchema(schema);
+      configuredSchema = getSchema(collector);
+      stageConfigurer.setOutputSchema(configuredSchema);
       return;
     }
 

--- a/src/main/java/io/cdap/plugin/gcp/datastore/source/DatastoreSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/datastore/source/DatastoreSourceConfig.java
@@ -62,7 +62,7 @@ public class DatastoreSourceConfig extends GCPReferenceSourceConfig {
   @Macro
   @Nullable
   @Description("Namespace of the entities to read. A namespace partitions entities into a subset of Cloud Datastore. "
-    + "If no value is provided, the `[default]` namespace will be used.")
+    + "If no value is provided, the `default` namespace will be used.")
   private String namespace;
 
   @Name(DatastoreSourceConstants.PROPERTY_KIND)
@@ -564,6 +564,9 @@ public class DatastoreSourceConfig extends GCPReferenceSourceConfig {
       !(containsMacro(DatastoreSourceConfig.NAME_SERVICE_ACCOUNT_FILE_PATH) ||
         containsMacro(DatastoreSourceConfig.NAME_SERVICE_ACCOUNT_JSON)) &&
       !containsMacro(DatastoreSourceConfig.NAME_PROJECT) &&
+      !containsMacro(DatastoreSourceConstants.PROPERTY_KIND) &&
+      !containsMacro(DatastoreSourceConstants.PROPERTY_NAMESPACE) &&
+      !containsMacro(DatastoreSourceConstants.PROPERTY_ANCESTOR) &&
       tryGetProject() != null &&
       !autoServiceAccountUnavailable();
   }

--- a/src/main/java/io/cdap/plugin/gcp/datastore/util/DatastorePropertyUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/datastore/util/DatastorePropertyUtil.java
@@ -43,7 +43,7 @@ public class DatastorePropertyUtil {
    * @return valid namespace value
    */
   public static String getNamespace(@Nullable String namespace) {
-    return Strings.isNullOrEmpty(namespace) ? DEFAULT_NAMESPACE : namespace;
+    return Strings.isNullOrEmpty(namespace) || namespace.equalsIgnoreCase("default") ? DEFAULT_NAMESPACE : namespace;
   }
 
   /**


### PR DESCRIPTION
1. Fix datastore doc 
2. Fix bug where namespace with value `default` was throwing error. The fix is to use empty string when namespace value is `default`
3. Fix bug when datastore kind is a macro, null error is thrown