### PR TITLE
PLUGIN-572 - BigQuery Sink fails when the user specifies arbitrary GCS Upload Request Chunk Size

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
@@ -159,7 +159,9 @@ public abstract class AbstractBigQuerySinkConfig extends GCPReferenceSinkConfig 
     if (!containsMacro(NAME_BUCKET)) {
       BigQueryUtil.validateBucket(bucket, NAME_BUCKET, collector);
     }
-
+    if (!containsMacro(NAME_GCS_CHUNK_SIZE)) {
+      BigQueryUtil.validateGCSChunkSize(gcsChunkSize, NAME_GCS_CHUNK_SIZE, collector);
+    }
     if (!containsMacro(NAME_DATASET)) {
       BigQueryUtil.validateDataset(dataset, NAME_DATASET, collector);
     }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
@@ -167,7 +167,8 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
 
   public BigQuerySinkConfig(String referenceName, String dataset, String table,
                             @Nullable String bucket, @Nullable String schema, @Nullable String partitioningType,
-                            @Nullable Long rangeStart, @Nullable Long rangeEnd, @Nullable Long rangeInterval) {
+                            @Nullable Long rangeStart, @Nullable Long rangeEnd, @Nullable Long rangeInterval,
+                            @Nullable String gcsChunkSize) {
     this.referenceName = referenceName;
     this.dataset = dataset;
     this.table = table;
@@ -177,6 +178,7 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
     this.rangeStart = rangeStart;
     this.rangeEnd = rangeEnd;
     this.rangeInterval = rangeInterval;
+    this.gcsChunkSize = gcsChunkSize;
   }
 
   public String getTable() {

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
@@ -588,15 +588,16 @@ public final class BigQueryUtil {
    * @param collector failure collector
    */
   public static void validateGCSChunkSize(String chunkSize, String chunkSizePropertyName, FailureCollector collector) {
-    String errorMessage1 = String.format("Value must be a multiple of %s", MediaHttpUploader.MINIMUM_CHUNK_SIZE);
-    String errorMessage2 = "Error parsing the provided value";
     if (!Strings.isNullOrEmpty(chunkSize)) {
       try {
         if (Integer.parseInt(chunkSize) % MediaHttpUploader.MINIMUM_CHUNK_SIZE != 0) {
-          collector.addFailure(errorMessage1, null).withConfigProperty(chunkSizePropertyName);
+          collector.addFailure(
+            String.format("Value must be a multiple of %s.", MediaHttpUploader.MINIMUM_CHUNK_SIZE), null)
+            .withConfigProperty(chunkSizePropertyName);
         }
       } catch (NumberFormatException e) {
-        collector.addFailure(errorMessage2, null).withConfigProperty(chunkSizePropertyName);
+        collector.addFailure(e.getMessage(), "Input value must be a valid number.")
+          .withConfigProperty(chunkSizePropertyName);
       }
     }
   }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.gcp.bigquery.util;
 
+import com.google.api.client.googleapis.media.MediaHttpUploader;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.Field;
@@ -577,6 +578,27 @@ public final class BigQueryUtil {
     // Allowed character validation for table name as per https://cloud.google.com/bigquery/docs/tables
     String errorMessage = "Table name can only contain letters (lower or uppercase), numbers and '_'.";
     match(table, tablePropertyName, TABLE_PATTERN, collector, errorMessage);
+  }
+
+  /**
+   * Validates allowed GCS Upload Request Chunk Size.
+   *
+   * @param chunkSize provided chunk size
+   * @param chunkSizePropertyName GCS chunk size name property
+   * @param collector failure collector
+   */
+  public static void validateGCSChunkSize(String chunkSize, String chunkSizePropertyName, FailureCollector collector) {
+    String errorMessage1 = String.format("Value must be a multiple of %s", MediaHttpUploader.MINIMUM_CHUNK_SIZE);
+    String errorMessage2 = "Error parsing the provided value";
+    if (!Strings.isNullOrEmpty(chunkSize)) {
+      try {
+        if (Integer.parseInt(chunkSize) % MediaHttpUploader.MINIMUM_CHUNK_SIZE != 0) {
+          collector.addFailure(errorMessage1, null).withConfigProperty(chunkSizePropertyName);
+        }
+      } catch (NumberFormatException e) {
+        collector.addFailure(errorMessage2, null).withConfigProperty(chunkSizePropertyName);
+      }
+    }
   }
 
   /**

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkTest.java
@@ -247,6 +247,42 @@ public class BigQuerySinkTest {
     Assert.assertEquals(0, collector.getValidationFailures().size());
   }
 
+  @Test
+  public void testBigQuerySinkConfigValidChunkSize() {
+    Schema schema = Schema.recordOf("record",
+                                    Schema.Field.of("id", Schema.of(Schema.Type.LONG)),
+                                    Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+                                    Schema.Field.of("price", Schema.of(Schema.Type.DOUBLE)),
+                                    Schema.Field.of("dt", Schema.nullableOf(Schema.of(Schema.LogicalType.DATE))),
+                                    Schema.Field.of("bytedata", Schema.of(Schema.Type.BYTES)),
+                                    Schema.Field.of("timestamp",
+                                                    Schema.nullableOf(Schema.of(Schema.LogicalType.TIMESTAMP_MICROS))));
+
+    BigQuerySinkConfig config = new BigQuerySinkConfig("44", "ds", "tb", "bucket", schema.toString(),
+                                                       "INTEGER", 0L, 100L, 10L, "2097152");
+    MockFailureCollector collector = new MockFailureCollector("bqsink");
+    config.validate(collector);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+  @Test
+  public void testBigQuerySinkConfigInvalidChunkSize() {
+    Schema schema = Schema.recordOf("record",
+                                    Schema.Field.of("id", Schema.of(Schema.Type.LONG)),
+                                    Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+                                    Schema.Field.of("price", Schema.of(Schema.Type.DOUBLE)),
+                                    Schema.Field.of("dt", Schema.nullableOf(Schema.of(Schema.LogicalType.DATE))),
+                                    Schema.Field.of("bytedata", Schema.of(Schema.Type.BYTES)),
+                                    Schema.Field.of("timestamp",
+                                                    Schema.nullableOf(Schema.of(Schema.LogicalType.TIMESTAMP_MICROS))));
+
+    BigQuerySinkConfig config = new BigQuerySinkConfig("44", "ds", "tb", "bucket", schema.toString(),
+                                                       "INTEGER", 0L, 100L, 10L, "120000");
+    MockFailureCollector collector = new MockFailureCollector("bqsink");
+    config.validate(collector);
+    Assert.assertEquals(1, collector.getValidationFailures().size());
+  }
+
   private Table getTestSchema() {
     Table table = mock(Table.class);
     TableId tableId = TableId.of("test", "testds", "testtab");

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkTest.java
@@ -65,7 +65,7 @@ public class BigQuerySinkTest {
                                                     Schema.nullableOf(Schema.of(Schema.LogicalType.TIMESTAMP_MICROS))));
 
     BigQuerySinkConfig config = new BigQuerySinkConfig("44", "ds", "tb", "bucket", schema.toString(),
-                                                       "INTEGER", 0L, 100L, 10L);
+                                                       "INTEGER", 0L, 100L, 10L, null);
     MockFailureCollector collector = new MockFailureCollector("bqsink");
     config.validate(collector);
     Assert.assertEquals(0, collector.getValidationFailures().size());
@@ -77,11 +77,11 @@ public class BigQuerySinkTest {
                                            Schema.Field.of("id", Schema.of(Schema.Type.LONG)));
 
     BigQuerySinkConfig config = new BigQuerySinkConfig("reference!!", "ds", "tb", "buck3t$$", invalidSchema.toString(),
-                                                       "INTEGER", 0L, 100L, 10L);
+                                                       "INTEGER", 0L, 100L, 10L, "200000");
     MockFailureCollector collector = new MockFailureCollector("bqsink");
     config.validate(collector);
     List<ValidationFailure> failures = collector.getValidationFailures();
-    Assert.assertEquals(2, failures.size());
+    Assert.assertEquals(3, failures.size());
   }
 
   @Test
@@ -132,7 +132,7 @@ public class BigQuerySinkTest {
                                     Schema.Field.of("name", Schema.of(Schema.Type.STRING)));
     BigQuerySinkConfig config =
       new BigQuerySinkConfig("testmetric", "ds", "tb", "bkt", schema.toString(),
-                             null, null, null, null);
+                             null, null, null, null, null);
     BigQuery bigQueryMock = mock(BigQuery.class);
     BigQuerySink sink = new BigQuerySink(config);
     setBigQuery(sink, bigQueryMock);
@@ -264,7 +264,7 @@ public class BigQuerySinkTest {
                                     Schema.Field.of("name", Schema.of(Schema.Type.STRING)));
     BigQuerySinkConfig config =
       new BigQuerySinkConfig("testmetric", "ds", "tb", "bkt", schema.toString(),
-                             "INTEGER", 0L, 100L, 10L);
+                             "INTEGER", 0L, 100L, 10L, null);
     FieldSetter.setField(config, AbstractBigQuerySinkConfig.class.getDeclaredField("truncateTable"),
                          truncateTable);
     BigQuery bigQueryMock = mock(BigQuery.class);


### PR DESCRIPTION
BigQuery Sink fails when the user specifies arbitrary GCS Upload Request Chunk Size
JIRA Ticket: https://cdap.atlassian.net/browse/PLUGIN-572