### PR TITLE
PLUGIN 517- fix issue with validation of partition field property

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -100,6 +100,7 @@ public final class BigQuerySink extends AbstractBigQuerySink {
   protected void prepareRunValidation(BatchSinkContext context) {
     FailureCollector collector = context.getFailureCollector();
     config.validate(context.getInputSchema(), config.getSchema(collector), collector);
+    collector.getOrThrowException();
   }
 
   @Override

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkTest.java
@@ -86,6 +86,26 @@ public class BigQuerySinkTest {
   }
 
   @Test
+  public void testBigQueryTimePartitionConfig() {
+    Schema schema = Schema.recordOf("record",
+            Schema.Field.of("id", Schema.of(Schema.Type.LONG)),
+            Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+            Schema.Field.of("price", Schema.of(Schema.Type.DOUBLE)),
+            Schema.Field.of("dt", Schema.nullableOf(Schema.of(Schema.LogicalType.DATE))),
+            Schema.Field.of("bytedata", Schema.of(Schema.Type.BYTES)),
+            Schema.Field.of("timestamp",
+                    Schema.nullableOf(Schema.of(Schema.LogicalType.TIMESTAMP_MICROS))));
+
+    BigQuerySinkConfig config = new BigQuerySinkConfig("44", "ds", "tb", "bucket", schema.toString(),
+            "TIME", 0L, 100L, 10L, null);
+    config.partitionByField = "dt";
+    
+    MockFailureCollector collector = new MockFailureCollector("bqsink");
+    config.validate(collector);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+  @Test
   public void testBigQuerySinkMetricInsert() throws Exception {
     Job mockJob = getMockLoadJob(10L);
     testMetric(mockJob, 10L, 1);


### PR DESCRIPTION
Fixed: Validate partition field property when partition type is integer:
    
    1. Throw validation issue in configuration stage when partition field is empty and partition type is Integer and destination table does not exist
    2. Throw validation issue in configuration stage when partition field is empty and partition type is Integer and destination table exist
    3. Throw validation issue in prepare run stage when partition field or partition type is macro and partition field is empty

Jira Ticket: https://cdap.atlassian.net/browse/PLUGIN-517