### PR TITLE
PLUGIN-575: Fixed Text and Blob formats in PubSub Sink

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/publisher/PubSubOutputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/publisher/PubSubOutputFormat.java
@@ -219,11 +219,7 @@ public class PubSubOutputFormat extends OutputFormat<NullWritable, StructuredRec
           break;
         }
         case PubSubConstants.TEXT:
-        case PubSubConstants.BLOB: {
-          data = ByteString.copyFromUtf8(String.valueOf(value));
-          message = PubsubMessage.newBuilder().setData(data).build();
-          break;
-        }
+        case PubSubConstants.BLOB:
         case PubSubConstants.JSON: {
           payload = StructuredRecordStringConverter.toJsonString(value);
           data = ByteString.copyFromUtf8(payload);


### PR DESCRIPTION
Text and Blob formats are not working as expected in PubSub Sink

Since the input is StructuredRecord, we cannot convert StructuredRecord directly to Bytes. 

In the previous implementation, StructuredRecord was converted to json first and then was written to Bytes. 

This approach will also maintain the Backward compatibility. 

JIRA Ticket: https://cdap.atlassian.net/browse/PLUGIN-575
