### PR TITLE
PLUGIN-678 - Override configured schema only for load job config 

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSink.java
@@ -122,8 +122,6 @@ public class BigQueryMultiSink extends AbstractBigQuerySink {
 
           validateSchema(tableName, bqSchema, configuredSchema, config.allowSchemaRelaxation, collector);
 
-          tableSchema = overrideOutputSchemaWithTableSchemaIfNeeded(
-            tableName, configuredSchema, bqSchema, collector);
         }
 
         String outputName = String.format("%s-%s", config.getReferenceName(), tableName);

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
@@ -283,7 +283,13 @@ public class BigQueryOutputFormat extends ForwardingBigQueryFileOutputFormat<Str
       }
       // Create load conf with minimal requirements.
       JobConfigurationLoad loadConfig = new JobConfigurationLoad();
-      loadConfig.setSchema(schema);
+      // If schema change is not allowed and if the destination table already exists, use the destination table schema
+      // See PLUGIN-395
+      if (!allowSchemaRelaxation && tableExists) {
+        loadConfig.setSchema(bigQueryHelper.getTable(tableRef).getSchema());
+      } else {
+        loadConfig.setSchema(schema);
+      }
       loadConfig.setSourceFormat(sourceFormat.getFormatIdentifier());
       loadConfig.setSourceUris(gcsPaths);
       loadConfig.setWriteDisposition(writeDisposition);
@@ -367,12 +373,12 @@ public class BigQueryOutputFormat extends ForwardingBigQueryFileOutputFormat<Str
         loadConfig.setDestinationEncryptionConfiguration(new EncryptionConfiguration().setKmsKeyName(kmsKeyName));
       }
 
-      // Auto detect the schema if we're not given one, otherwise use the passed schema.
-      if (schema == null) {
+      // Auto detect the schema if we're not given one, otherwise use the set schema.
+      if (loadConfig.getSchema() == null) {
         LOG.info("No import schema provided, auto detecting schema.");
         loadConfig.setAutodetect(true);
       } else {
-        LOG.info("Using provided import schema '{}'.", schema.toString());
+        LOG.info("Using schema '{}' for the load job config.", loadConfig.getSchema());
       }
 
       JobConfiguration config = new JobConfiguration();

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -108,8 +108,7 @@ public final class BigQuerySink extends AbstractBigQuerySink {
     FailureCollector collector = context.getFailureCollector();
 
     Schema configSchema = config.getSchema(collector);
-    Schema outputSchema = overrideOutputSchemaWithTableSchemaIfNeeded(
-      config.getTable(), configSchema == null ? context.getInputSchema() : configSchema, null, collector);
+    Schema outputSchema = configSchema == null ? context.getInputSchema() : configSchema;
 
     configureTable(outputSchema);
     configureBigQuerySink();


### PR DESCRIPTION
- Configured schema was overridden for BQSink in prepareRun for preventing unexpected schema changes in target table (https://cdap.atlassian.net/browse/PLUGIN-395)
- With date time changes (https://github.com/data-integrations/google-cloud/commit/9bde7d253ec42f43919170a97ea8b470040d9dfc), the configured schema was used to create the AVRO schema and this resulted in the bug https://cdap.atlassian.net/browse/PLUGIN-678 . This was done because configured schema could be a subset of the data schema and is consistent with the BigQueryJsonConverter behavior.
- Moved the schema overriding to OutputCommitter only for the load job setting so that the configured schema remains the same and target table schema is not changed
- Tested for existing/new tables with INTEGER, Float, Date, Time, Timestamp, String , Datetime
- Tested for upsert on existing tables
- Tested pipeline with no schema (GCS avro to BQ sink)
- Tested that schema change happens when `update schema` is set
- Tested BQ multi table sink with Integer