### PR TITLE
Handle nullable arrays in BigQuery Sink

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryRecordToJson.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryRecordToJson.java
@@ -187,44 +187,42 @@ public final class BigQueryRecordToJson {
                                  String name,
                                  @Nullable Object value,
                                  Schema fieldSchema) throws IOException {
-    if (value == null) {
-      throw new RuntimeException(
-        String.format("Field '%s' is of value null, which is not a valid value for BigQuery type array.", name));
-    }
-
-    Collection collection;
-    if (value instanceof Collection) {
-      collection = (Collection) value;
-    } else if (value instanceof Object[]) {
-      collection = Arrays.asList((Object[]) value);
-    } else {
-      throw new IllegalArgumentException(String.format(
-        "A value for the field '%s' is of type '%s' when it is expected to be a Collection or array.",
-        name, value.getClass().getSimpleName()));
-    }
-
-    Schema componentSchema = BigQueryUtil.getNonNullableSchema(
-      Objects.requireNonNull(fieldSchema.getComponentSchema()));
-    if (BigQueryUtil.UNSUPPORTED_ARRAY_TYPES.contains(componentSchema.getType())) {
-      throw new IllegalArgumentException(String.format("Field '%s' is an array of '%s', " +
-                                                         "which is not a valid BigQuery type.",
-                                                       name, componentSchema));
-    }
-
     writer.name(name);
     writer.beginArray();
 
-    for (Object element : collection) {
-      // BigQuery does not allow null values in array items
-      if (element == null) {
-        throw new IllegalArgumentException(String.format("Field '%s' contains null values in its array, " +
-                                                           "which is not allowed by BigQuery.", name));
-      }
-      if (element instanceof StructuredRecord) {
-        StructuredRecord record = (StructuredRecord) element;
-        processRecord(writer, record, Objects.requireNonNull(record.getSchema().getFields()));
+    if (value != null) {
+      Collection collection;
+      if (value instanceof Collection) {
+        collection = (Collection) value;
+      } else if (value instanceof Object[]) {
+        collection = Arrays.asList((Object[]) value);
       } else {
-        write(writer, name, true, element, componentSchema);
+        throw new IllegalArgumentException(String.format(
+                "A value for the field '%s' is of type '%s' when it is expected to be a Collection or array.",
+                name, value.getClass().getSimpleName()));
+      }
+
+      Schema componentSchema = BigQueryUtil.getNonNullableSchema(
+              Objects.requireNonNull(fieldSchema.getComponentSchema()));
+      if (BigQueryUtil.UNSUPPORTED_ARRAY_TYPES.contains(componentSchema.getType())) {
+        throw new IllegalArgumentException(String.format("Field '%s' is an array of '%s', " +
+                        "which is not a valid BigQuery type.",
+                name, componentSchema));
+      }
+
+
+      for (Object element : collection) {
+        // BigQuery does not allow null values in array items
+        if (element == null) {
+          throw new IllegalArgumentException(String.format("Field '%s' contains null values in its array, " +
+                  "which is not allowed by BigQuery.", name));
+        }
+        if (element instanceof StructuredRecord) {
+          StructuredRecord record = (StructuredRecord) element;
+          processRecord(writer, record, Objects.requireNonNull(record.getSchema().getFields()));
+        } else {
+          write(writer, name, true, element, componentSchema);
+        }
       }
     }
     writer.endArray();

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtilTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtilTest.java
@@ -1,0 +1,27 @@
+package io.cdap.plugin.gcp.bigquery.util;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.FailureCollector;
+import io.cdap.cdap.etl.api.validation.ValidationFailure;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class BigQueryUtilTest {
+
+    @Test
+    public void testValidateArraySchema() {
+        String arrayField = "nullArray";
+        Schema schema = Schema.recordOf("record",
+                Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+                Schema.Field.of(arrayField, Schema.nullableOf(Schema.arrayOf(Schema.of(Schema.Type.STRING)))));
+
+        FailureCollector collector = Mockito.mock(FailureCollector.class);
+
+        ValidationFailure failure  = BigQueryUtil.validateArraySchema(
+                schema.getField(arrayField).getSchema(), arrayField, collector
+        );
+
+        Assert.assertNull(failure);
+    }
+}

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtilTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtilTest.java
@@ -1,11 +1,19 @@
 package io.cdap.plugin.gcp.bigquery.util;
 
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.StandardSQLTypeName;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.validation.ValidationFailure;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import java.util.List;
+import javax.validation.constraints.AssertTrue;
+
+import static org.mockito.ArgumentMatchers.anyString;
 
 public class BigQueryUtilTest {
 
@@ -17,11 +25,13 @@ public class BigQueryUtilTest {
                 Schema.Field.of(arrayField, Schema.nullableOf(Schema.arrayOf(Schema.of(Schema.Type.STRING)))));
 
         FailureCollector collector = Mockito.mock(FailureCollector.class);
+        Mockito.when(collector.addFailure(anyString(), anyString())).thenReturn(new ValidationFailure("errorMessage"));
 
-        ValidationFailure failure  = BigQueryUtil.validateArraySchema(
-                schema.getField(arrayField).getSchema(), arrayField, collector
-        );
+        Field bigQueryField = Field.newBuilder(arrayField, StandardSQLTypeName.STRING).setMode(Field.Mode.REPEATED).build();
+        Schema.Field recordField = schema.getField(arrayField);
 
-        Assert.assertNull(failure);
+        BigQueryUtil.validateFieldModeMatches(bigQueryField,recordField, false, collector);
+
+        Mockito.verify(collector,Mockito.times(0)).addFailure(anyString(), anyString());
     }
 }


### PR DESCRIPTION
BigQuery fields can't be both NULLABLE and REQUIRED. However, it is still possible to insert null arrays BigQuery, which are then converted into empty arrays.

There is then no reason to deny users from using schema with nullable arrays in the BigQuery Sink.