### PR TITLE
Fix double period in error message in BQ connector

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/connector/BigQueryConnector.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/connector/BigQueryConnector.java
@@ -111,7 +111,7 @@ public final class BigQueryConnector implements DirectConnector {
         credentials =
           GCPUtils.loadServiceAccountCredentials(config.getServiceAccount(), config.isServiceAccountFilePath());
       } catch (Exception e) {
-        failureCollector.addFailure(String.format("Service account key provided is not valid: %s.", e.getMessage()),
+        failureCollector.addFailure(String.format("Service account key provided is not valid: %s", e.getMessage()),
           "Please provide a valid service account key.");
       }
     }


### PR DESCRIPTION
Issue: There are two periods in the error message when you provide an invalid service account json to the BigQuery connector.

Testing:
<img width="1081" alt="Screen Shot 2021-07-30 at 2 13 18 PM" src="https://user-images.githubusercontent.com/20047281/127712640-30feb823-1ff0-4e96-987f-89644dfe4263.png">
