### PR TITLE
Support datetime for Bigtable source and sink

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigtable/sink/BigtableSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigtable/sink/BigtableSink.java
@@ -57,7 +57,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 /**
@@ -192,7 +191,8 @@ public final class BigtableSink extends BatchSink<StructuredRecord, ImmutableByt
       Schema nonNullableSchema = field.getSchema().isNullable() ?
         field.getSchema().getNonNullable() : field.getSchema();
       if (!SUPPORTED_FIELD_TYPES.contains(nonNullableSchema.getType()) ||
-        nonNullableSchema.getLogicalType() != null) {
+        (nonNullableSchema.getLogicalType() != Schema.LogicalType.DATETIME &&
+          nonNullableSchema.getLogicalType() != null)) {
 
         String supportedTypes = SUPPORTED_FIELD_TYPES.stream()
           .map(Enum::name)
@@ -201,7 +201,7 @@ public final class BigtableSink extends BatchSink<StructuredRecord, ImmutableByt
 
         String errorMessage = String.format("Field '%s' is of unsupported type '%s'.",
                                             field.getName(), nonNullableSchema.getDisplayName());
-        collector.addFailure(errorMessage, String.format("Supported types are: %s.", supportedTypes))
+        collector.addFailure(errorMessage, String.format("Supported types are: datetime, %s.", supportedTypes))
           .withInputSchemaField(field.getName());
       }
     }

--- a/src/main/java/io/cdap/plugin/gcp/bigtable/source/BigtableSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigtable/source/BigtableSourceConfig.java
@@ -237,14 +237,15 @@ public final class BigtableSourceConfig extends GCPReferenceSourceConfig {
             field.getSchema().getNonNullable() : field.getSchema();
 
           if (!SUPPORTED_FIELD_TYPES.contains(nonNullableSchema.getType()) ||
-            nonNullableSchema.getLogicalType() != null) {
+            (nonNullableSchema.getLogicalType() != Schema.LogicalType.DATETIME &&
+              nonNullableSchema.getLogicalType() != null)) {
             String supportedTypes = SUPPORTED_FIELD_TYPES.stream()
               .map(Enum::name)
               .map(String::toLowerCase)
               .collect(Collectors.joining(", "));
             String errorMessage = String.format("Field '%s' is of unsupported type '%s'.",
                                                 field.getName(), nonNullableSchema.getDisplayName());
-            collector.addFailure(errorMessage, String.format("Supported types are: %s.", supportedTypes))
+            collector.addFailure(errorMessage, String.format("Supported types are: datetime, %s.", supportedTypes))
               .withOutputSchemaField(field.getName());
           }
         }

--- a/src/main/java/io/cdap/plugin/gcp/bigtable/source/HBaseResultToRecordTransformer.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigtable/source/HBaseResultToRecordTransformer.java
@@ -22,6 +22,8 @@ import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.util.Bytes;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -76,7 +78,16 @@ public class HBaseResultToRecordTransformer {
     }
     switch (fieldSchema.getType()) {
       case STRING:
-        return Bytes.toString(bytes);
+        String stringValue = Bytes.toString(bytes);
+        if (fieldSchema.getLogicalType() == Schema.LogicalType.DATETIME) {
+          try {
+            LocalDateTime.parse(stringValue);
+          } catch (DateTimeParseException exception) {
+            throw new UnexpectedFormatException(
+              String.format("Datetime field with value '%s' is not in ISO-8601 format.", stringValue), exception);
+          }
+        }
+        return stringValue;
       case BYTES:
         return bytes;
       case INT:

--- a/src/test/java/io/cdap/plugin/gcp/bigtable/sink/RecordToHBaseMutationTransformerTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigtable/sink/RecordToHBaseMutationTransformerTest.java
@@ -26,6 +26,8 @@ import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
 public class RecordToHBaseMutationTransformerTest {
@@ -43,9 +45,11 @@ public class RecordToHBaseMutationTransformerTest {
       Schema.Field.of("long_column", Schema.nullableOf(Schema.of(Schema.Type.LONG))),
       Schema.Field.of("float_column", Schema.nullableOf(Schema.of(Schema.Type.FLOAT))),
       Schema.Field.of("double_column", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
-      Schema.Field.of("boolean_column", Schema.nullableOf(Schema.of(Schema.Type.BOOLEAN)))
+      Schema.Field.of("boolean_column", Schema.nullableOf(Schema.of(Schema.Type.BOOLEAN))),
+      Schema.Field.of("datetime_column", Schema.nullableOf(Schema.of(Schema.LogicalType.DATETIME)))
     );
 
+    LocalDateTime now = LocalDateTime.now();
     StructuredRecord inputRecord = StructuredRecord.builder(schema)
       .set("id", 1)
       .set("string_column", "string_value")
@@ -55,6 +59,7 @@ public class RecordToHBaseMutationTransformerTest {
       .set("float_column", 15.5F)
       .set("double_column", 10.5D)
       .set("boolean_column", true)
+      .setDateTime("datetime_column", now)
       .build();
 
     Map<String, HBaseColumn> columnMappings = ImmutableMap.<String, HBaseColumn>builder()
@@ -66,6 +71,7 @@ public class RecordToHBaseMutationTransformerTest {
       .put("double_column", HBaseColumn.fromFamilyAndQualifier(TEST_FAMILY_STRING, "double_column"))
       .put("bytes_column", HBaseColumn.fromFamilyAndQualifier(TEST_FAMILY_STRING, "bytes_column"))
       .put("string_column", HBaseColumn.fromFamilyAndQualifier(TEST_FAMILY_STRING, "string_column"))
+      .put("datetime_column", HBaseColumn.fromFamilyAndQualifier(TEST_FAMILY_STRING, "datetime_column"))
       .build();
 
     RecordToHBaseMutationTransformer transformer =
@@ -80,6 +86,8 @@ public class RecordToHBaseMutationTransformerTest {
     Assert.assertTrue(put.has(TEST_FAMILY, Bytes.toBytes("float_column"), Bytes.toBytes(15.5F)));
     Assert.assertTrue(put.has(TEST_FAMILY, Bytes.toBytes("double_column"), Bytes.toBytes(10.5D)));
     Assert.assertTrue(put.has(TEST_FAMILY, Bytes.toBytes("boolean_column"), Bytes.toBytes(true)));
+    Assert.assertTrue(put.has(TEST_FAMILY, Bytes.toBytes("datetime_column"),
+                              Bytes.toBytes(now.format(DateTimeFormatter.ISO_DATE_TIME))));
   }
 
   @Test

--- a/src/test/java/io/cdap/plugin/gcp/bigtable/source/HBaseResultToRecordTransformerTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigtable/source/HBaseResultToRecordTransformerTest.java
@@ -29,6 +29,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 
@@ -39,6 +41,8 @@ public class HBaseResultToRecordTransformerTest {
 
   @Test
   public void testTransformAllTypes() {
+    LocalDateTime now = LocalDateTime.now();
+    String formatted = now.format(DateTimeFormatter.ISO_DATE_TIME);
     List<Cell> cellList = ImmutableList.of(
       createCell("boolean_column", Bytes.toBytes(true)),
       createCell("bytes_column", Bytes.toBytes("bytes")),
@@ -46,7 +50,8 @@ public class HBaseResultToRecordTransformerTest {
       createCell("float_column", Bytes.toBytes(10.5F)),
       createCell("int_column", Bytes.toBytes(1)),
       createCell("long_column", Bytes.toBytes(10L)),
-      createCell("string_column", Bytes.toBytes("string"))
+      createCell("string_column", Bytes.toBytes("string")),
+      createCell("datetime_column", Bytes.toBytes(formatted))
     );
     Result result = Result.create(cellList);
 
@@ -58,7 +63,8 @@ public class HBaseResultToRecordTransformerTest {
                       Schema.Field.of("float_column", Schema.of(Schema.Type.FLOAT)),
                       Schema.Field.of("double_column", Schema.of(Schema.Type.DOUBLE)),
                       Schema.Field.of("bytes_column", Schema.of(Schema.Type.BYTES)),
-                      Schema.Field.of("string_column", Schema.of(Schema.Type.STRING))
+                      Schema.Field.of("string_column", Schema.of(Schema.Type.STRING)),
+                      Schema.Field.of("datetime_column", Schema.of(Schema.LogicalType.DATETIME))
       );
 
     Map<String, String> columnMappings = ImmutableMap.<String, String>builder()
@@ -69,6 +75,7 @@ public class HBaseResultToRecordTransformerTest {
       .put("test:double_column", "double_column")
       .put("test:bytes_column", "bytes_column")
       .put("test:string_column", "string_column")
+      .put("test:datetime_column", "datetime_column")
       .build();
 
     HBaseResultToRecordTransformer transformer = new HBaseResultToRecordTransformer(schema, null, columnMappings);
@@ -81,6 +88,7 @@ public class HBaseResultToRecordTransformerTest {
     Assert.assertEquals(10.5D, record.get("double_column"), 0);
     Assert.assertEquals("bytes", new String((byte[]) record.get("bytes_column")));
     Assert.assertEquals("string", record.get("string_column"));
+    Assert.assertEquals(formatted, record.get("datetime_column"));
   }
 
   @Test

--- a/src/test/java/io/cdap/plugin/gcp/datastore/sink/RecordToEntityTransformerTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/datastore/sink/RecordToEntityTransformerTest.java
@@ -37,6 +37,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -255,7 +256,7 @@ public class RecordToEntityTransformerTest {
     Assert.assertTrue(value.getExcludeFromIndexes());
 
     value = outputEntity.getPropertiesOrThrow("datetime_field");
-    Assert.assertEquals(localDateTime.toString(), DatastoreHelper.getString(value));
+    Assert.assertEquals(localDateTime.format(DateTimeFormatter.ISO_DATE_TIME), DatastoreHelper.getString(value));
     Assert.assertTrue(value.getExcludeFromIndexes());
 
     value = outputEntity.getPropertiesOrThrow("boolean_field");

--- a/src/test/java/io/cdap/plugin/gcp/datastore/source/EntityToRecordTransformerTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/datastore/source/EntityToRecordTransformerTest.java
@@ -40,6 +40,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 
 /**
@@ -81,6 +82,7 @@ public class EntityToRecordTransformerTest {
       Value.newBuilder().setStringValue("value_2").build())).build();
 
     LocalDateTime currentDateTime = LocalDateTime.now();
+    String formattedDt = currentDateTime.format(DateTimeFormatter.ISO_DATE_TIME);
     Entity entity = Entity.newBuilder()
       .setKey(Key.newBuilder().
         setPartitionId(PartitionId.newBuilder()
@@ -90,7 +92,7 @@ public class EntityToRecordTransformerTest {
       .putProperties("double_field", Value.newBuilder().setDoubleValue(10.5D).build())
       .putProperties("boolean_field", Value.newBuilder().setBooleanValue(true).build())
       .putProperties("timestamp_field", Value.newBuilder().setTimestampValue(entityTs).build())
-      .putProperties("datetime_field", Value.newBuilder().setStringValue(currentDateTime.toString()).build())
+      .putProperties("datetime_field", Value.newBuilder().setStringValue(formattedDt).build())
       .putProperties("blob_field", Value.newBuilder().
         setBlobValue(ByteString.copyFrom(Blob.copyFrom("test_blob".getBytes()).toByteArray())).build())
       .putProperties("null_field", Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build())

--- a/src/test/java/io/cdap/plugin/gcp/spanner/sink/RecordToMutationTransformerTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/spanner/sink/RecordToMutationTransformerTest.java
@@ -33,6 +33,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
@@ -239,7 +240,7 @@ public class RecordToMutationTransformerTest {
                                     Schema.Field.of("DT", Schema.nullableOf(Schema.of(Schema.LogicalType.DATETIME))));
     RecordToMutationTransformer transformer = new RecordToMutationTransformer("test", schema);
     StructuredRecord record = StructuredRecord.builder(schema).setDateTime("DT", localDateTime).build();
-    Assert.assertEquals(Value.string(localDateTime.toString()),
+    Assert.assertEquals(Value.string(localDateTime.format(DateTimeFormatter.ISO_DATE_TIME)),
                         transformer.convertToValue("DT", schema.getField("DT").getSchema(), record));
   }
 

--- a/src/test/java/io/cdap/plugin/gcp/spanner/source/ResultSetToRecordTransformerTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/spanner/source/ResultSetToRecordTransformerTest.java
@@ -34,6 +34,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
 
@@ -127,8 +128,9 @@ public class ResultSetToRecordTransformerTest {
     );
 
     LocalDateTime datetime = LocalDateTime.now();
+    String formattedDatetime = datetime.format(DateTimeFormatter.ISO_DATE_TIME);
     Mockito.when(rsMock.getColumnType("datetime_field")).thenReturn(Type.string());
-    Mockito.when(rsMock.getString("datetime_field")).thenReturn(datetime.toString());
+    Mockito.when(rsMock.getString("datetime_field")).thenReturn(formattedDatetime);
 
     ResultSetToRecordTransformer transformer = new ResultSetToRecordTransformer(TEST_SCHEMA);
     StructuredRecord record = transformer.transform(rsMock);
@@ -145,7 +147,7 @@ public class ResultSetToRecordTransformerTest {
     Assert.assertArrayEquals(expectedFloatList.toArray(), record.get("float_array"));
     Assert.assertArrayEquals(expectedStringList.toArray(), record.get("string_array"));
     Assert.assertArrayEquals(new byte[][]{"1".getBytes(), "2".getBytes(), null}, record.get("bytes_array"));
-    Assert.assertEquals(datetime.toString(), record.get("datetime_field"));
+    Assert.assertEquals(formattedDatetime, record.get("datetime_field"));
   }
 
   @Test(expected = UnexpectedFormatException.class)


### PR DESCRIPTION
- Datetime support for Bigtable source and sink
- Fixed other plugin tests to test with formatted datetime string to avoid flakiness 
- Tested Bigtable source , sink with valid and invalid datetime values