### PR TITLE
Add properties for GCS schema detection

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/gcs/source/GCSSource.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/source/GCSSource.java
@@ -213,6 +213,17 @@ public class GCSSource extends AbstractFileSource<GCSSource.GCSSourceConfig> {
       + "The default is '" + DEFAULT_ENCRYPTED_METADATA_SUFFIX + "'.")
     private String encryptedMetadataSuffix;
 
+    @Macro
+    @Nullable
+    @Description("A list of columns with the corresponding data types for whom the automatic data type detection gets" +
+      " skipped.")
+    private String override;
+
+    @Macro
+    @Nullable
+    @Description("The maximum number of rows that will get investigated for automatic data type detection.")
+    private Long sampleSize;
+
     public GCSSourceConfig() {
       this.maxSplitSize = 128L * 1024 * 1024;
       this.recursive = false;

--- a/widgets/GCSFile-batchsource.json
+++ b/widgets/GCSFile-batchsource.json
@@ -45,6 +45,44 @@
           "name": "format",
           "widget-attributes": {
             "plugin-type": "validatingInputFormat"
+          }
+        },
+        {
+          "widget-type": "number",
+          "label": "Sample Size",
+          "name": "sampleSize",
+          "widget-attributes": {
+            "default": "1000",
+            "minimum": "1"
+          }
+        },
+        {
+          "widget-type": "keyvalue-dropdown",
+          "label": "Override",
+          "name": "override",
+          "widget-attributes": {
+            "key-placeholder": "Field Name",
+            "value-placeholder": "Data Type",
+            "dropdownOptions": [
+              "boolean",
+              "bytes",
+              "double",
+              "float",
+              "int",
+              "long",
+              "string",
+              "date",
+              "time",
+              "timestamp"
+            ]
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Delimiter",
+          "name": "delimiter",
+          "widget-attributes": {
+            "placeholder": "Delimiter if the format is 'delimited'"
           },
           "plugin-function": {
             "method": "POST",
@@ -55,14 +93,6 @@
             ],
             "missing-required-fields-message": "Please provide path field",
             "plugin-method": "getSchema"
-          }
-        },
-        {
-          "widget-type": "textbox",
-          "label": "Delimiter",
-          "name": "delimiter",
-          "widget-attributes": {
-            "placeholder": "Delimiter if the format is 'delimited'"
           }
         },
         {


### PR DESCRIPTION
As per the plugin **CSV Schema Detection Plugin**,  the GCS Source should support automated schema detection. In this PR, I've introduced two new properties at the GCS Source plugin: 

1. `sampleSize`,
2. `override`.

Jira: https://cdap.atlassian.net/browse/PLUGIN-593