### PR TITLE
CDAP-17746: Field validation logic in BigQuery sink pipelines causes a NullPointerException

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
@@ -365,7 +365,8 @@ public final class BigQueryUtil {
    */
   public static void validateFieldModeMatches(Field bigQueryField, Schema.Field field, boolean allowSchemaRelaxation,
                                               FailureCollector collector) {
-    boolean isBqFieldNullable = bigQueryField.getMode().equals(Field.Mode.NULLABLE);
+    Field.Mode mode = bigQueryField.getMode();
+    boolean isBqFieldNullable = mode == null || mode.equals(Field.Mode.NULLABLE);
     if (!allowSchemaRelaxation && field.getSchema().isNullable() != isBqFieldNullable) {
       collector.addFailure(String.format("Field '%s' cannot be %s.", bigQueryField.getName(),
                                          isBqFieldNullable ? "required" : "nullable"),


### PR DESCRIPTION
API returns null for BigQuery Field Mode. Which by defaults means it's NULLABLE.

Reference: https://github.com/googleapis/google-cloud-java/issues/3509
Jira: https://cdap.atlassian.net/browse/CDAP-17746