### PR TITLE
Add details about Format field in Pub/Sub plugins

### DIFF
--- a/docs/GooglePublisher-batchsink.md
+++ b/docs/GooglePublisher-batchsink.md
@@ -28,6 +28,9 @@ It can be found on the Dashboard in the Google Cloud Platform Console.
 
 **Topic**: Name of the Google Cloud Pub/Sub topic to publish to.
 
+**Format**: Format of the data to read. Supported formats are avro, blob, tsv, csv, delimited, json,
+parquet, and text. Default is text.
+
 **Service Account**  - service account key used for authorization
 * **File Path**: Path on the local file system of the service account key used for
 authorization. Can be set to 'auto-detect' when running on a Dataproc cluster.

--- a/docs/GoogleSubscriber-streamingsource.md
+++ b/docs/GoogleSubscriber-streamingsource.md
@@ -52,6 +52,9 @@ If the subscription needs to be created then the topic to which the subscription
 does not exists it will be created. If a subscriber does not exists and is created only the messages arrived after
 the creation of subscriber will be received.
 
+**Format**: Format of the data to read. Supported formats are avro, blob, tsv, csv, delimited, json, parquet, and text.
+Default is text.
+
 **Service Account**  - service account key used for authorization
 * **File Path**: Path on the local file system of the service account key used for
 authorization. Can be set to 'auto-detect' when running on a Dataproc cluster.


### PR DESCRIPTION
Pub/Sub Streaming Source markdown documentation was missing the Format property.
This was also missing from Pub/Sub sink plugin, the same information has been added here as well.

Testing:

In Source:
<img width="1788" alt="Screen Shot 2021-08-09 at 11 05 46 AM" src="https://user-images.githubusercontent.com/20047281/128757760-4e4248c7-666d-4f1d-93bb-85cc0d7a702e.png">

In Sink:
<img width="1783" alt="Screen Shot 2021-08-09 at 11 06 12 AM" src="https://user-images.githubusercontent.com/20047281/128757770-5ecf4e08-6049-4f5d-b197-bfce427e7c05.png">