### PR TITLE
Updated logic to run BQ Join jobs in the same location as the dataset.

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQuerySQLEngine.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQuerySQLEngine.java
@@ -233,7 +233,6 @@ public class BigQuerySQLEngine
                                                                       getStageNameToBQTableNameMap(),
                                                                       sqlEngineConfig,
                                                                       bigQuery,
-                                                                      location,
                                                                       project,
                                                                       dataset,
                                                                       runId);


### PR DESCRIPTION
Discovered bug where we were using the supplied dataset location even when the dataset was previously created in another region. This fixes this issue.