### PR TITLE
[PLUGIN-178] Allow writing required CDAP schema field to null BQ tabl…

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
@@ -362,11 +362,12 @@ public final class BigQueryUtil {
    */
   public static void validateFieldModeMatches(Field bigQueryField, Schema.Field field, boolean allowSchemaRelaxation,
                                               FailureCollector collector) {
-    boolean isBqFieldNullable = bigQueryField.getMode().equals(Field.Mode.NULLABLE);
-    if (!allowSchemaRelaxation && field.getSchema().isNullable() != isBqFieldNullable) {
-      collector.addFailure(String.format("Field '%s' cannot be %s.", bigQueryField.getName(),
-                                         isBqFieldNullable ? "required" : "nullable"),
-                           String.format("Change the field to be %s.", isBqFieldNullable ? "nullable" : "required"))
+    Field.Mode mode = bigQueryField.getMode();
+    boolean isBqFieldNullable = mode == null || mode.equals(Field.Mode.NULLABLE);
+    if (!allowSchemaRelaxation && field.getSchema().isNullable() && !isBqFieldNullable) {
+      // Nullable output schema field is incompatible with required BQ table field
+      collector.addFailure(String.format("Field '%s' cannot be nullable.", bigQueryField.getName()),
+                           "Change the field to be required.")
         .withOutputSchemaField(field.getName());
     }
   }


### PR DESCRIPTION
…e field

In #554, we added a validation check that enforced nullability of each CDAP schema field = BQ field.
While this check is correct when CDAP field is nullable and BQ field is required (we shouldn't write
nulls to a required BQ field), the reverse check is incorrect. i.e. we should be able to write a
non-nullable CDAP field to a nullable BQ field because it's ok to write non null values to a nullable
field.