### PR TITLE
[PLUGIN-470] Implemented DelegatingOutputFormat for schemaless BigQuery multisink

### DIFF
--- a/docs/BigQueryMultiTable-batchsink.md
+++ b/docs/BigQueryMultiTable-batchsink.md
@@ -67,6 +67,9 @@ In this case, those fields in the BigQuery schema will be modified to become nul
                          
 Incompatible schema changes will result in pipeline failure.
 
+**Allow flexible schemas in Output**: When enabled, this sink will write out records with arbitrary schemas. 
+Records may not have a well defined schema depending on the source.
+
 **Service Account**  - service account key used for authorization
 
 * **File Path**: Path on the local file system of the service account key used for

--- a/docs/GCSMultiFiles-batchsink.md
+++ b/docs/GCSMultiFiles-batchsink.md
@@ -67,6 +67,10 @@ When running on other clusters, the file must be present on every node in the cl
 The 'avro' supports 'snappy' and 'deflate'. The parquet supports 'snappy' and 'gzip'. 
 Other formats does not support compression.
 
+**Allow flexible schemas in Output**: When enabled, this sink will write out records with arbitrary schemas. 
+Records may not have a well defined schema depending on the source.
+When enabled, the format must be one of 'avro', 'json', 'csv', 'tsv', 'delimited'.
+
 **Split Field:** The name of the field that will be used to determine which directory to write to. 
 Defaults to 'tablename'.
 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSink.java
@@ -20,6 +20,7 @@ import com.google.cloud.bigquery.Table;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.data.batch.Output;
 import io.cdap.cdap.api.data.batch.OutputFormatProvider;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
