### PR TITLE
Plugin-655: BQ Sink without input schema or table fails with NPE - CherryPick for release/0.15

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -185,7 +185,12 @@ public final class BigQuerySink extends AbstractBigQuerySink {
 
       @Override
       public Map<String, String> getOutputFormatConfiguration() {
-        return BigQueryUtil.configToMap(configuration);
+        Map<String, String> configToMap = BigQueryUtil.configToMap(configuration);
+        if (tableSchema != null) {
+          configToMap
+            .put(BigQueryConstants.CDAP_BQ_SINK_OUTPUT_SCHEMA, tableSchema.toString());
+        }
+        return configToMap;
       }
     };
   }
@@ -244,15 +249,17 @@ public final class BigQuerySink extends AbstractBigQuerySink {
                                                 config.getServiceAccount(),
                                                 config.isServiceAccountFilePath());
     baseConfiguration.setBoolean(BigQueryConstants.CONFIG_DESTINATION_TABLE_EXISTS, table != null);
-    List<String> tableFieldsNames;
+    List<String> tableFieldsNames = null;
     if (table != null) {
        tableFieldsNames = Objects.requireNonNull(table.getDefinition().getSchema()).getFields().stream()
         .map(Field::getName).collect(Collectors.toList());
-    } else {
+    } else if (schema != null) {
       tableFieldsNames = schema.getFields().stream()
         .map(Schema.Field::getName).collect(Collectors.toList());
     }
-    baseConfiguration.set(BigQueryConstants.CONFIG_TABLE_FIELDS, String.join(",", tableFieldsNames));
+    if (tableFieldsNames != null) {
+      baseConfiguration.set(BigQueryConstants.CONFIG_TABLE_FIELDS, String.join(",", tableFieldsNames));
+    }
   }
 
   private void validateConfiguredSchema(Schema schema, FailureCollector collector) {

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
@@ -43,4 +43,5 @@ public interface BigQueryConstants {
   String CONFIG_PARTITION_INTEGER_RANGE_END = "cdap.bq.sink.partition.integer.range.end";
   String CONFIG_PARTITION_INTEGER_RANGE_INTERVAL = "cdap.bq.sink.partition.integer.range.interval";
   String CONFIG_TEMPORARY_TABLE_NAME = "cdap.bq.source.temporary.table.name";
+  String CDAP_BQ_SINK_OUTPUT_SCHEMA = "cdap.bq.sink.output.schema";
 }


### PR DESCRIPTION
BQ Sink without input schema or table fails with NPE
PR: https://github.com/data-integrations/google-cloud/pull/611
JIRA ticket: https://cdap.atlassian.net/browse/PLUGIN-655

