### PR TITLE
[PLUGIN-624] Cherrypick, Fix issue where BQ sink fails if there are two input sources with different schema record name 

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSink.java
@@ -110,8 +110,6 @@ public class BigQueryMultiSink extends AbstractBigQuerySink {
 
           validateSchema(tableName, bqSchema, configuredSchema, config.allowSchemaRelaxation, collector);
 
-          tableSchema = overrideOutputSchemaWithTableSchemaIfNeeded(
-            tableName, configuredSchema, bqSchema, collector);
         }
 
         String outputName = String.format("%s-%s", config.getReferenceName(), tableName);

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -115,8 +115,7 @@ public final class BigQuerySink extends AbstractBigQuerySink {
     FailureCollector collector = context.getFailureCollector();
 
     Schema configSchema = config.getSchema(collector);
-    Schema outputSchema = overrideOutputSchemaWithTableSchemaIfNeeded(
-      config.getTable(), configSchema == null ? context.getInputSchema() : configSchema, null, collector);
+    Schema outputSchema = configSchema == null ? context.getInputSchema() : configSchema;
 
     configureTable(outputSchema);
     configureBigQuerySink();

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
@@ -43,4 +43,5 @@ public interface BigQueryConstants {
   String CONFIG_PARTITION_INTEGER_RANGE_END = "cdap.bq.sink.partition.integer.range.end";
   String CONFIG_PARTITION_INTEGER_RANGE_INTERVAL = "cdap.bq.sink.partition.integer.range.interval";
   String CONFIG_TEMPORARY_TABLE_NAME = "cdap.bq.source.temporary.table.name";
+  String CDAP_BQ_SINK_TABLE = "cdap.bq.sink.output.schema";
 }


### PR DESCRIPTION
Cherrypick commit 78cc2bc which already fixed issue in release/0.17
JIRA: https://cdap.atlassian.net/browse/PLUGIN-624