@@ -76,6 +77,23 @@ public class BigQueryMultiSink extends AbstractBigQuerySink {
     baseConfiguration.set(BigQueryConstants.CONFIG_OPERATION, Operation.INSERT.name());
     Map<String, String> arguments = new HashMap<>(context.getArguments().asMap());
     FailureCollector collector = context.getFailureCollector();
+
+    if (config.getAllowFlexibleSchema()) {
+      //Configure MultiSink with support for flexible schemas.
+      configureSchemalessOutput(context, bucket);
+    } else {
+      //Configure MultiSink with fixed schemas based on arguments.
+      configureOutputSchemas(context, bigQuery, bucket, arguments, collector);
+    }
+
+    collector.getOrThrowException();
+  }
+
+  protected void configureOutputSchemas(BatchSinkContext context,
+                                        BigQuery bigQuery,
+                                        String bucket,
+                                        Map<String, String> arguments,
+                                        FailureCollector collector) {
     for (Map.Entry<String, String> argument : arguments.entrySet()) {
       String key = argument.getKey();
       if (!key.startsWith(TABLE_PREFIX)) {
@@ -114,7 +132,18 @@ public class BigQueryMultiSink extends AbstractBigQuerySink {
         collector.addFailure("Invalid schema: " + e.getMessage(), null);
       }
     }
-    collector.getOrThrowException();
+  }
+
+  protected void configureSchemalessOutput(BatchSinkContext context,
+                                           String bucket) throws IOException {
+    Configuration conf = getOutputConfiguration();
+    String splitField = config.getSplitField();
+    String bucketName = config.getBucket();
+    String projectName = config.getDatasetProject();
+    String datasetName = config.getDataset();
+    context.addOutput(Output.of(config.getReferenceName(),
+                                new DelegatingMultiSinkOutputFormatProvider(conf, splitField, bucketName,
+                                                                            projectName, datasetName)));
   }
 
   /**

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSinkConfig.java
@@ -18,6 +18,7 @@ package io.cdap.plugin.gcp.bigquery.sink;
 import com.google.common.base.Strings;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
+import io.cdap.cdap.api.annotation.Name;
 
 import javax.annotation.Nullable;
 
@@ -27,14 +28,25 @@ import javax.annotation.Nullable;
 public class BigQueryMultiSinkConfig extends AbstractBigQuerySinkConfig {
 
   private static final String SPLIT_FIELD_DEFAULT = "tablename";
+  private static final String NAME_ALLOW_FLEXIBLE_SCHEMA = "allowFlexibleSchema";
 
   @Macro
   @Nullable
   @Description("The name of the field that will be used to determine which table to write to.")
   private String splitField;
 
+  @Name(NAME_ALLOW_FLEXIBLE_SCHEMA)
+  @Macro
+  @Nullable
+  @Description("Allow Flexible Schemas in output. If disabled, only records with schemas set as " +
+    "arguments will be processed. If enabled, all records will be written as-is.")
+  private Boolean allowFlexibleSchema;
+
   public String getSplitField() {
     return Strings.isNullOrEmpty(splitField) ? SPLIT_FIELD_DEFAULT : splitField;
   }
 
+  public Boolean getAllowFlexibleSchema() {
+    return allowFlexibleSchema != null ? allowFlexibleSchema : false;
+  }
 }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
@@ -108,9 +108,24 @@ public class BigQueryOutputFormat extends ForwardingBigQueryFileOutputFormat<Str
   public RecordWriter<StructuredRecord, NullWritable> getRecordWriter(TaskAttemptContext taskAttemptContext)
     throws IOException, InterruptedException {
     Configuration configuration = taskAttemptContext.getConfiguration();
+    return getRecordWriter(taskAttemptContext,
+                           getOutputSchema(configuration));
+  }
+
+  /**
+   * Get a Record Writer instance which uses a supplied schema to write output records.
+   *
+   * @param taskAttemptContext the execution context
+   * @param schema             output schema
+   * @return Record Writer Instance
+   */
+  public RecordWriter<StructuredRecord, NullWritable> getRecordWriter(TaskAttemptContext taskAttemptContext,
+                                                                      io.cdap.cdap.api.data.schema.Schema schema)
+    throws IOException, InterruptedException {
+    Configuration configuration = taskAttemptContext.getConfiguration();
     return new BigQueryRecordWriter(getDelegate(configuration).getRecordWriter(taskAttemptContext),
                                     BigQueryOutputConfiguration.getFileFormat(configuration),
-                                    getOutputSchema(configuration));
+                                    schema);
   }
 
   private io.cdap.cdap.api.data.schema.Schema getOutputSchema(Configuration configuration) throws IOException {

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryRecordWriter.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryRecordWriter.java
@@ -52,6 +52,7 @@ public class BigQueryRecordWriter extends RecordWriter<StructuredRecord, NullWri
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public void write(StructuredRecord structuredRecord, NullWritable nullWriter) throws IOException,
     InterruptedException {
     delegate.write(recordConverter.transform(structuredRecord, outputSchema), nullWriter);

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.gcp.bigquery.sink;
+
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.hadoop.io.bigquery.BigQueryFileFormat;
+import com.google.cloud.hadoop.io.bigquery.output.BigQueryOutputConfiguration;
+import com.google.cloud.hadoop.io.bigquery.output.BigQueryTableFieldSchema;
+import com.google.cloud.hadoop.io.bigquery.output.BigQueryTableSchema;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.plugin.gcp.bigquery.util.BigQueryConstants;
+import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class for the BigQuery DelegatingMultiSink.
+ *
+ * The logic in this class has been extracted from the {@link AbstractBigQuerySink} in order to make this functionality
+ * available to other classes in this package.
+ */
+final class BigQuerySinkUtils {
+
+  private static final String gcsPathFormat = "gs://%s/%s";
+  private static final String temporaryBucketFormat = gcsPathFormat + "/input/%s-%s";
+  private static final String DATETIME = "DATETIME";
+
+  public static void configureBigQueryOutput(Configuration configuration,
+                                             String projectName,
+                                             String datasetName,
+                                             String tableName,
+                                             String temporaryGCSPath,
+                                             List<BigQueryTableFieldSchema> fields) throws IOException {
+    BigQueryTableSchema outputTableSchema = new BigQueryTableSchema();
+    if (!fields.isEmpty()) {
+      outputTableSchema.setFields(fields);
+    }
+
+    BigQueryFileFormat fileFormat = getFileFormat(fields);
+    BigQueryOutputConfiguration.configure(
+      configuration,
+      String.format("%s:%s.%s", projectName, datasetName, tableName),
+      outputTableSchema,
+      temporaryGCSPath,
+      fileFormat,
+      getOutputFormat(fileFormat));
+  }
+
+  public static void configureBigQueryOutputForMultiSink(JobContext context,
+                                                         String projectName,
+                                                         String datasetName,
+                                                         String bucketName,
+                                                         String bucketPathUniqueId,
+                                                         String tableName,
+                                                         Schema schema) throws IOException {
+    Configuration configuration = context.getConfiguration();
+    String temporaryGcsPath = BigQuerySinkUtils.getTemporaryGcsPath(bucketName, tableName, bucketPathUniqueId);
+    List<BigQueryTableFieldSchema> fields = BigQuerySinkUtils.getBigQueryTableFieldsFromSchema(schema);
+
+    BigQuerySinkUtils.configureBigQueryOutput(configuration,
+                                              projectName,
+                                              datasetName,
+                                              tableName,
+                                              temporaryGcsPath,
+                                              fields);
+
+    //Set operation as Insertion. Currently the BQ MultiSink can only support the insertion operation.
+    configuration.set(BigQueryConstants.CONFIG_OPERATION, Operation.INSERT.name());
+  }
+
+  public static String getTemporaryGcsPath(String bucket, String tableName, String bucketPathUniqueId) {
+    return String.format(temporaryBucketFormat, bucket, bucketPathUniqueId, tableName, bucketPathUniqueId);
+  }
+
+  public static List<BigQueryTableFieldSchema> getBigQueryTableFieldsFromSchema(Schema tableSchema) {
+    List<Schema.Field> inputFields = Objects.requireNonNull(tableSchema.getFields(), "Schema must have fields");
+    return inputFields.stream()
+      .map(BigQuerySinkUtils::generateTableFieldSchema)
+      .collect(Collectors.toList());
+  }
+
+  private static BigQueryTableFieldSchema generateTableFieldSchema(Schema.Field field) {
+    BigQueryTableFieldSchema fieldSchema = new BigQueryTableFieldSchema();
+    fieldSchema.setName(field.getName());
+    fieldSchema.setMode(getMode(field.getSchema()).name());
+    LegacySQLTypeName type = getTableDataType(field.getSchema());
+    fieldSchema.setType(type.name());
+    if (type == LegacySQLTypeName.RECORD) {
+      List<Schema.Field> schemaFields;
+      if (Schema.Type.ARRAY == field.getSchema().getType()) {
+        schemaFields = Objects.requireNonNull(field.getSchema().getComponentSchema()).getFields();
+      } else {
+        schemaFields = field.getSchema().isNullable()
+          ? field.getSchema().getNonNullable().getFields()
+          : field.getSchema().getFields();
+      }
+      fieldSchema.setFields(Objects.requireNonNull(schemaFields).stream()
+                              .map(BigQuerySinkUtils::generateTableFieldSchema)
+                              .collect(Collectors.toList()));
+
+    }
+    return fieldSchema;
+  }
+
+  private static Field.Mode getMode(Schema schema) {
+    boolean isNullable = schema.isNullable();
+    Schema.Type nonNullableType = isNullable ? schema.getNonNullable().getType() : schema.getType();
+    if (isNullable && nonNullableType != Schema.Type.ARRAY) {
+      return Field.Mode.NULLABLE;
+    } else if (nonNullableType == Schema.Type.ARRAY) {
+      return Field.Mode.REPEATED;
+    }
+    return Field.Mode.REQUIRED;
+  }
+
+  private static LegacySQLTypeName getTableDataType(Schema schema) {
+    schema = BigQueryUtil.getNonNullableSchema(schema);
+    Schema.LogicalType logicalType = schema.getLogicalType();
+
+    if (logicalType != null) {
+      switch (logicalType) {
+        case DATE:
+          return LegacySQLTypeName.DATE;
+        case TIME_MILLIS:
+        case TIME_MICROS:
+          return LegacySQLTypeName.TIME;
+        case TIMESTAMP_MILLIS:
+        case TIMESTAMP_MICROS:
+          return LegacySQLTypeName.TIMESTAMP;
+        case DECIMAL:
+          return LegacySQLTypeName.NUMERIC;
+        case DATETIME:
+          return LegacySQLTypeName.DATETIME;
+        default:
+          throw new IllegalStateException("Unsupported type " + logicalType.getToken());
+      }
+    }
+
+    Schema.Type type = schema.getType();
+    switch (type) {
+      case INT:
+      case LONG:
+        return LegacySQLTypeName.INTEGER;
+      case STRING:
+        return LegacySQLTypeName.STRING;
+      case FLOAT:
+      case DOUBLE:
+        return LegacySQLTypeName.FLOAT;
+      case BOOLEAN:
+        return LegacySQLTypeName.BOOLEAN;
+      case BYTES:
+        return LegacySQLTypeName.BYTES;
+      case ARRAY:
+        return getTableDataType(schema.getComponentSchema());
+      case RECORD:
+        return LegacySQLTypeName.RECORD;
+      default:
+        throw new IllegalStateException("Unsupported type " + type);
+    }
+  }
+
+  private static BigQueryFileFormat getFileFormat(List<BigQueryTableFieldSchema> fields) {
+    for (BigQueryTableFieldSchema field : fields) {
+      if (DATETIME.equals(field.getType())) {
+        return BigQueryFileFormat.NEWLINE_DELIMITED_JSON;
+      }
+    }
+    return BigQueryFileFormat.AVRO;
+  }
+
+  private static Class<? extends FileOutputFormat> getOutputFormat(BigQueryFileFormat fileFormat) {
+    if (fileFormat == BigQueryFileFormat.NEWLINE_DELIMITED_JSON) {
+      return TextOutputFormat.class;
+    }
+    return AvroOutputFormat.class;
+  }
+}

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/DelegatingMultiSinkOutputCommitter.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/DelegatingMultiSinkOutputCommitter.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.gcp.bigquery.sink;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.JobStatus;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Output Committer which creates and delegates operations to other Bigquery Output Committer instances.
+ * <p>
+ * Delegated instances are supplied along with a schema, which is used to configure the commit operation.
+ */
+public class DelegatingMultiSinkOutputCommitter extends OutputCommitter {
+  private final Map<String, OutputCommitter> committerMap;
+  private final Map<String, Schema> schemaMap;
+  private final String projectName;
+  private final String datasetName;
+  private final String bucketName;
+  private final String bucketPathUniqueId;
+
+  public DelegatingMultiSinkOutputCommitter(String projectName,
+                                            String datasetName,
+                                            String bucketName,
+                                            String bucketPathUniqueId) {
+    this.projectName = projectName;
+    this.datasetName = datasetName;
+    this.bucketName = bucketName;
+    this.bucketPathUniqueId = bucketPathUniqueId;
+    this.committerMap = new HashMap<>();
+    this.schemaMap = new HashMap<>();
+  }
+
+  /**
+   * Add a committer and schema to this instance.
+   * <p>
+   * The supplied committer and schema will be used when the commit operations are invoked.
+   */
+  public void addCommitterAndSchema(OutputCommitter committer,
+                                    String tableName,
+                                    Schema schema,
+                                    TaskAttemptContext context) throws IOException, InterruptedException {
+    committerMap.put(tableName, committer);
+    schemaMap.put(tableName, schema);
+
+    //Configure the supplied committer.
+    committer.setupJob(context);
+    committer.setupTask(context);
+  }
+
+  @Override
+  public void setupJob(JobContext jobContext) throws IOException {
+    //no-op
+  }
+
+  @Override
+  public void setupTask(TaskAttemptContext taskAttemptContext) throws IOException {
+    //no-op
+  }
+
+  @Override
+  public boolean needsTaskCommit(TaskAttemptContext taskAttemptContext) throws IOException {
+    if (committerMap.isEmpty()) {
+      return false;
+    }
+
+    boolean needsTaskCommit = true;
+
+    for (OutputCommitter committer : committerMap.values()) {
+      needsTaskCommit = needsTaskCommit && committer.needsTaskCommit(taskAttemptContext);
+    }
+
+    return needsTaskCommit;
+  }
+
+  @Override
+  public void commitTask(TaskAttemptContext taskAttemptContext) throws IOException {
+    for (String tableName : committerMap.keySet()) {
+      configureContext(taskAttemptContext, tableName);
+
+      committerMap.get(tableName).commitTask(taskAttemptContext);
+    }
+  }
+
+  @Override
+  public void commitJob(JobContext jobContext) throws IOException {
+    for (String tableName : committerMap.keySet()) {
+      configureContext(jobContext, tableName);
+
+      committerMap.get(tableName).commitJob(jobContext);
+    }
+  }
+
+  @Override
+  public void abortTask(TaskAttemptContext taskAttemptContext) throws IOException {
+    IOException ioe = null;
+
+    for (OutputCommitter committer : committerMap.values()) {
+      try {
+        committer.abortTask(taskAttemptContext);
+      } catch (IOException e) {
+        if (ioe == null) {
+          ioe = e;
+        } else {
+          ioe.addSuppressed(e);
+        }
+      }
+    }
+
+    if (ioe != null) {
+      throw ioe;
+    }
+  }
+
+  @Override
+  public void abortJob(JobContext jobContext, JobStatus.State state) throws IOException {
+    IOException ioe = null;
+
+    for (OutputCommitter committer : committerMap.values()) {
+      try {
+        committer.abortJob(jobContext, state);
+      } catch (IOException e) {
+        if (ioe == null) {
+          ioe = e;
+        } else {
+          ioe.addSuppressed(e);
+        }
+      }
+    }
+
+    if (ioe != null) {
+      throw ioe;
+    }
+  }
+
+  public void configureContext(JobContext context, String tableName) throws IOException {
+    Schema schema = schemaMap.get(tableName);
+
+    BigQuerySinkUtils.configureBigQueryOutputForMultiSink(context,
+                                                          projectName,
+                                                          datasetName,
+                                                          bucketName,
+                                                          bucketPathUniqueId,
+                                                          tableName,
+                                                          schema);
+  }
+}

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/DelegatingMultiSinkOutputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/DelegatingMultiSinkOutputFormat.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.gcp.bigquery.sink;
+
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.OutputFormat;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Output Format used to handle the use case where the output schema is not set as a pipeline argument.
+ */
+public class DelegatingMultiSinkOutputFormat extends OutputFormat<StructuredRecord, NullWritable> {
+  private static final String TABLENAME_FIELD = "bq.delegating.multi.tablename.field";
+  private static final String BUCKET_NAME = "bq.delegating.multi.bucket";
+  private static final String BUCKET_PATH_UNIQUE_ID = "bq.delegating.multi.bucket.path.uuid";
+  private static final String PROJECT_NAME = "bq.delegating.multi.project";
+  private static final String DATASET_NAME = "bq.delegating.multi.dataset";
+
+  private DelegatingMultiSinkOutputCommitter delegatingMultiSinkOutputCommitter = null;
+
+  public static void configure(Configuration conf,
+                               String filterField,
+                               String bucketName,
+                               String projectName,
+                               String datasetName) {
+    conf.set(TABLENAME_FIELD, filterField);
+    conf.set(BUCKET_NAME, bucketName);
+    conf.set(BUCKET_PATH_UNIQUE_ID, UUID.randomUUID().toString());
+    conf.set(PROJECT_NAME, projectName);
+    conf.set(DATASET_NAME, datasetName);
+  }
+
+  @Override
+  public RecordWriter<StructuredRecord, NullWritable> getRecordWriter(TaskAttemptContext taskAttemptContext) {
+    Configuration conf = taskAttemptContext.getConfiguration();
+    String tableNameField = conf.get(TABLENAME_FIELD);
+    String bucketName = conf.get(BUCKET_NAME);
+    String bucketPathUniqueId = conf.get(BUCKET_PATH_UNIQUE_ID);
+    String projectName = conf.get(PROJECT_NAME);
+    String datasetName = conf.get(DATASET_NAME);
+
+    return new DelegatingMultiSinkRecordWriter(taskAttemptContext,
+                                               tableNameField,
+                                               bucketName,
+                                               bucketPathUniqueId,
+                                               projectName,
+                                               datasetName,
+                                               getOutputCommitterInstance(taskAttemptContext));
+  }
+
+  @Override
+  public void checkOutputSpecs(JobContext jobContext) throws IOException, InterruptedException {
+    //no-op
+  }
+
+  @Override
+  public OutputCommitter getOutputCommitter(TaskAttemptContext taskAttemptContext) {
+    return getOutputCommitterInstance(taskAttemptContext);
+  }
+
+  private DelegatingMultiSinkOutputCommitter getOutputCommitterInstance(TaskAttemptContext taskAttemptContext) {
+    if (delegatingMultiSinkOutputCommitter == null) {
+      Configuration conf = taskAttemptContext.getConfiguration();
+      String projectName = conf.get(PROJECT_NAME);
+      String datasetName = conf.get(DATASET_NAME);
+      String bucketName = conf.get(BUCKET_NAME);
+      String bucketPathUniqueId = conf.get(BUCKET_PATH_UNIQUE_ID);
+      delegatingMultiSinkOutputCommitter = new DelegatingMultiSinkOutputCommitter(projectName,
+                                                                                  datasetName,
+                                                                                  bucketName,
+                                                                                  bucketPathUniqueId);
+    }
+
+    return delegatingMultiSinkOutputCommitter;
+  }
+}

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/DelegatingMultiSinkOutputFormatProvider.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/DelegatingMultiSinkOutputFormatProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.gcp.bigquery.sink;
+
+import io.cdap.cdap.api.data.batch.OutputFormatProvider;
+import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;
+import org.apache.avro.mapred.AvroKey;
+import org.apache.hadoop.conf.Configuration;
+
+import java.util.Map;
+
+/**
+ * Provides {@link DelegatingMultiSinkOutputFormat} to output values for multiple tables when the table schema
+ * is not defined as a pipeline argument.
+ */
+public class DelegatingMultiSinkOutputFormatProvider implements OutputFormatProvider {
+
+  private final Configuration config;
+
+  public DelegatingMultiSinkOutputFormatProvider(Configuration config,
+                                                 String filterField,
+                                                 String bucketName,
+                                                 String projectName,
+                                                 String datasetName) {
+    this.config = config;
+    DelegatingMultiSinkOutputFormat.configure(config, filterField, bucketName, projectName, datasetName);
+  }
+
+  @Override
+  public String getOutputFormatClassName() {
+    return DelegatingMultiSinkOutputFormat.class.getName();
+  }
+
+  @Override
+  public Map<String, String> getOutputFormatConfiguration() {
+    Map<String, String> map = BigQueryUtil.configToMap(config);
+    map.put(org.apache.hadoop.mapred.JobContext.OUTPUT_KEY_CLASS, AvroKey.class.getName());
+    return map;
+  }
+
+}

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/DelegatingMultiSinkRecordWriter.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/DelegatingMultiSinkRecordWriter.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.gcp.bigquery.sink;
+
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Record Writer which delegates writes to other Record Writers based on the record's Table name.
+ * <p>
+ * This Record Writer will initialize record writes and Output Committers as needed.
+ */
+public class DelegatingMultiSinkRecordWriter extends RecordWriter<StructuredRecord, NullWritable> {
+
+  private final TaskAttemptContext initialContext;
+  private final String tableNameField;
+  private final String bucketName;
+  private final String bucketPathUniqueId;
+  private final String projectName;
+  private final String datasetName;
+  private final Map<String, RecordWriter<StructuredRecord, NullWritable>> delegateMap;
+  private final DelegatingMultiSinkOutputCommitter delegatingOutputCommitter;
+
+  public DelegatingMultiSinkRecordWriter(TaskAttemptContext initialContext,
+                                         String tableNameField,
+                                         String bucketName,
+                                         String bucketPathUniqueId,
+                                         String projectName,
+                                         String datasetName,
+                                         DelegatingMultiSinkOutputCommitter delegatingMultiSinkOutputCommitter) {
+    this.initialContext = initialContext;
+    this.tableNameField = tableNameField;
+    this.bucketName = bucketName;
+    this.bucketPathUniqueId = bucketPathUniqueId;
+    this.projectName = projectName;
+    this.datasetName = datasetName;
+    this.delegateMap = new HashMap<>();
+    this.delegatingOutputCommitter = delegatingMultiSinkOutputCommitter;
+  }
+
+  @Override
+  public void write(StructuredRecord key, NullWritable value) throws IOException, InterruptedException {
+    String tableName = key.get(tableNameField);
+
+    RecordWriter<StructuredRecord, NullWritable> delegate;
+
+    if (delegateMap.containsKey(tableName)) {
+      delegate = delegateMap.get(tableName);
+    } else {
+      delegate = getRecordWriterDelegate(tableName, key.getSchema());
+    }
+
+    delegate.write(key, value);
+  }
+
+  @Override
+  public void close(TaskAttemptContext context) throws IOException, InterruptedException {
+    for (RecordWriter<StructuredRecord, NullWritable> delegate : delegateMap.values()) {
+      delegate.close(context);
+    }
+
+    // The task attempt context at this stage doesn't have all of the configuration properties we need to properly
+    // execute the commit job step. For this reason, we use the original context instance that was used when
+    // creating this record writer.
+    delegatingOutputCommitter.commitTask(initialContext);
+    delegatingOutputCommitter.commitJob(initialContext);
+  }
+
+  /**
+   * Gets a new Record Writer Delegate instance for the specified table name and record schema.
+   */
+  public RecordWriter<StructuredRecord, NullWritable> getRecordWriterDelegate(String tableName, Schema schema)
+    throws IOException, InterruptedException {
+    // Configure output.
+    BigQuerySinkUtils.configureBigQueryOutputForMultiSink(initialContext,
+                                                          projectName,
+                                                          datasetName,
+                                                          bucketName,
+                                                          bucketPathUniqueId,
+                                                          tableName,
+                                                          schema);
+
+    BigQueryOutputFormat bqOutputFormat = new BigQueryOutputFormat();
+
+    // Get output committer instance for the current table and add it to the delegating Output Committer.
+    OutputCommitter bqOutputCommitter = bqOutputFormat.getOutputCommitter(initialContext);
+    delegatingOutputCommitter.addCommitterAndSchema(bqOutputCommitter, tableName, schema, initialContext);
+
+    // Get record writer instance and add it to the delegate map.
+    RecordWriter<StructuredRecord, NullWritable> delegate = bqOutputFormat.getRecordWriter(initialContext, schema);
+    delegateMap.put(tableName, delegate);
+
+    return delegate;
+  }
+}

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/DelegatingMultiSinkOutputCommitterTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/DelegatingMultiSinkOutputCommitterTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.gcp.bigquery.sink;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import org.apache.hadoop.mapreduce.JobStatus;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.doNothing;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+public class DelegatingMultiSinkOutputCommitterTest {
+
+  DelegatingMultiSinkOutputCommitter committer;
+  TaskAttemptContext ctx;
+  OutputCommitter c1;
+  OutputCommitter c2;
+  OutputCommitter c3;
+  Schema s1;
+  Schema s2;
+  Schema s3;
+
+  @Before
+  @Test
+  public void setUp() throws IOException, InterruptedException {
+    committer = spy(new DelegatingMultiSinkOutputCommitter("project", "ds", "bucket", "path"));
+    doNothing().when(committer).configureContext(any(), anyString());
+    ctx = mock(TaskAttemptContext.class);
+    c1 = mock(OutputCommitter.class);
+    c2 = mock(OutputCommitter.class);
+    c3 = mock(OutputCommitter.class);
+    s1 = null;
+    s2 = null;
+    s3 = null;
+  }
+
+  @Test
+  public void testAddCommitterAndSchema() throws IOException, InterruptedException {
+    committer.addCommitterAndSchema(c1, "table1", s1, ctx);
+
+    verify(c1, times(1)).setupJob(ctx);
+    verify(c1, times(1)).setupTask(ctx);
+  }
+
+  @Test
+  public void testNeedsTaskCommit() throws IOException, InterruptedException {
+    committer.addCommitterAndSchema(c1, "table1", s1, ctx);
+    committer.addCommitterAndSchema(c2, "table2", s2, ctx);
+    committer.addCommitterAndSchema(c3, "table3", s3, ctx);
+
+    when(c1.needsTaskCommit(ctx)).thenReturn(false);
+    when(c2.needsTaskCommit(ctx)).thenReturn(false);
+    when(c3.needsTaskCommit(ctx)).thenReturn(false);
+
+    Assert.assertFalse(committer.needsTaskCommit(ctx));
+
+    when(c1.needsTaskCommit(ctx)).thenReturn(false);
+    when(c2.needsTaskCommit(ctx)).thenReturn(false);
+    when(c3.needsTaskCommit(ctx)).thenReturn(true);
+
+    Assert.assertFalse(committer.needsTaskCommit(ctx));
+
+    when(c1.needsTaskCommit(ctx)).thenReturn(true);
+    when(c2.needsTaskCommit(ctx)).thenReturn(true);
+    when(c3.needsTaskCommit(ctx)).thenReturn(true);
+
+    Assert.assertTrue(committer.needsTaskCommit(ctx));
+  }
+
+  @Test
+  public void testCommitTask() throws IOException, InterruptedException {
+    committer.addCommitterAndSchema(c1, "table1", s1, ctx);
+    committer.addCommitterAndSchema(c2, "table2", s2, ctx);
+    committer.addCommitterAndSchema(c3, "table3", s3, ctx);
+
+    committer.commitTask(ctx);
+
+    verify(c1, times(1)).commitTask(ctx);
+    verify(c2, times(1)).commitTask(ctx);
+    verify(c3, times(1)).commitTask(ctx);
+  }
+
+  @Test
+  public void testCommitJob() throws IOException, InterruptedException {
+    committer.addCommitterAndSchema(c1, "table1", s1, ctx);
+    committer.addCommitterAndSchema(c2, "table2", s2, ctx);
+    committer.addCommitterAndSchema(c3, "table3", s3, ctx);
+
+    committer.commitJob(ctx);
+
+    verify(c1, times(1)).commitJob(ctx);
+    verify(c2, times(1)).commitJob(ctx);
+    verify(c3, times(1)).commitJob(ctx);
+  }
+
+  @Test
+  public void testAbortTask() throws IOException, InterruptedException {
+    committer.addCommitterAndSchema(c1, "table1", s1, ctx);
+    committer.addCommitterAndSchema(c2, "table2", s2, ctx);
+    committer.addCommitterAndSchema(c3, "table3", s3, ctx);
+
+    committer.abortTask(ctx);
+
+    verify(c1, times(1)).abortTask(ctx);
+    verify(c2, times(1)).abortTask(ctx);
+    verify(c3, times(1)).abortTask(ctx);
+  }
+
+  @Test
+  public void testAbortTaskCollectsExceptions() throws IOException, InterruptedException {
+    committer.addCommitterAndSchema(c1, "table1", s1, ctx);
+    committer.addCommitterAndSchema(c2, "table2", s2, ctx);
+    committer.addCommitterAndSchema(c3, "table3", s3, ctx);
+
+    doThrow(new IOException("e1")).when(c1).abortTask(any());
+    doThrow(new IOException("e2")).when(c2).abortTask(any());
+    doThrow(new IOException("e3")).when(c3).abortTask(any());
+
+    IOException expected = null;
+    String message = null;
+
+    try {
+      committer.abortTask(ctx);
+    } catch (IOException ex) {
+      expected = ex;
+    }
+
+    Set<String> exceptionMessages = new HashSet<String>() {{
+      add("e1");
+      add("e2");
+      add("e3");
+    }};
+
+    Assert.assertNotNull(expected);
+    message = expected.getMessage();
+    Assert.assertTrue(exceptionMessages.contains(message));
+    exceptionMessages.remove(message);
+
+    Assert.assertEquals(2, expected.getSuppressed().length);
+
+    message = expected.getSuppressed()[0].getMessage();
+    Assert.assertTrue(exceptionMessages.contains(message));
+    exceptionMessages.remove(message);
+
+    message = expected.getSuppressed()[1].getMessage();
+    Assert.assertTrue(exceptionMessages.contains(message));
+    exceptionMessages.remove(message);
+  }
+
+  @Test
+  public void testAbortJob() throws IOException, InterruptedException {
+    committer.addCommitterAndSchema(c1, "table1", s1, ctx);
+    committer.addCommitterAndSchema(c2, "table2", s2, ctx);
+    committer.addCommitterAndSchema(c3, "table3", s3, ctx);
+
+    committer.abortJob(ctx, JobStatus.State.FAILED);
+
+    verify(c1, times(1)).abortJob(ctx, JobStatus.State.FAILED);
+    verify(c2, times(1)).abortJob(ctx, JobStatus.State.FAILED);
+    verify(c3, times(1)).abortJob(ctx, JobStatus.State.FAILED);
+  }
+
+  @Test
+  public void testAbortJobCollectsExceptions() throws IOException, InterruptedException {
+    committer.addCommitterAndSchema(c1, "table1", s1, ctx);
+    committer.addCommitterAndSchema(c2, "table2", s2, ctx);
+    committer.addCommitterAndSchema(c3, "table3", s3, ctx);
+
+    doThrow(new IOException("e1")).when(c1).abortJob(ctx, JobStatus.State.FAILED);
+    doThrow(new IOException("e2")).when(c2).abortJob(ctx, JobStatus.State.FAILED);
+    doThrow(new IOException("e3")).when(c3).abortJob(ctx, JobStatus.State.FAILED);
+
+    IOException expected = null;
+    String message = null;
+
+    try {
+      committer.abortJob(ctx, JobStatus.State.FAILED);
+    } catch (IOException ex) {
+      expected = ex;
+    }
+
+    Set<String> exceptionMessages = new HashSet<String>() {{
+      add("e1");
+      add("e2");
+      add("e3");
+    }};
+
+    Assert.assertNotNull(expected);
+    message = expected.getMessage();
+    Assert.assertTrue(exceptionMessages.contains(message));
+    exceptionMessages.remove(message);
+
+    Assert.assertEquals(2, expected.getSuppressed().length);
+
+    message = expected.getSuppressed()[0].getMessage();
+    Assert.assertTrue(exceptionMessages.contains(message));
+    exceptionMessages.remove(message);
+
+    message = expected.getSuppressed()[1].getMessage();
+    Assert.assertTrue(exceptionMessages.contains(message));
+    exceptionMessages.remove(message);
+  }
+}

--- a/widgets/BigQueryMultiTable-batchsink.json
+++ b/widgets/BigQueryMultiTable-batchsink.json
@@ -2,7 +2,7 @@
   "metadata": {
     "spec-version": "1.5"
   },
-  "display-name" : "BigQuery Multi Table",
+  "display-name": "BigQuery Multi Table",
   "configuration-groups": [
     {
       "label": "Basic",
@@ -11,7 +11,7 @@
           "widget-type": "textbox",
           "label": "Reference Name",
           "name": "referenceName",
-          "widget-attributes" : {
+          "widget-attributes": {
             "placeholder": "Name used to identify this sink for lineage"
           }
         },
@@ -19,7 +19,7 @@
           "widget-type": "textbox",
           "label": "Project ID",
           "name": "project",
-          "widget-attributes" : {
+          "widget-attributes": {
             "default": "auto-detect"
           }
         },
@@ -35,7 +35,7 @@
           "widget-type": "textbox",
           "label": "Dataset",
           "name": "dataset",
-          "widget-attributes" : {
+          "widget-attributes": {
             "placeholder": "Dataset the tables belong to"
           }
         },
@@ -58,8 +58,8 @@
       ]
     },
     {
-      "label" : "Credentials",
-      "properties" : [
+      "label": "Credentials",
+      "properties": [
         {
           "name": "serviceAccountType",
           "label": "Service Account Type",
@@ -83,7 +83,7 @@
           "widget-type": "textbox",
           "label": "Service Account File Path",
           "name": "serviceFilePath",
-          "widget-attributes" : {
+          "widget-attributes": {
             "default": "auto-detect"
           }
         },
@@ -95,13 +95,13 @@
       ]
     },
     {
-      "label" : "Advanced",
-      "properties" : [
+      "label": "Advanced",
+      "properties": [
         {
           "widget-type": "textbox",
           "label": "Temporary Bucket Name",
           "name": "bucket",
-          "widget-attributes" : {
+          "widget-attributes": {
             "placeholder": "Google Cloud Storage bucket for temporary data"
           }
         },
@@ -109,7 +109,7 @@
           "widget-type": "textbox",
           "label": "GCS Upload Request Chunk Size",
           "name": "gcsChunkSize",
-          "widget-attributes" : {
+          "widget-attributes": {
             "placeholder": "GCS upload request chunk size in bytes"
           }
         },
@@ -119,6 +119,22 @@
           "name": "splitField",
           "widget-attributes": {
             "placeholder": "Field used to determine which table to write to"
+          }
+        },
+        {
+          "widget-type": "toggle",
+          "label": "Allow flexible schemas in Output",
+          "name": "allowFlexibleSchema",
+          "widget-attributes": {
+            "on": {
+              "value": "true",
+              "label": "Yes"
+            },
+            "off": {
+              "value": "false",
+              "label": "No"
+            },
+            "default": "off"
           }
         },
         {


### PR DESCRIPTION
I have added the option to use the BigQuery Multisink without having to set schemas as pipeline arguments. This ties to the Database MultiSource when used with custom SQL statements.

Users now have a configuration option in the BigQuery MultiSink which allows the  BigQuery Multisink to run without having the record(s) schema set in the pipeline. However, this means that we will not try to validate the BigQuery schema before writing to output.