### PR TITLE
PLUGIN-514 fix spanner source getSchema and correctly fix PLUGIN-251

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/spanner/source/SpannerSource.java
+++ b/src/main/java/io/cdap/plugin/gcp/spanner/source/SpannerSource.java
@@ -183,7 +183,9 @@ public class SpannerSource extends BatchSource<NullWritable, ResultSet, Structur
   @Override
   public void initialize(BatchRuntimeContext context) throws Exception {
     super.initialize(context);
-    schema = context.getOutputSchema();
+    // this will be null if schema is macro enabled or not set at configure time
+    Schema configuredSchema = context.getOutputSchema();
+    schema = configuredSchema == null ? getSchema(context.getFailureCollector()) : configuredSchema;
     transformer = new ResultSetToRecordTransformer(schema);
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/spanner/source/SpannerSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/spanner/source/SpannerSourceConfig.java
@@ -84,10 +84,6 @@ public class SpannerSourceConfig extends GCPReferenceSourceConfig {
     if (!containsMacro(NAME_SCHEMA) && schema != null) {
       SpannerUtil.validateSchema(schema, SUPPORTED_TYPES, collector);
     }
-    if (!containsMacro(NAME_SCHEMA) && schema == null) {
-      collector.addFailure("Invalid schema.", "Ensure the schema is provided.")
-              .withConfigProperty(NAME_SCHEMA);
-    }
     if (!containsMacro(NAME_MAX_PARTITIONS) && maxPartitions != null && maxPartitions < 1) {
       collector.addFailure("Invalid max partitions.", "Ensure the value is a positive number.")
         .withConfigProperty(NAME_MAX_PARTITIONS);


### PR DESCRIPTION
We shouldn't enforce the schema in configure time, instead we should get the actual schema at runtime if it is not provided