### PR TITLE
[PLUGIN-624] Cherrypick, Fix issue where BQ sink fails if there are two input sources with different schema record name 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
     <httpclient.version>4.5.6</httpclient.version>
     <jackson.core.version>2.8.11.1</jackson.core.version>
     <junit.version>4.12</junit.version>
+    <powermock.version>2.0.2</powermock.version>
     <slf4j.version>1.7.5</slf4j.version>
     <spark.version>2.3.1</spark.version>
   </properties>
@@ -450,6 +451,18 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
@@ -34,6 +34,7 @@ import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
 import com.google.common.base.Strings;
+import com.google.gson.Gson;
 import io.cdap.cdap.api.data.batch.Output;
 import io.cdap.cdap.api.data.batch.OutputFormatProvider;
 import io.cdap.cdap.api.data.format.StructuredRecord;
@@ -76,6 +77,7 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, A
   private static final String gcsPathFormat = "gs://%s/%s";
   private static final String temporaryBucketFormat = gcsPathFormat + "/input/%s-%s";
   public static final String RECORDS_UPDATED_METRIC = "records.updated";
+  private static final Gson GSON = new Gson();
 
   // UUID for the run. Will be used as bucket name if bucket is not provided.
   // UUID is used since GCS bucket names must be globally unique.
