### PR TITLE
Added additional settings for BQ Pushdown.

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQuerySQLEngineConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQuerySQLEngineConfig.java
@@ -29,6 +29,8 @@ import javax.annotation.Nullable;
 public class BigQuerySQLEngineConfig extends BigQueryBaseConfig {
 
   public static final String NAME_LOCATION = "location";
+  public static final String NAME_RETAIN_TABLES = "retainTables";
+  public static final String NAME_TEMP_TABLE_TTL_HOURS = "tempTableTTLHours";
 
   @Name(NAME_LOCATION)
   @Macro
@@ -37,9 +39,30 @@ public class BigQuerySQLEngineConfig extends BigQueryBaseConfig {
     "This value is ignored if the dataset or temporary bucket already exist.")
   protected String location;
 
+  @Name(NAME_RETAIN_TABLES)
+  @Macro
+  @Nullable
+  @Description("Select this option if the pipeline should retain all temporary BigQuery tables created during the " +
+    "execution of the pipeline.")
+  protected Boolean retainTables;
+
+  @Name(NAME_TEMP_TABLE_TTL_HOURS)
+  @Macro
+  @Nullable
+  @Description("Set table TTL for temporary BigQuery tables, in number of hours. Tables will be deleted " +
+    "automatically on pipeline completion.")
+  protected Integer tempTableTTLHours;
+
   @Nullable
   public String getLocation() {
     return location;
   }
 
+  public Boolean shouldRetainTables() {
+    return retainTables != null ? retainTables : false;
+  }
+
+  public Integer getTempTableTTLHours() {
+    return tempTableTTLHours != null && tempTableTTLHours > 0 ? tempTableTTLHours : 72;
+  }
 }

--- a/widgets/BigQueryPushdownEngine-sqlengine.json
+++ b/widgets/BigQueryPushdownEngine-sqlengine.json
@@ -26,6 +26,14 @@
         },
         {
           "widget-type": "textbox",
+          "label": "Dataset Project ID",
+          "name": "datasetProject",
+          "widget-attributes": {
+            "placeholder": "The project in which the dataset is located/should be created. Defaults to the project specified in the Project Id property."
+          }
+        },
+        {
+          "widget-type": "textbox",
           "label": "Dataset",
           "name": "dataset",
           "widget-attributes": {
@@ -84,6 +92,36 @@
           "widget-type": "textbox",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
+        }
+      ]
+    },
+    {
+      "label": "Advanced",
+      "properties": [
+        {
+          "widget-type": "toggle",
+          "label": "Retain BigQuery tables after completion",
+          "name": "retainTables",
+          "widget-attributes": {
+            "on": {
+              "value": "true",
+              "label": "YES"
+            },
+            "off": {
+              "value": "false",
+              "label": "NO"
+            },
+            "default": "false"
+          }
+        },
+        {
+          "name": "tempTableTTLHours",
+          "widget-type": "number",
+          "label": "Temporary Table TTL (in Hours)",
+          "widget-attributes": {
+            "min": "1",
+            "default": "72"
+          }
         }
       ]
     }


### PR DESCRIPTION
Added logic to define a TTL for all tables. This is used as a backup in case of driver failures. Defaults to 72 hours.

Added option to retain all tables. This is useful when testing and debugging.