### PR TITLE
Added logic to relax BQ schema even when the output contains no records

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQueryPushDataset.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQueryPushDataset.java
@@ -92,6 +92,7 @@ public class BigQueryPushDataset extends BigQueryOutputFormatProvider
     configuration.set(BigQueryConstants.CONFIG_OPERATION, Operation.INSERT.name());
     configuration.setBoolean(BigQueryConstants.CONFIG_DESTINATION_TABLE_EXISTS, true);
     configuration.setBoolean(BigQueryConstants.CONFIG_ALLOW_SCHEMA_RELAXATION, true);
+    configuration.setBoolean(BigQueryConstants.CONFIG_ALLOW_SCHEMA_RELAXATION_ON_EMPTY_OUTPUT, true);
 
     // Configure output.
     String gcsPath = BigQuerySQLEngineUtils.getGCSPath(bucket, runId, table);

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
@@ -21,6 +21,7 @@ package io.cdap.plugin.gcp.bigquery.util;
 public interface BigQueryConstants {
 
   String CONFIG_ALLOW_SCHEMA_RELAXATION = "cdap.bq.sink.allow.schema.relaxation";
+  String CONFIG_ALLOW_SCHEMA_RELAXATION_ON_EMPTY_OUTPUT = "cdap.bq.sink.allow.schema.relaxationoemptyoutput";
   String CONFIG_DESTINATION_TABLE_EXISTS = "cdap.bq.sink.destination.table.exists";
   String CONFIG_PARTITION_BY_FIELD = "cdap.bq.sink.partition.by.field";
   String CONFIG_REQUIRE_PARTITION_FILTER = "cdap.bq.sink.require.partition.filter";


### PR DESCRIPTION
...as long as the user has specified the  option