### PR TITLE
[PLUGIN-521] [Cherrypick] Fixed issue with macros on the Key Type property for the Datastore plugin

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/datastore/source/DatastoreSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/datastore/source/DatastoreSourceConfig.java
@@ -561,12 +561,14 @@ public class DatastoreSourceConfig extends GCPReferenceSourceConfig {
   boolean shouldConnect() {
     return !containsMacro(DatastoreSourceConstants.PROPERTY_SCHEMA) &&
       !containsMacro(NAME_SERVICE_ACCOUNT_TYPE) &&
-      !(containsMacro(DatastoreSourceConfig.NAME_SERVICE_ACCOUNT_FILE_PATH) ||
-        containsMacro(DatastoreSourceConfig.NAME_SERVICE_ACCOUNT_JSON)) &&
+      !containsMacro(DatastoreSourceConfig.NAME_SERVICE_ACCOUNT_FILE_PATH) &&
+      !containsMacro(DatastoreSourceConfig.NAME_SERVICE_ACCOUNT_JSON) &&
       !containsMacro(DatastoreSourceConfig.NAME_PROJECT) &&
       !containsMacro(DatastoreSourceConstants.PROPERTY_KIND) &&
       !containsMacro(DatastoreSourceConstants.PROPERTY_NAMESPACE) &&
       !containsMacro(DatastoreSourceConstants.PROPERTY_ANCESTOR) &&
+      !containsMacro(DatastoreSourceConstants.PROPERTY_KEY_TYPE) &&
+      !containsMacro(DatastoreSourceConstants.PROPERTY_KEY_ALIAS) &&
       tryGetProject() != null &&
       !autoServiceAccountUnavailable();
   }


### PR DESCRIPTION
Cherrypick into 0.16 release branch.