### PR TITLE
[PLUGIN-522] Fix macro for bigtable sink

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigtable/sink/BigtableSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigtable/sink/BigtableSink.java
@@ -174,9 +174,9 @@ public final class BigtableSink extends BatchSink<StructuredRecord, ImmutableByt
   }
 
   private void validateInputSchema(Schema inputSchema, FailureCollector collector) {
-    if (inputSchema.getField(config.keyAlias) == null) {
+    if (!config.containsMacro(BigtableSinkConfig.KEY_ALIAS) && inputSchema.getField(config.keyAlias) == null) {
       collector.addFailure(
-        String.format("Field '%s' declared as key alias does not exist in input schema", config.keyAlias),
+        String.format("Field '%s' declared as key alias does not exist in input schema.", config.keyAlias),
         "Specify input field name as key alias.").withConfigProperty(BigtableSinkConfig.KEY_ALIAS);
     }
     List<Schema.Field> fields = inputSchema.getFields();


### PR DESCRIPTION
Fix bigtable sink when key alias is a macro.

![image](https://user-images.githubusercontent.com/14131070/103611409-10b27c80-4ed7-11eb-880e-10936cd6d919.png)