@@ -135,14 +137,15 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, A
 
   @Override
   public void initialize(BatchRuntimeContext context) throws Exception {
-    avroTransformer = new StructuredToAvroTransformer(null);
+    Schema schema = GSON.fromJson(context.getArguments().get(BigQueryConstants.CDAP_BQ_SINK_TABLE), Schema.class);
+    avroTransformer = new StructuredToAvroTransformer(schema);
   }
 
   /**
    * Transform the given {@link StructuredRecord} into avro {@link GenericRecord} with the same schema.
    */
   protected final GenericRecord toAvroRecord(StructuredRecord record) throws IOException {
-    return avroTransformer.transform(record, record.getSchema());
+    return avroTransformer.transform(record);
   }
 
   /**
@@ -170,6 +173,7 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, A
       .map(BigQueryTableFieldSchema::getName)
       .collect(Collectors.toList());
     recordLineage(context, outputName, tableSchema, fieldNames);
+    context.getArguments().set(BigQueryConstants.CDAP_BQ_SINK_TABLE, GSON.toJson(tableSchema));
     context.addOutput(Output.of(outputName, getOutputFormatProvider(configuration, tableName, tableSchema)));
   }
 
@@ -265,76 +269,6 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, A
     baseConfiguration.setBoolean("fs.gs.impl.disable.cache", true);
     baseConfiguration.setBoolean("fs.gs.metadata.cache.enable", false);
     return bucket;
-  }
-
-  /**
-   * Adjusts output format schema depending on allowSchemaRelaxation setting to avoid unexpected
-   * schema changes to the underlying bigQuery table.
-   * @param configuredSchema Schema configured for output format.
-   * @param bqSchema Optional BigQuery table schema to avoid duplicate calls.
-   * @param tableName BigQuery table name for writing record.
-   * @param collector Failure collector to report failures to the client.
-   * @return
-   */
-  protected final Schema overrideOutputSchemaWithTableSchemaIfNeeded(
-    String tableName,
-    Schema configuredSchema,
-    @Nullable com.google.cloud.bigquery.Schema bqSchema,
-    FailureCollector collector) {
-    AbstractBigQuerySinkConfig config = getConfig();
-
-    if (!config.isAllowSchemaRelaxation()) {
-      Schema tableSchema = getTableSchema(tableName, bqSchema, collector);
-      // We use GCS buckets to write AVRO files and import them in BigQuery.
-      // Avro is a self describing format and BigQuery overwrites table schema with AVRO record
-      // schema.
-      // If table schema relaxation is not allowed then AVRO records will be normalized and
-      // written to GCS using table schema to avoid any table schema changes.
-      if (tableSchema != null) {
-        LOG.info("Output schema updated to use table schema");
-        return tableSchema;
-      }
-    }
-    return configuredSchema;
-  }
-
-  /**
-   * Returns Bigtable schema in a CDAP schema format.
-   * @param tableName BigQuery table name for writing record.
-   * @param bqSchema Optional BigQuery table schema to avoid duplicate calls.
-   * @param collector Failure collector to report failures to the client.
-   * @return
-   */
-  @Nullable
-  private Schema getTableSchema(
-    String tableName,
-    @Nullable com.google.cloud.bigquery.Schema bqSchema,
-    FailureCollector collector) {
-    if (bqSchema == null) {
-      AbstractBigQuerySinkConfig config = getConfig();
-      Table table = BigQueryUtil.getBigQueryTable(
-        config.getProject(),
-        config.getDataset(),
-        tableName,
-        config.getServiceAccount(),
-        config.isServiceAccountFilePath(),
-        collector);
-
-      if (table == null) {
-        LOG.info("Table [%s] doesn't exist yet. Using input schema for writing records.",
-          tableName);
-        return null;
-      }
-
-      bqSchema = table.getDefinition().getSchema();
-    }
-
-    if (bqSchema == null || bqSchema.getFields().isEmpty()) {
-      // Table is created without schema, so no further validation is required.
-      LOG.info("Table [%s] doesn't have a schema. Using input schema for writing records.", tableName);
-      return null;
-    }
-    return BigQueryUtil.getTableSchema(bqSchema, collector);
   }
 
   protected void validateInsertSchema(Table table, @Nullable Schema tableSchema, FailureCollector collector) {

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSink.java
@@ -109,8 +109,6 @@ public class BigQueryMultiSink extends AbstractBigQuerySink {
 
           validateSchema(tableName, bqSchema, configuredSchema, config.allowSchemaRelaxation, collector);
 
-          tableSchema = overrideOutputSchemaWithTableSchemaIfNeeded(
-            tableName, configuredSchema, bqSchema, collector);
         }
 
         String outputName = String.format("%s-%s", config.getReferenceName(), tableName);

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -112,8 +112,7 @@ public final class BigQuerySink extends AbstractBigQuerySink {
     FailureCollector collector = context.getFailureCollector();
 
     Schema configSchema = config.getSchema(collector);
-    Schema outputSchema = overrideOutputSchemaWithTableSchemaIfNeeded(
-      config.getTable(), configSchema == null ? context.getInputSchema() : configSchema, null, collector);
+    Schema outputSchema = configSchema == null ? context.getInputSchema() : configSchema;
 
     configureTable(outputSchema);
     configureBigQuerySink();
@@ -185,12 +184,7 @@ public final class BigQuerySink extends AbstractBigQuerySink {
 
       @Override
       public Map<String, String> getOutputFormatConfiguration() {
-        Map<String, String> configToMap = BigQueryUtil.configToMap(configuration);
-        if (tableSchema != null) {
-          configToMap
-            .put(BigQueryConstants.CDAP_BQ_SINK_OUTPUT_SCHEMA, tableSchema.toString());
-        }
-        return configToMap;
+        return BigQueryUtil.configToMap(configuration);
       }
     };
   }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
@@ -43,5 +43,5 @@ public interface BigQueryConstants {
   String CONFIG_PARTITION_INTEGER_RANGE_END = "cdap.bq.sink.partition.integer.range.end";
   String CONFIG_PARTITION_INTEGER_RANGE_INTERVAL = "cdap.bq.sink.partition.integer.range.interval";
   String CONFIG_TEMPORARY_TABLE_NAME = "cdap.bq.source.temporary.table.name";
-  String CDAP_BQ_SINK_OUTPUT_SCHEMA = "cdap.bq.sink.output.schema";
+  String CDAP_BQ_SINK_TABLE = "cdap.bq.sink.output.schema";
 }


### PR DESCRIPTION
Cherrypick commit 78cc2bc which already fixed issue in release/0.17
JIRA: https://cdap.atlassian.net/browse/PLUGIN-624