### PR TITLE
Support datetime datatype in BQ source, sink and multisink. 

### DIFF
--- a/docs/BigQueryTable-batchsink.md
+++ b/docs/BigQueryTable-batchsink.md
@@ -146,13 +146,14 @@ corresponding BigQuery data type for each CDAP type, for updates and upserts.
 | boolean        | bool          |
 | bytes          | bytes         |
 | date           | date          |
+| datetime       | datetime, string|
 | decimal        | numeric       |
 | double / float | float64       |
 | enum           | unsupported   |
 | int / long     | int64         |
 | map            | unsupported   |
 | record         | struct        |
-| string         | string        |
+| string         | string, datetime(Should be ISO 8601 format)|
 | time           | time          |
 | timestamp      | timestamp     |
 | union          | unsupported   |

--- a/docs/BigQueryTable-batchsource.md
+++ b/docs/BigQueryTable-batchsource.md
@@ -84,14 +84,14 @@ corresponding CDAP data type for each BigQuery type.
 | bool          | boolean                               |
 | bytes         | bytes                                 |
 | date          | date                                  |
-| datetime      | string, eg. 2020-04-06T18:06:54.371637|
+| datetime      | datetime, string                      |
 | float64       | double                                |
 | geo           | unsupported                           |
 | int64         | long                                  |
 | numeric       | decimal (38 digits, 9 decimal places) |
 | record        | record                                |
 | repeated      | array                                 |
-| string        | string                                |
+| string        | string, datetime(Should be ISO 8601 format)|
 | struct        | record                                |
 | time          | time (microseconds)                   |
 | timestamp     | timestamp (microseconds)              |

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryAvroConverter.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryAvroConverter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.gcp.bigquery.sink;
+
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.plugin.common.RecordConverter;
+import io.cdap.plugin.format.avro.StructuredToAvroTransformer;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.mapred.AvroKey;
+
+import java.io.IOException;
+import javax.annotation.Nullable;
+
+/**
+ * BigQueryAvroConverter converts a {@link StructuredRecord} to {@link AvroKey<GenericRecord>}
+ */
+public class BigQueryAvroConverter extends RecordConverter<StructuredRecord, AvroKey<GenericRecord>> {
+
+  private final StructuredToAvroTransformer structuredToAvroTransformer;
+
+  BigQueryAvroConverter() {
+    structuredToAvroTransformer = new StructuredToAvroTransformer(null);
+  }
+
+  @Override
+  public AvroKey<GenericRecord> transform(StructuredRecord record, @Nullable Schema schema) throws IOException {
+    return new AvroKey<>(structuredToAvroTransformer.transform(record, schema == null ? record.getSchema() : schema));
+  }
+}

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryJsonConverter.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryJsonConverter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.gcp.bigquery.sink;
+
+import com.google.gson.JsonObject;
+import com.google.gson.internal.bind.JsonTreeWriter;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.plugin.common.RecordConverter;
+
+import java.io.IOException;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * BigQueryJsonConverter converts a {@link StructuredRecord} to {@link JsonObject}
+ */
+public class BigQueryJsonConverter extends RecordConverter<StructuredRecord, JsonObject> {
+
+  @Override
+  public JsonObject transform(StructuredRecord input, @Nullable Schema schema) throws IOException {
+    try (JsonTreeWriter writer = new JsonTreeWriter()) {
+      writer.beginObject();
+      for (Schema.Field recordField : Objects.requireNonNull(input.getSchema().getFields())) {
+        // From all the fields in input record, write only those fields that are present in output schema
+        if (schema != null && schema.getField(recordField.getName()) == null) {
+          continue;
+        }
+        BigQueryRecordToJson.write(writer, recordField.getName(), input.get(recordField.getName()),
+                                   recordField.getSchema());
+      }
+      writer.endObject();
+      return writer.get().getAsJsonObject();
+    }
+  }
+}

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSink.java
@@ -23,18 +23,13 @@ import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.data.batch.OutputFormatProvider;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
-import io.cdap.cdap.api.dataset.lib.KeyValue;
-import io.cdap.cdap.etl.api.Emitter;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryConstants;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;
-import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.mapred.AvroKey;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.io.NullWritable;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -125,11 +120,5 @@ public class BigQueryMultiSink extends AbstractBigQuerySink {
                                                          String tableName,
                                                          Schema tableSchema) {
     return new MultiSinkOutputFormatProvider(configuration, tableName, tableSchema, config.getSplitField());
-  }
-
-  @Override
-  public void transform(StructuredRecord input,
-                        Emitter<KeyValue<AvroKey<GenericRecord>, NullWritable>> emitter) throws IOException {
-    emitter.emit(new KeyValue<>(new AvroKey<>(toAvroRecord(input)), NullWritable.get()));
   }
 }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryRecordWriter.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryRecordWriter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.gcp.bigquery.sink;
