### PR TITLE
Handle nullable arrays of records in BigQuery Sink 

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
@@ -29,6 +29,7 @@ import com.google.cloud.hadoop.io.bigquery.output.BigQueryTableSchema;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
+import com.google.common.annotations.VisibleForTesting;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryConstants;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;
@@ -239,27 +240,52 @@ public final class BigQuerySinkUtils {
       .collect(Collectors.toList());
   }
 
-  private static BigQueryTableFieldSchema generateTableFieldSchema(Schema.Field field) {
-    BigQueryTableFieldSchema fieldSchema = new BigQueryTableFieldSchema();
-    fieldSchema.setName(field.getName());
-    fieldSchema.setMode(getMode(field.getSchema()).name());
-    LegacySQLTypeName type = getTableDataType(field.getSchema());
-    fieldSchema.setType(type.name());
+  public static BigQueryTableFieldSchema generateTableFieldSchema(Schema.Field field) {
+    BigQueryTableFieldSchema bqFieldSchema = new BigQueryTableFieldSchema();
+    Schema fieldSchema = field.getSchema();
+    bqFieldSchema.setName(field.getName());
+    bqFieldSchema.setMode(getMode(fieldSchema).name());
+    LegacySQLTypeName type = getTableDataType(fieldSchema);
+    bqFieldSchema.setType(type.name());
     if (type == LegacySQLTypeName.RECORD) {
       List<Schema.Field> schemaFields;
-      if (Schema.Type.ARRAY == field.getSchema().getType()) {
-        schemaFields = Objects.requireNonNull(field.getSchema().getComponentSchema()).getFields();
+
+      if (fieldIsArray(field)) {
+        Schema nonNullableSchema = fieldSchema.isNullable() ? fieldSchema.getNonNullable() : fieldSchema;
+        Schema componentSchema = nonNullableSchema.getComponentSchema();
+        schemaFields = Objects.requireNonNull(componentSchema).getFields();
       } else {
         schemaFields = field.getSchema().isNullable()
           ? field.getSchema().getNonNullable().getFields()
           : field.getSchema().getFields();
       }
-      fieldSchema.setFields(Objects.requireNonNull(schemaFields).stream()
+      bqFieldSchema.setFields(Objects.requireNonNull(schemaFields).stream()
                               .map(BigQuerySinkUtils::generateTableFieldSchema)
                               .collect(Collectors.toList()));
 
     }
-    return fieldSchema;
+    return bqFieldSchema;
+  }
+
+  /**
+   * Return true if field is of type array and false else
+   * @param field the field
+   * @return isArray
+   */
+  private static boolean fieldIsArray(Schema.Field field) {
+    Schema fieldSchema = field.getSchema();
+
+    if (fieldSchema.getType().equals(Schema.Type.ARRAY)) {
+      return true;
+    } else if (fieldSchema.getType().equals(Schema.Type.UNION)) {
+      for (Schema s: fieldSchema.getUnionSchemas()) {
+        if (s.getType().equals(Schema.Type.ARRAY)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
   }
 
   private static Field.Mode getMode(Schema schema) {

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
@@ -251,9 +251,17 @@ public final class BigQuerySinkUtils {
       List<Schema.Field> schemaFields;
 
       if (fieldIsArray(field)) {
-        Schema nonNullableSchema = fieldSchema.isNullable() ? fieldSchema.getNonNullable() : fieldSchema;
+        // In case of NULLABLES array of records
+        Schema nonNullableSchema = fieldSchema.isNullable()
+                ? fieldSchema.getNonNullable()
+                : fieldSchema;
         Schema componentSchema = nonNullableSchema.getComponentSchema();
-        schemaFields = Objects.requireNonNull(componentSchema).getFields();
+
+        // In case of array of NULLABLE records
+        Schema nonNullableComponentSchema = componentSchema.isNullable()
+                ? componentSchema.getNonNullable()
+                : componentSchema;
+        schemaFields = Objects.requireNonNull(nonNullableComponentSchema).getFields();
       } else {
         schemaFields = field.getSchema().isNullable()
           ? field.getSchema().getNonNullable().getFields()

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
@@ -29,6 +29,7 @@ import com.google.cloud.hadoop.io.bigquery.output.BigQueryTableSchema;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
+import com.google.common.annotations.VisibleForTesting;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryConstants;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;
@@ -210,27 +211,52 @@ final class BigQuerySinkUtils {
       .collect(Collectors.toList());
   }
 
-  private static BigQueryTableFieldSchema generateTableFieldSchema(Schema.Field field) {
-    BigQueryTableFieldSchema fieldSchema = new BigQueryTableFieldSchema();
-    fieldSchema.setName(field.getName());
-    fieldSchema.setMode(getMode(field.getSchema()).name());
-    LegacySQLTypeName type = getTableDataType(field.getSchema());
-    fieldSchema.setType(type.name());
+  public static BigQueryTableFieldSchema generateTableFieldSchema(Schema.Field field) {
+    BigQueryTableFieldSchema bqFieldSchema = new BigQueryTableFieldSchema();
+    Schema fieldSchema = field.getSchema();
+    bqFieldSchema.setName(field.getName());
+    bqFieldSchema.setMode(getMode(fieldSchema).name());
+    LegacySQLTypeName type = getTableDataType(fieldSchema);
+    bqFieldSchema.setType(type.name());
     if (type == LegacySQLTypeName.RECORD) {
       List<Schema.Field> schemaFields;
-      if (Schema.Type.ARRAY == field.getSchema().getType()) {
-        schemaFields = Objects.requireNonNull(field.getSchema().getComponentSchema()).getFields();
+
+      if (fieldIsArray(field)) {
+        Schema nonNullableSchema = fieldSchema.isNullable() ? fieldSchema.getNonNullable() : fieldSchema;
+        Schema componentSchema = nonNullableSchema.getComponentSchema();
+        schemaFields = Objects.requireNonNull(componentSchema).getFields();
       } else {
         schemaFields = field.getSchema().isNullable()
           ? field.getSchema().getNonNullable().getFields()
           : field.getSchema().getFields();
       }
-      fieldSchema.setFields(Objects.requireNonNull(schemaFields).stream()
+      bqFieldSchema.setFields(Objects.requireNonNull(schemaFields).stream()
                               .map(BigQuerySinkUtils::generateTableFieldSchema)
                               .collect(Collectors.toList()));
 
     }
-    return fieldSchema;
+    return bqFieldSchema;
+  }
+
+  /**
+   * Return true if field is of type array and false else
+   * @param field the field
+   * @return isArray
+   */
+  private static boolean fieldIsArray(Schema.Field field) {
+    Schema fieldSchema = field.getSchema();
+
+    if (fieldSchema.getType().equals(Schema.Type.ARRAY)) {
+      return true;
+    } else if (fieldSchema.getType().equals(Schema.Type.UNION)) {
+      for (Schema s: fieldSchema.getUnionSchemas()) {
+        if (s.getType().equals(Schema.Type.ARRAY)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
   }
 
   private static Field.Mode getMode(Schema schema) {

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
@@ -29,7 +29,6 @@ import com.google.cloud.hadoop.io.bigquery.output.BigQueryTableSchema;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
-import com.google.common.annotations.VisibleForTesting;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryConstants;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;
@@ -256,7 +255,8 @@ final class BigQuerySinkUtils {
 
     if (fieldSchema.getType().equals(Schema.Type.ARRAY)) {
       return true;
-    } else if (fieldSchema.getType().equals(Schema.Type.UNION)) {
+    }
+    if (fieldSchema.getType().equals(Schema.Type.UNION)) {
       for (Schema s: fieldSchema.getUnionSchemas()) {
         if (s.getType().equals(Schema.Type.ARRAY)) {
           return true;

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
@@ -222,9 +222,17 @@ final class BigQuerySinkUtils {
       List<Schema.Field> schemaFields;
 
       if (fieldIsArray(field)) {
-        Schema nonNullableSchema = fieldSchema.isNullable() ? fieldSchema.getNonNullable() : fieldSchema;
+        // In case of NULLABLES array of records
+        Schema nonNullableSchema = fieldSchema.isNullable()
+                ? fieldSchema.getNonNullable()
+                : fieldSchema;
         Schema componentSchema = nonNullableSchema.getComponentSchema();
-        schemaFields = Objects.requireNonNull(componentSchema).getFields();
+
+        // In case of array of NULLABLE records
+        Schema nonNullableComponentSchema = componentSchema.isNullable()
+                ? componentSchema.getNonNullable()
+                : componentSchema;
+        schemaFields = Objects.requireNonNull(nonNullableComponentSchema).getFields();
       } else {
         schemaFields = field.getSchema().isNullable()
           ? field.getSchema().getNonNullable().getFields()

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
@@ -29,7 +29,6 @@ import com.google.cloud.hadoop.io.bigquery.output.BigQueryTableSchema;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
-import com.google.common.annotations.VisibleForTesting;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryConstants;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;
@@ -285,7 +284,8 @@ public final class BigQuerySinkUtils {
 
     if (fieldSchema.getType().equals(Schema.Type.ARRAY)) {
       return true;
-    } else if (fieldSchema.getType().equals(Schema.Type.UNION)) {
+    }
+    if (fieldSchema.getType().equals(Schema.Type.UNION)) {
       for (Schema s: fieldSchema.getUnionSchemas()) {
         if (s.getType().equals(Schema.Type.ARRAY)) {
           return true;

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtilsTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtilsTest.java
@@ -43,13 +43,11 @@ public class BigQuerySinkUtilsTest {
         Schema schema = Schema.recordOf("record",
                 Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
                 Schema.Field.of(fieldName,
-                        Schema.nullableOf(
-                                Schema.arrayOf(
-                                        Schema.recordOf("innerRecord",
-                                                Schema.Field.of("field1", Schema.of(Schema.Type.STRING))
-                                        )
+                        Schema.nullableOf(Schema.arrayOf(
+                                Schema.recordOf("innerRecord",
+                                        Schema.Field.of("field1", Schema.of(Schema.Type.STRING))
                                 )
-                        )
+                        ))
                 )
         );
 
@@ -65,8 +63,62 @@ public class BigQuerySinkUtilsTest {
         expectedSchema.setName("field1");
 
         Assert.assertEquals(fields.get(0), expectedSchema);
+    }
 
+    @Test
+    public void testGenerateTableFieldSchemaNullable2() {
+        String fieldName = "arrayOfRecords";
+        Schema schema = Schema.recordOf("record",
+                Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+                Schema.Field.of(fieldName,
+                        Schema.nullableOf(Schema.arrayOf(
+                                Schema.recordOf("innerRecord",
+                                        Schema.Field.of("field1", Schema.nullableOf(Schema.of(Schema.Type.STRING)))
+                                )
+                        ))
+                )
+        );
 
+        BigQueryTableFieldSchema bqTableFieldSchema =
+                BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
+
+        List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
+        Assert.assertEquals(fields.size(), 1);
+
+        BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
+        expectedSchema.setType("STRING");
+        expectedSchema.setMode("NULLABLE");
+        expectedSchema.setName("field1");
+
+        Assert.assertEquals(fields.get(0), expectedSchema);
+    }
+
+    @Test
+    public void testGenerateTableFieldSchemaNullable3() {
+        String fieldName = "arrayOfRecords";
+        Schema schema = Schema.recordOf("record",
+                Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+                Schema.Field.of(fieldName,
+                        Schema.nullableOf(Schema.arrayOf(
+                                Schema.nullableOf(Schema.recordOf("innerRecord",
+                                        Schema.Field.of("field1", Schema.nullableOf(Schema.of(Schema.Type.STRING)))
+                                ))
+                        ))
+                )
+        );
+
+        BigQueryTableFieldSchema bqTableFieldSchema =
+                BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
+
+        List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
+        Assert.assertEquals(fields.size(), 1);
+
+        BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
+        expectedSchema.setType("STRING");
+        expectedSchema.setMode("NULLABLE");
+        expectedSchema.setName("field1");
+
+        Assert.assertEquals(fields.get(0), expectedSchema);
     }
 
 }

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtilsTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtilsTest.java
@@ -56,116 +56,115 @@ public class BigQuerySinkUtilsTest {
     Assert.assertFalse(configuration.getBoolean("fs.gs.metadata.cache.enable", true));
   }
 
-    @Test
-    public void testGenerateTableFieldSchema() {
-        String fieldName = "arrayOfRecords";
-        Schema schema = Schema.recordOf("record",
-                Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
-                Schema.Field.of(fieldName,
-                        Schema.arrayOf(
-                                Schema.recordOf("innerRecord",
-                                        Schema.Field.of("field1", Schema.of(Schema.Type.STRING))
-                                )
-                        )
-                )
-        );
+  public void testGenerateTableFieldSchema() {
+    String fieldName = "arrayOfRecords";
+    Schema schema = Schema.recordOf("record",
+            Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+            Schema.Field.of(fieldName,
+                    Schema.arrayOf(
+                            Schema.recordOf("innerRecord",
+                                    Schema.Field.of("field1", Schema.of(Schema.Type.STRING))
+                            )
+                    )
+            )
+    );
 
-        BigQueryTableFieldSchema bqTableFieldSchema =
-                BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
+    BigQueryTableFieldSchema bqTableFieldSchema =
+            BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
 
-        List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
-        Assert.assertEquals(fields.size(), 1);
+    List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
+    Assert.assertEquals(fields.size(), 1);
 
-        BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
-        expectedSchema.setType("STRING");
-        expectedSchema.setMode("REQUIRED");
-        expectedSchema.setName("field1");
+    BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
+    expectedSchema.setType("STRING");
+    expectedSchema.setMode("REQUIRED");
+    expectedSchema.setName("field1");
 
-        Assert.assertEquals(fields.get(0), expectedSchema);
-    }
+    Assert.assertEquals(fields.get(0), expectedSchema);
+  }
 
-    @Test
-    public void testGenerateTableFieldSchemaNullable() {
-        String fieldName = "arrayOfRecords";
-        Schema schema = Schema.recordOf("record",
-                Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
-                Schema.Field.of(fieldName,
-                        Schema.nullableOf(Schema.arrayOf(
-                                Schema.recordOf("innerRecord",
-                                        Schema.Field.of("field1", Schema.of(Schema.Type.STRING))
-                                )
-                        ))
-                )
-        );
+  @Test
+  public void testGenerateTableFieldSchemaNullable() {
+    String fieldName = "arrayOfRecords";
+    Schema schema = Schema.recordOf("record",
+            Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+            Schema.Field.of(fieldName,
+                    Schema.nullableOf(Schema.arrayOf(
+                            Schema.recordOf("innerRecord",
+                                    Schema.Field.of("field1", Schema.of(Schema.Type.STRING))
+                            )
+                    ))
+            )
+    );
 
-        BigQueryTableFieldSchema bqTableFieldSchema =
-                BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
+    BigQueryTableFieldSchema bqTableFieldSchema =
+            BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
 
-        List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
-        Assert.assertEquals(fields.size(), 1);
+    List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
+    Assert.assertEquals(fields.size(), 1);
 
-        BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
-        expectedSchema.setType("STRING");
-        expectedSchema.setMode("REQUIRED");
-        expectedSchema.setName("field1");
+    BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
+    expectedSchema.setType("STRING");
+    expectedSchema.setMode("REQUIRED");
+    expectedSchema.setName("field1");
 
-        Assert.assertEquals(fields.get(0), expectedSchema);
-    }
+    Assert.assertEquals(fields.get(0), expectedSchema);
+  }
 
-    @Test
-    public void testGenerateTableFieldSchemaNullable2() {
-        String fieldName = "arrayOfRecords";
-        Schema schema = Schema.recordOf("record",
-                Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
-                Schema.Field.of(fieldName,
-                        Schema.nullableOf(Schema.arrayOf(
-                                Schema.recordOf("innerRecord",
-                                        Schema.Field.of("field1", Schema.nullableOf(Schema.of(Schema.Type.STRING)))
-                                )
-                        ))
-                )
-        );
+  @Test
+  public void testGenerateTableFieldSchemaNullable2() {
+    String fieldName = "arrayOfRecords";
+    Schema schema = Schema.recordOf("record",
+            Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+            Schema.Field.of(fieldName,
+                    Schema.nullableOf(Schema.arrayOf(
+                            Schema.recordOf("innerRecord",
+                                    Schema.Field.of("field1", Schema.nullableOf(Schema.of(Schema.Type.STRING)))
+                            )
+                    ))
+            )
+    );
 
-        BigQueryTableFieldSchema bqTableFieldSchema =
-                BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
+    BigQueryTableFieldSchema bqTableFieldSchema =
+            BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
 
-        List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
-        Assert.assertEquals(fields.size(), 1);
+    List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
+    Assert.assertEquals(fields.size(), 1);
 
-        BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
-        expectedSchema.setType("STRING");
-        expectedSchema.setMode("NULLABLE");
-        expectedSchema.setName("field1");
+    BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
+    expectedSchema.setType("STRING");
+    expectedSchema.setMode("NULLABLE");
+    expectedSchema.setName("field1");
 
-        Assert.assertEquals(fields.get(0), expectedSchema);
-    }
+    Assert.assertEquals(fields.get(0), expectedSchema);
+  }
 
-    @Test
-    public void testGenerateTableFieldSchemaNullable3() {
-        String fieldName = "arrayOfRecords";
-        Schema schema = Schema.recordOf("record",
-                Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
-                Schema.Field.of(fieldName,
-                        Schema.nullableOf(Schema.arrayOf(
-                                Schema.nullableOf(Schema.recordOf("innerRecord",
-                                        Schema.Field.of("field1", Schema.nullableOf(Schema.of(Schema.Type.STRING)))
-                                ))
-                        ))
-                )
-        );
+  @Test
+  public void testGenerateTableFieldSchemaNullable3() {
+    String fieldName = "arrayOfRecords";
+    Schema schema = Schema.recordOf("record",
+            Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+            Schema.Field.of(fieldName,
+                    Schema.nullableOf(Schema.arrayOf(
+                            Schema.nullableOf(Schema.recordOf("innerRecord",
+                                    Schema.Field.of("field1", Schema.nullableOf(Schema.of(Schema.Type.STRING)))
+                            ))
+                    ))
+            )
+    );
 
-        BigQueryTableFieldSchema bqTableFieldSchema =
-                BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
+    BigQueryTableFieldSchema bqTableFieldSchema =
+            BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
 
-        List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
-        Assert.assertEquals(fields.size(), 1);
+    List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
+    Assert.assertEquals(fields.size(), 1);
 
-        BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
-        expectedSchema.setType("STRING");
-        expectedSchema.setMode("NULLABLE");
-        expectedSchema.setName("field1");
+    BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
+    expectedSchema.setType("STRING");
+    expectedSchema.setMode("NULLABLE");
+    expectedSchema.setName("field1");
 
-        Assert.assertEquals(fields.get(0), expectedSchema);
-    }
+    Assert.assertEquals(fields.get(0), expectedSchema);
+  }
 
 }

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtilsTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtilsTest.java
@@ -1,0 +1,72 @@
+package io.cdap.plugin.gcp.bigquery.sink;
+
+import com.google.cloud.hadoop.io.bigquery.output.BigQueryTableFieldSchema;
+import io.cdap.cdap.api.data.schema.Schema;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class BigQuerySinkUtilsTest {
+
+    @Test
+    public void testGenerateTableFieldSchema() {
+        String fieldName = "arrayOfRecords";
+        Schema schema = Schema.recordOf("record",
+                Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+                Schema.Field.of(fieldName,
+                        Schema.arrayOf(
+                                Schema.recordOf("innerRecord",
+                                        Schema.Field.of("field1", Schema.of(Schema.Type.STRING))
+                                )
+                        )
+                )
+        );
+
+        BigQueryTableFieldSchema bqTableFieldSchema =
+                BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
+
+        List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
+        Assert.assertEquals(fields.size(), 1);
+
+        BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
+        expectedSchema.setType("STRING");
+        expectedSchema.setMode("REQUIRED");
+        expectedSchema.setName("field1");
+
+        Assert.assertEquals(fields.get(0), expectedSchema);
+    }
+
+    @Test
+    public void testGenerateTableFieldSchemaNullable() {
+        String fieldName = "arrayOfRecords";
+        Schema schema = Schema.recordOf("record",
+                Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+                Schema.Field.of(fieldName,
+                        Schema.nullableOf(
+                                Schema.arrayOf(
+                                        Schema.recordOf("innerRecord",
+                                                Schema.Field.of("field1", Schema.of(Schema.Type.STRING))
+                                        )
+                                )
+                        )
+                )
+        );
+
+        BigQueryTableFieldSchema bqTableFieldSchema =
+                BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
+
+        List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
+        Assert.assertEquals(fields.size(), 1);
+
+        BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
+        expectedSchema.setType("STRING");
+        expectedSchema.setMode("REQUIRED");
+        expectedSchema.setName("field1");
+
+        Assert.assertEquals(fields.get(0), expectedSchema);
+
+
+    }
+
+}

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtilsTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtilsTest.java
@@ -58,18 +58,18 @@ public class BigQuerySinkUtilsTest {
   public void testGenerateTableFieldSchema() {
     String fieldName = "arrayOfRecords";
     Schema schema = Schema.recordOf("record",
-            Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
-            Schema.Field.of(fieldName,
-                    Schema.arrayOf(
-                            Schema.recordOf("innerRecord",
-                                    Schema.Field.of("field1", Schema.of(Schema.Type.STRING))
-                            )
-                    )
+        Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+        Schema.Field.of(fieldName,
+            Schema.arrayOf(
+                Schema.recordOf("innerRecord",
+                    Schema.Field.of("field1", Schema.of(Schema.Type.STRING))
+                )
             )
+        )
     );
 
     BigQueryTableFieldSchema bqTableFieldSchema =
-            BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
+        BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
 
     List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
     Assert.assertEquals(fields.size(), 1);
@@ -86,18 +86,18 @@ public class BigQuerySinkUtilsTest {
   public void testGenerateTableFieldSchemaNullable() {
     String fieldName = "arrayOfRecords";
     Schema schema = Schema.recordOf("record",
-            Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
-            Schema.Field.of(fieldName,
-                    Schema.nullableOf(Schema.arrayOf(
-                            Schema.recordOf("innerRecord",
-                                    Schema.Field.of("field1", Schema.of(Schema.Type.STRING))
-                            )
-                    ))
-            )
+        Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+        Schema.Field.of(fieldName,
+            Schema.nullableOf(Schema.arrayOf(
+                Schema.recordOf("innerRecord",
+                    Schema.Field.of("field1", Schema.of(Schema.Type.STRING))
+                )
+            ))
+        )
     );
 
     BigQueryTableFieldSchema bqTableFieldSchema =
-            BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
+        BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
 
     List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
     Assert.assertEquals(fields.size(), 1);
@@ -114,18 +114,18 @@ public class BigQuerySinkUtilsTest {
   public void testGenerateTableFieldSchemaNullable2() {
     String fieldName = "arrayOfRecords";
     Schema schema = Schema.recordOf("record",
-            Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
-            Schema.Field.of(fieldName,
-                    Schema.nullableOf(Schema.arrayOf(
-                            Schema.recordOf("innerRecord",
-                                    Schema.Field.of("field1", Schema.nullableOf(Schema.of(Schema.Type.STRING)))
-                            )
-                    ))
-            )
+        Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+        Schema.Field.of(fieldName,
+            Schema.nullableOf(Schema.arrayOf(
+                Schema.recordOf("innerRecord",
+                    Schema.Field.of("field1", Schema.nullableOf(Schema.of(Schema.Type.STRING)))
+                )
+            ))
+        )
     );
 
     BigQueryTableFieldSchema bqTableFieldSchema =
-            BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
+        BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
 
     List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
     Assert.assertEquals(fields.size(), 1);
@@ -142,18 +142,18 @@ public class BigQuerySinkUtilsTest {
   public void testGenerateTableFieldSchemaNullable3() {
     String fieldName = "arrayOfRecords";
     Schema schema = Schema.recordOf("record",
-            Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
-            Schema.Field.of(fieldName,
-                    Schema.nullableOf(Schema.arrayOf(
-                            Schema.nullableOf(Schema.recordOf("innerRecord",
-                                    Schema.Field.of("field1", Schema.nullableOf(Schema.of(Schema.Type.STRING)))
-                            ))
-                    ))
-            )
+        Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+        Schema.Field.of(fieldName,
+            Schema.nullableOf(Schema.arrayOf(
+                Schema.nullableOf(Schema.recordOf("innerRecord",
+                    Schema.Field.of("field1", Schema.nullableOf(Schema.of(Schema.Type.STRING)))
+                ))
+            ))
+        )
     );
 
     BigQueryTableFieldSchema bqTableFieldSchema =
-            BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
+        BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
 
     List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
     Assert.assertEquals(fields.size(), 1);

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtilsTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtilsTest.java
@@ -56,62 +56,116 @@ public class BigQuerySinkUtilsTest {
     Assert.assertFalse(configuration.getBoolean("fs.gs.metadata.cache.enable", true));
   }
 
-  @Test
-  public void testGenerateTableFieldSchema() {
-    String fieldName = "arrayOfRecords";
-    Schema schema = Schema.recordOf("record",
-            Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
-            Schema.Field.of(fieldName,
-                    Schema.arrayOf(
-                            Schema.recordOf("innerRecord",
-                                    Schema.Field.of("field1", Schema.of(Schema.Type.STRING))
-                            )
-                    )
-            )
-    );
+    @Test
+    public void testGenerateTableFieldSchema() {
+        String fieldName = "arrayOfRecords";
+        Schema schema = Schema.recordOf("record",
+                Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+                Schema.Field.of(fieldName,
+                        Schema.arrayOf(
+                                Schema.recordOf("innerRecord",
+                                        Schema.Field.of("field1", Schema.of(Schema.Type.STRING))
+                                )
+                        )
+                )
+        );
 
-    BigQueryTableFieldSchema bqTableFieldSchema =
-            BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
+        BigQueryTableFieldSchema bqTableFieldSchema =
+                BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
 
-    List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
-    Assert.assertEquals(fields.size(), 1);
+        List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
+        Assert.assertEquals(fields.size(), 1);
 
-    BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
-    expectedSchema.setType("STRING");
-    expectedSchema.setMode("REQUIRED");
-    expectedSchema.setName("field1");
+        BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
+        expectedSchema.setType("STRING");
+        expectedSchema.setMode("REQUIRED");
+        expectedSchema.setName("field1");
 
-    Assert.assertEquals(fields.get(0), expectedSchema);
-  }
+        Assert.assertEquals(fields.get(0), expectedSchema);
+    }
 
-  @Test
-  public void testGenerateTableFieldSchemaNullable() {
-    String fieldName = "arrayOfRecords";
-    Schema schema = Schema.recordOf("record",
-            Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
-            Schema.Field.of(fieldName,
-                    Schema.nullableOf(
-                            Schema.arrayOf(
-                                    Schema.recordOf("innerRecord",
-                                            Schema.Field.of("field1", Schema.of(Schema.Type.STRING))
-                                    )
-                            )
-                    )
-            )
-    );
+    @Test
+    public void testGenerateTableFieldSchemaNullable() {
+        String fieldName = "arrayOfRecords";
+        Schema schema = Schema.recordOf("record",
+                Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+                Schema.Field.of(fieldName,
+                        Schema.nullableOf(Schema.arrayOf(
+                                Schema.recordOf("innerRecord",
+                                        Schema.Field.of("field1", Schema.of(Schema.Type.STRING))
+                                )
+                        ))
+                )
+        );
 
-    BigQueryTableFieldSchema bqTableFieldSchema =
-            BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
+        BigQueryTableFieldSchema bqTableFieldSchema =
+                BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
 
-    List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
-    Assert.assertEquals(fields.size(), 1);
+        List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
+        Assert.assertEquals(fields.size(), 1);
 
-    BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
-    expectedSchema.setType("STRING");
-    expectedSchema.setMode("REQUIRED");
-    expectedSchema.setName("field1");
+        BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
+        expectedSchema.setType("STRING");
+        expectedSchema.setMode("REQUIRED");
+        expectedSchema.setName("field1");
 
-    Assert.assertEquals(fields.get(0), expectedSchema);
-    
-  }
+        Assert.assertEquals(fields.get(0), expectedSchema);
+    }
+
+    @Test
+    public void testGenerateTableFieldSchemaNullable2() {
+        String fieldName = "arrayOfRecords";
+        Schema schema = Schema.recordOf("record",
+                Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+                Schema.Field.of(fieldName,
+                        Schema.nullableOf(Schema.arrayOf(
+                                Schema.recordOf("innerRecord",
+                                        Schema.Field.of("field1", Schema.nullableOf(Schema.of(Schema.Type.STRING)))
+                                )
+                        ))
+                )
+        );
+
+        BigQueryTableFieldSchema bqTableFieldSchema =
+                BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
+
+        List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
+        Assert.assertEquals(fields.size(), 1);
+
+        BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
+        expectedSchema.setType("STRING");
+        expectedSchema.setMode("NULLABLE");
+        expectedSchema.setName("field1");
+
+        Assert.assertEquals(fields.get(0), expectedSchema);
+    }
+
+    @Test
+    public void testGenerateTableFieldSchemaNullable3() {
+        String fieldName = "arrayOfRecords";
+        Schema schema = Schema.recordOf("record",
+                Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+                Schema.Field.of(fieldName,
+                        Schema.nullableOf(Schema.arrayOf(
+                                Schema.nullableOf(Schema.recordOf("innerRecord",
+                                        Schema.Field.of("field1", Schema.nullableOf(Schema.of(Schema.Type.STRING)))
+                                ))
+                        ))
+                )
+        );
+
+        BigQueryTableFieldSchema bqTableFieldSchema =
+                BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
+
+        List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
+        Assert.assertEquals(fields.size(), 1);
+
+        BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
+        expectedSchema.setType("STRING");
+        expectedSchema.setMode("NULLABLE");
+        expectedSchema.setName("field1");
+
+        Assert.assertEquals(fields.get(0), expectedSchema);
+    }
+
 }

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtilsTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtilsTest.java
@@ -9,116 +9,116 @@ import java.util.List;
 
 public class BigQuerySinkUtilsTest {
 
-    @Test
-    public void testGenerateTableFieldSchema() {
-        String fieldName = "arrayOfRecords";
-        Schema schema = Schema.recordOf("record",
-                Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
-                Schema.Field.of(fieldName,
-                        Schema.arrayOf(
-                                Schema.recordOf("innerRecord",
-                                        Schema.Field.of("field1", Schema.of(Schema.Type.STRING))
-                                )
-                        )
-                )
-        );
+  @Test
+  public void testGenerateTableFieldSchema() {
+    String fieldName = "arrayOfRecords";
+    Schema schema = Schema.recordOf("record",
+            Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+            Schema.Field.of(fieldName,
+                    Schema.arrayOf(
+                            Schema.recordOf("innerRecord",
+                                    Schema.Field.of("field1", Schema.of(Schema.Type.STRING))
+                            )
+                    )
+            )
+    );
 
-        BigQueryTableFieldSchema bqTableFieldSchema =
-                BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
+    BigQueryTableFieldSchema bqTableFieldSchema =
+            BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
 
-        List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
-        Assert.assertEquals(fields.size(), 1);
+    List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
+    Assert.assertEquals(fields.size(), 1);
 
-        BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
-        expectedSchema.setType("STRING");
-        expectedSchema.setMode("REQUIRED");
-        expectedSchema.setName("field1");
+    BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
+    expectedSchema.setType("STRING");
+    expectedSchema.setMode("REQUIRED");
+    expectedSchema.setName("field1");
 
-        Assert.assertEquals(fields.get(0), expectedSchema);
-    }
+    Assert.assertEquals(fields.get(0), expectedSchema);
+  }
 
-    @Test
-    public void testGenerateTableFieldSchemaNullable() {
-        String fieldName = "arrayOfRecords";
-        Schema schema = Schema.recordOf("record",
-                Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
-                Schema.Field.of(fieldName,
-                        Schema.nullableOf(Schema.arrayOf(
-                                Schema.recordOf("innerRecord",
-                                        Schema.Field.of("field1", Schema.of(Schema.Type.STRING))
-                                )
-                        ))
-                )
-        );
+  @Test
+  public void testGenerateTableFieldSchemaNullable() {
+    String fieldName = "arrayOfRecords";
+    Schema schema = Schema.recordOf("record",
+            Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+            Schema.Field.of(fieldName,
+                    Schema.nullableOf(Schema.arrayOf(
+                            Schema.recordOf("innerRecord",
+                                    Schema.Field.of("field1", Schema.of(Schema.Type.STRING))
+                            )
+                    ))
+            )
+    );
 
-        BigQueryTableFieldSchema bqTableFieldSchema =
-                BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
+    BigQueryTableFieldSchema bqTableFieldSchema =
+            BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
 
-        List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
-        Assert.assertEquals(fields.size(), 1);
+    List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
+    Assert.assertEquals(fields.size(), 1);
 
-        BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
-        expectedSchema.setType("STRING");
-        expectedSchema.setMode("REQUIRED");
-        expectedSchema.setName("field1");
+    BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
+    expectedSchema.setType("STRING");
+    expectedSchema.setMode("REQUIRED");
+    expectedSchema.setName("field1");
 
-        Assert.assertEquals(fields.get(0), expectedSchema);
-    }
+    Assert.assertEquals(fields.get(0), expectedSchema);
+  }
 
-    @Test
-    public void testGenerateTableFieldSchemaNullable2() {
-        String fieldName = "arrayOfRecords";
-        Schema schema = Schema.recordOf("record",
-                Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
-                Schema.Field.of(fieldName,
-                        Schema.nullableOf(Schema.arrayOf(
-                                Schema.recordOf("innerRecord",
-                                        Schema.Field.of("field1", Schema.nullableOf(Schema.of(Schema.Type.STRING)))
-                                )
-                        ))
-                )
-        );
+  @Test
+  public void testGenerateTableFieldSchemaNullable2() {
+    String fieldName = "arrayOfRecords";
+    Schema schema = Schema.recordOf("record",
+            Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+            Schema.Field.of(fieldName,
+                    Schema.nullableOf(Schema.arrayOf(
+                            Schema.recordOf("innerRecord",
+                                    Schema.Field.of("field1", Schema.nullableOf(Schema.of(Schema.Type.STRING)))
+                            )
+                    ))
+            )
+    );
 
-        BigQueryTableFieldSchema bqTableFieldSchema =
-                BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
+    BigQueryTableFieldSchema bqTableFieldSchema =
+            BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
 
-        List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
-        Assert.assertEquals(fields.size(), 1);
+    List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
+    Assert.assertEquals(fields.size(), 1);
 
-        BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
-        expectedSchema.setType("STRING");
-        expectedSchema.setMode("NULLABLE");
-        expectedSchema.setName("field1");
+    BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
+    expectedSchema.setType("STRING");
+    expectedSchema.setMode("NULLABLE");
+    expectedSchema.setName("field1");
 
-        Assert.assertEquals(fields.get(0), expectedSchema);
-    }
+    Assert.assertEquals(fields.get(0), expectedSchema);
+  }
 
-    @Test
-    public void testGenerateTableFieldSchemaNullable3() {
-        String fieldName = "arrayOfRecords";
-        Schema schema = Schema.recordOf("record",
-                Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
-                Schema.Field.of(fieldName,
-                        Schema.nullableOf(Schema.arrayOf(
-                                Schema.nullableOf(Schema.recordOf("innerRecord",
-                                        Schema.Field.of("field1", Schema.nullableOf(Schema.of(Schema.Type.STRING)))
-                                ))
-                        ))
-                )
-        );
+  @Test
+  public void testGenerateTableFieldSchemaNullable3() {
+    String fieldName = "arrayOfRecords";
+    Schema schema = Schema.recordOf("record",
+            Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+            Schema.Field.of(fieldName,
+                    Schema.nullableOf(Schema.arrayOf(
+                            Schema.nullableOf(Schema.recordOf("innerRecord",
+                                    Schema.Field.of("field1", Schema.nullableOf(Schema.of(Schema.Type.STRING)))
+                            ))
+                    ))
+            )
+    );
 
-        BigQueryTableFieldSchema bqTableFieldSchema =
-                BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
+    BigQueryTableFieldSchema bqTableFieldSchema =
+            BigQuerySinkUtils.generateTableFieldSchema(schema.getField(fieldName));
 
-        List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
-        Assert.assertEquals(fields.size(), 1);
+    List<BigQueryTableFieldSchema> fields = bqTableFieldSchema.getFields();
+    Assert.assertEquals(fields.size(), 1);
 
-        BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
-        expectedSchema.setType("STRING");
-        expectedSchema.setMode("NULLABLE");
-        expectedSchema.setName("field1");
+    BigQueryTableFieldSchema expectedSchema = new BigQueryTableFieldSchema();
+    expectedSchema.setType("STRING");
+    expectedSchema.setMode("NULLABLE");
+    expectedSchema.setName("field1");
 
-        Assert.assertEquals(fields.get(0), expectedSchema);
-    }
+    Assert.assertEquals(fields.get(0), expectedSchema);
+  }
 
 }


### PR DESCRIPTION
Fix to handle properly nullable array of records and arrays of nullable records in BigQuery Sink