### PR TITLE
Support string to datetime mapping and vice versa in datastore, spanner

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQueryAvroToStructuredTransformer.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQueryAvroToStructuredTransformer.java
@@ -61,12 +61,11 @@ public class BigQueryAvroToStructuredTransformer extends RecordConverter<Generic
 
   @Override
   @Nullable
-  protected Object convertField(Object field, Schema.Field schemaField) throws IOException {
+  protected Object convertField(Object field, Schema fieldSchema) throws IOException {
     if (field == null) {
       return null;
     }
 
-    Schema fieldSchema = schemaField.getSchema();
     // Union schema expected to be nullable schema. Underlying non-nullable type should always be a supported type
     fieldSchema = fieldSchema.isNullable() ? fieldSchema.getNonNullable() : fieldSchema;
     Schema.Type fieldType = fieldSchema.getType();
@@ -92,8 +91,7 @@ public class BigQueryAvroToStructuredTransformer extends RecordConverter<Generic
               LocalDateTime.parse(field.toString());
             } catch (DateTimeParseException exception) {
               throw new UnexpectedFormatException(
-                String.format("Field '%s' of type '%s' with value '%s' is not in ISO-8601 format.",
-                              schemaField.getName(),
+                String.format("Datetime field with value '%s' is not in ISO-8601 format.",
                               fieldSchema.getDisplayName(),
                               field.toString()),
                 exception);

--- a/src/main/java/io/cdap/plugin/gcp/common/Schemas.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/Schemas.java
@@ -54,7 +54,7 @@ public class Schemas {
       Schema trueNonNullable = isTrueFieldNullable ? trueFieldSchema.getNonNullable() : trueFieldSchema;
       Schema providedNonNullable = isProvidedFieldNullable ? providedFieldSchema.getNonNullable() : providedFieldSchema;
 
-      if (trueNonNullable.getLogicalType() != providedNonNullable.getLogicalType() ||
+      if (incompatibleLogicalTypes(trueNonNullable, providedNonNullable) ||
         trueNonNullable.getType() != providedNonNullable.getType()) {
         failureCollector.addFailure(String.format("Field '%s' is of unexpected type '%s'.",
                                                   field.getName(), providedNonNullable.getDisplayName()),
@@ -67,5 +67,13 @@ public class Schemas {
           .withOutputSchemaField(field.getName());
       }
     }
+  }
+
+  private static boolean incompatibleLogicalTypes(Schema trueNonNullable, Schema providedNonNullable) {
+    //Allow true schema string to be matched to datetime type
+    if (providedNonNullable.getLogicalType() == Schema.LogicalType.DATETIME) {
+      return trueNonNullable.getType() != Schema.Type.STRING;
+    }
+    return trueNonNullable.getLogicalType() != providedNonNullable.getLogicalType();
   }
 }

--- a/src/main/java/io/cdap/plugin/gcp/datastore/sink/DatastoreSinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/datastore/sink/DatastoreSinkConfig.java
@@ -236,6 +236,8 @@ public class DatastoreSinkConfig extends GCPReferenceSinkConfig {
         // timestamps in CDAP are represented as LONG with TIMESTAMP_MICROS logical type
         case TIMESTAMP_MICROS:
         case TIMESTAMP_MILLIS:
+          // datetime type is a string
+        case DATETIME:
           break;
         default:
           collector.addFailure(String.format("Field '%s' is of unsupported type '%s'",

--- a/src/main/java/io/cdap/plugin/gcp/datastore/sink/RecordToEntityTransformer.java
+++ b/src/main/java/io/cdap/plugin/gcp/datastore/sink/RecordToEntityTransformer.java
@@ -284,6 +284,9 @@ public class RecordToEntityTransformer {
           return DatastoreHelper.makeValue(Date.from(ts.toInstant()))
             .setExcludeFromIndexes(excludeFromIndex)
             .build();
+        //write datetime value as string - this will be handled by the next block
+        case DATETIME:
+          break;
         default:
           throw new IllegalStateException(
             String.format("Record type '%s' is not supported for field '%s'", logicalType.getToken(), fieldName));

--- a/src/main/java/io/cdap/plugin/gcp/spanner/common/SpannerUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/spanner/common/SpannerUtil.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
  */
 public class SpannerUtil {
   private static final Set<Schema.LogicalType> SUPPORTED_LOGICAL_TYPES =
-    ImmutableSet.of(Schema.LogicalType.DATE, Schema.LogicalType.TIMESTAMP_MICROS);
+    ImmutableSet.of(Schema.LogicalType.DATE, Schema.LogicalType.TIMESTAMP_MICROS, Schema.LogicalType.DATETIME);
 
   /**
    * Construct and return the {@link Spanner} service for the provided credentials and projectId
@@ -181,7 +181,7 @@ public class SpannerUtil {
       if (logicalType != null && !SUPPORTED_LOGICAL_TYPES.contains(logicalType)) {
         collector.addFailure(
           String.format("Field '%s' is of unsupported type '%s'.", field.getName(), fieldSchema.getDisplayName()),
-          "Change the type to be a date or timestamp.").withOutputSchemaField(field.getName());
+          "Change the type to be a date, timestamp or datetime.").withOutputSchemaField(field.getName());
       }
 
       if (logicalType == null) {
@@ -189,7 +189,7 @@ public class SpannerUtil {
         if (!supportedTypes.contains(type)) {
           collector.addFailure(
             String.format("Field '%s' is of unsupported type '%s'.", field.getName(), fieldSchema.getDisplayName()),
-            String.format("Supported types are: %s, date and timestamp.",
+            String.format("Supported types are: %s, date, datetime and timestamp.",
                           supportedTypes.stream().map(t -> t.name().toLowerCase()).collect(Collectors.joining(", "))))
             .withOutputSchemaField(field.getName());
         }
@@ -224,6 +224,9 @@ public class SpannerUtil {
           case TIMESTAMP_MILLIS:
           case TIMESTAMP_MICROS:
             spannerType = "TIMESTAMP";
+            break;
+          case DATETIME:
+            spannerType = "STRING(MAX)";
             break;
           default:
             // this should not happen

--- a/src/main/java/io/cdap/plugin/gcp/spanner/sink/RecordToMutationTransformer.java
+++ b/src/main/java/io/cdap/plugin/gcp/spanner/sink/RecordToMutationTransformer.java
@@ -77,6 +77,8 @@ public class RecordToMutationTransformer {
             ZonedDateTime ts = record.getTimestamp(fieldName);
             Timestamp spannerTs = Timestamp.ofTimeSecondsAndNanos(ts.toEpochSecond(), ts.getNano());
             return Value.timestamp(spannerTs);
+          case DATETIME:
+            return Value.string(record.get(fieldName));
           default:
             throw new IllegalStateException(
               String.format("Field '%s' is of unsupported logical type '%s'", fieldName, logicalType.getToken()));

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/AvroToStructuredRecordTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/AvroToStructuredRecordTest.java
@@ -18,7 +18,6 @@ package io.cdap.plugin.gcp.bigquery;
 
 import com.google.common.collect.ImmutableList;
 import io.cdap.cdap.api.data.format.StructuredRecord;
-import io.cdap.cdap.api.data.format.UnexpectedFormatException;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.plugin.gcp.bigquery.source.BigQueryAvroToStructuredTransformer;
 import org.apache.avro.generic.GenericRecord;
@@ -176,7 +175,7 @@ public class AvroToStructuredRecordTest {
     Assert.assertEquals(expected, actual);
   }
 
-  @Test(expected = UnexpectedFormatException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void testUnionTypeUnsupported() throws Exception {
     Schema schema = Schema.recordOf("record",
                                     Schema.Field.of("id", Schema.of(Schema.Type.LONG)),

--- a/src/test/java/io/cdap/plugin/gcp/datastore/sink/DatastoreSinkConfigTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/datastore/sink/DatastoreSinkConfigTest.java
@@ -500,4 +500,22 @@ public class DatastoreSinkConfigTest {
     Assert.assertEquals("array_of_array", collector.getValidationFailures().get(0).getCauses().get(0)
       .getAttribute(CauseAttributes.INPUT_SCHEMA_FIELD));
   }
+
+  @Test
+  public void testValidateDatetimeSchema() {
+    Schema schema = Schema.recordOf("record",
+                                    Schema.Field
+                                      .of("dt_field", Schema.nullableOf(Schema.of(Schema.LogicalType.DATETIME))));
+
+    DatastoreSinkConfig config = Mockito.spy(DatastoreSinkConfigHelper.newConfigBuilder()
+                                               .setKeyType(SinkKeyType.AUTO_GENERATED_KEY.getValue())
+                                               .setServiceFilePath(null)
+                                               .setBatchSize(25)
+                                               .setIndexStrategy(IndexStrategy.ALL.getValue())
+                                               .build());
+    MockFailureCollector collector = new MockFailureCollector();
+    Mockito.doNothing().when(config).validateDatastoreConnection(collector);
+    config.validate(schema, collector);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
 }

--- a/src/test/java/io/cdap/plugin/gcp/datastore/sink/RecordToEntityTransformerTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/datastore/sink/RecordToEntityTransformerTest.java
@@ -35,6 +35,7 @@ import org.junit.rules.ExpectedException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collections;
@@ -180,6 +181,7 @@ public class RecordToEntityTransformerTest {
       Schema.Field.of("float_field", Schema.nullableOf(Schema.of(Schema.Type.FLOAT))),
       Schema.Field.of("boolean_field", Schema.nullableOf(Schema.of(Schema.Type.BOOLEAN))),
       Schema.Field.of("timestamp_field", Schema.nullableOf(Schema.of(Schema.LogicalType.TIMESTAMP_MICROS))),
+      Schema.Field.of("datetime_field", Schema.nullableOf(Schema.of(Schema.LogicalType.DATETIME))),
       Schema.Field.of("blob_field", Schema.nullableOf(Schema.of(Schema.Type.BYTES))),
       Schema.Field.of("null_field", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
       Schema.Field.of("entity_field",
@@ -194,6 +196,7 @@ public class RecordToEntityTransformerTest {
     );
 
     ZonedDateTime dateTime = ZonedDateTime.now();
+    LocalDateTime localDateTime = LocalDateTime.now();
     List<Long> longList = Arrays.asList(1L, null, 2L, null, 3L);
 
     StructuredRecord inputRecord = StructuredRecord.builder(schema)
@@ -204,6 +207,7 @@ public class RecordToEntityTransformerTest {
       .set("float_field", 15.5F)
       .set("boolean_field", true)
       .setTimestamp("timestamp_field", dateTime)
+      .setDateTime("datetime_field", localDateTime)
       .set("blob_field", "test_blob".getBytes())
       .set("null_field", null)
       .set("entity_field", StructuredRecord.builder(schema.getField("entity_field").getSchema().getNonNullable())
@@ -248,6 +252,10 @@ public class RecordToEntityTransformerTest {
     value = outputEntity.getPropertiesOrThrow("timestamp_field");
     Assert.assertEquals(dateTime.toInstant().toEpochMilli() * 1000,
                         DatastoreHelper.getTimestamp(value));
+    Assert.assertTrue(value.getExcludeFromIndexes());
+
+    value = outputEntity.getPropertiesOrThrow("datetime_field");
+    Assert.assertEquals(localDateTime.toString(), DatastoreHelper.getString(value));
     Assert.assertTrue(value.getExcludeFromIndexes());
 
     value = outputEntity.getPropertiesOrThrow("boolean_field");

--- a/src/test/java/io/cdap/plugin/gcp/datastore/source/DatastoreSourceConfigTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/datastore/source/DatastoreSourceConfigTest.java
@@ -363,6 +363,7 @@ public class DatastoreSourceConfigTest {
       Schema.Field.of("double_field", Schema.of(Schema.Type.DOUBLE)),
       Schema.Field.of("boolean_field", Schema.nullableOf(Schema.of(Schema.Type.BOOLEAN))),
       Schema.Field.of("timestamp_field", Schema.nullableOf(Schema.of(Schema.LogicalType.TIMESTAMP_MICROS))),
+      Schema.Field.of("datetime_field", Schema.nullableOf(Schema.of(Schema.LogicalType.DATETIME))),
       Schema.Field.of("blob_field", Schema.of(Schema.Type.BYTES)),
       Schema.Field.of("record_field",
       Schema.recordOf("record",

--- a/src/test/java/io/cdap/plugin/gcp/spanner/SpannerUtilTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/spanner/SpannerUtilTest.java
@@ -42,8 +42,8 @@ public class SpannerUtilTest {
       Schema.Field.of("bytes_array", Schema.arrayOf(Schema.nullableOf(Schema.of(Schema.Type.BYTES)))),
       Schema.Field.of("timestamp_array",
                       Schema.arrayOf(Schema.nullableOf(Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)))),
-      Schema.Field.of("date_array", Schema.arrayOf(Schema.nullableOf(Schema.of(Schema.LogicalType.DATE))))
-
+      Schema.Field.of("date_array", Schema.arrayOf(Schema.nullableOf(Schema.of(Schema.LogicalType.DATE)))),
+      Schema.Field.of("datetime_field", Schema.nullableOf(Schema.of(Schema.LogicalType.DATETIME)))
     );
 
     Assert.assertEquals("CREATE TABLE table (id INT64 NOT NULL, name STRING(MAX) NOT NULL, " +
@@ -51,7 +51,7 @@ public class SpannerUtilTest {
                           "int_array ARRAY<INT64> NOT NULL, string_array ARRAY<STRING(MAX)> NOT NULL, " +
                           "bool_array ARRAY<BOOL> NOT NULL, float_array ARRAY<FLOAT64> NOT NULL, " +
                           "bytes_array ARRAY<BYTES(MAX)> NOT NULL, timestamp_array ARRAY<TIMESTAMP> NOT NULL, " +
-                          "date_array ARRAY<DATE> NOT NULL) PRIMARY KEY (id, name)",
+                          "date_array ARRAY<DATE> NOT NULL, datetime_field STRING(MAX)) PRIMARY KEY (id, name)",
                         SpannerUtil.convertSchemaToCreateStatement("table", "id, name", schema));
   }
 }

--- a/src/test/java/io/cdap/plugin/gcp/spanner/sink/RecordToMutationTransformerTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/spanner/sink/RecordToMutationTransformerTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -229,6 +230,17 @@ public class RecordToMutationTransformerTest {
   public void testToCollectionFromListObjects() {
     Collection<Integer> collection = Arrays.asList(1, 2, 3);
     testToCollection(collection, collection);
+  }
+
+  @Test
+  public void testDateTime() {
+    LocalDateTime localDateTime = LocalDateTime.now();
+    Schema schema = Schema.recordOf("record",
+                                    Schema.Field.of("DT", Schema.nullableOf(Schema.of(Schema.LogicalType.DATETIME))));
+    RecordToMutationTransformer transformer = new RecordToMutationTransformer("test", schema);
+    StructuredRecord record = StructuredRecord.builder(schema).setDateTime("DT", localDateTime).build();
+    Assert.assertEquals(Value.string(localDateTime.toString()),
+                        transformer.convertToValue("DT", schema.getField("DT").getSchema(), record));
   }
 
   public void testToCollection(Collection expected, Object object) {


### PR DESCRIPTION
Support string to datetime mapping and vice versa in datastore, spanner
- Fixed a bug in BQ support to override the right overloaded convertField method in BigQueryAvroToStructuredTransformer . The calling method will add the field name in the final exception thrown
- Datastore and spanner source will allow string to be mapped to CDAP datetime and validate for correct format 
- Datastore and spanner sink will allow cdap datetime to be written as string
- Tested GCS source and sink. Datetime is supported with changes in https://github.com/cdapio/hydrator-plugins/pull/1327