+
+import com.google.cloud.hadoop.io.bigquery.BigQueryFileFormat;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.plugin.common.RecordConverter;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+import javax.annotation.Nullable;
+
+/**
+ * BigQueryRecordWriter picks the  {@link RecordConverter} based on output file format
+ */
+public class BigQueryRecordWriter extends RecordWriter<StructuredRecord, NullWritable> {
+
+  private final RecordWriter delegate;
+  private final BigQueryFileFormat fileFormat;
+  private final Schema outputSchema;
+  private RecordConverter recordConverter;
+
+  public BigQueryRecordWriter(RecordWriter delegate, BigQueryFileFormat fileFormat, @Nullable Schema outputSchema) {
+    this.delegate = delegate;
+    this.fileFormat = fileFormat;
+    this.outputSchema = outputSchema;
+    initRecordConverter();
+  }
+
+  private void initRecordConverter() {
+    if (this.fileFormat == BigQueryFileFormat.NEWLINE_DELIMITED_JSON) {
+      recordConverter = new BigQueryJsonConverter();
+      return;
+    }
+    recordConverter = new BigQueryAvroConverter();
+  }
+
+  @Override
+  public void write(StructuredRecord structuredRecord, NullWritable nullWriter) throws IOException,
+    InterruptedException {
+    delegate.write(recordConverter.transform(structuredRecord, outputSchema), nullWriter);
+  }
+
+  @Override
+  public void close(TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
+    delegate.close(taskAttemptContext);
+  }
+}

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -26,10 +26,7 @@ import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.data.batch.OutputFormatProvider;
-import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
-import io.cdap.cdap.api.dataset.lib.KeyValue;
-import io.cdap.cdap.etl.api.Emitter;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.StageConfigurer;
@@ -37,10 +34,7 @@ import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryConstants;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;
-import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.mapred.AvroKey;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.io.NullWritable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -186,15 +180,12 @@ public final class BigQuerySink extends AbstractBigQuerySink {
 
       @Override
       public Map<String, String> getOutputFormatConfiguration() {
-        return BigQueryUtil.configToMap(configuration);
+        Map<String, String> configToMap = BigQueryUtil.configToMap(configuration);
+        configToMap
+          .put(BigQueryConstants.CDAP_BQ_SINK_OUTPUT_SCHEMA, tableSchema == null ? null : tableSchema.toString());
+        return configToMap;
       }
     };
-  }
-
-  @Override
-  public void transform(StructuredRecord input,
-                        Emitter<KeyValue<AvroKey<GenericRecord>, NullWritable>> emitter) throws IOException {
-    emitter.emit(new KeyValue<>(new AvroKey<>(toAvroRecord(input)), NullWritable.get()));
   }
 
   /**

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
@@ -43,4 +43,5 @@ public interface BigQueryConstants {
   String CONFIG_PARTITION_INTEGER_RANGE_END = "cdap.bq.sink.partition.integer.range.end";
   String CONFIG_PARTITION_INTEGER_RANGE_INTERVAL = "cdap.bq.sink.partition.integer.range.interval";
   String CONFIG_TEMPORARY_TABLE_NAME = "cdap.bq.source.temporary.table.name";
+  String CDAP_BQ_SINK_OUTPUT_SCHEMA = "cdap.bq.sink.output.schema";
 }


### PR DESCRIPTION
Support datetime datatype in BQ source, sink and multisink
- BQ source will allow mapping from BQ datetime to CDAP datetime
- BQ source will also allow mapping string to CDAP datetime (Runtime failure if string is not ISO 8601 format), mapping from BQ datetime to CDAP string 
- BigQuery sink will allow mapping CDAP datetime to BQ datetime
- BQ sink will also allow mapping from cdap datetime to BQ string , cdap string to BQ datetime (Error on loading if not valid ISO 8601 string)
- BigQuery Sink does not support mapping of any AVRO type to datetime. (https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-avro#logical_types). To work around this issue, anytime when a datetime field is present in output schema, JSON format for file will be used to load data in to BQ.

Tested the following scenarios
- BQ source date time to cdap date time
- BQ source date time to cdap string
- BQ source string to cdap datetime 
- CDAP datetime to BQ sink datetime
- CDAP datetime to BQ sink string
- CDAP string to BQ sink datetime
- BQ sink with both datetime and bytes fields to test JSON support for bytes
- BQ Multisink with filter where one source schema has datetime  and one does not.(This will use AVRO for one source and JSON for the other)
