### PR TITLE
Add support for the Spark BigQuery connector for SQL Engine Pull operations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,8 @@
     <junit.version>4.13.1</junit.version>
     <powermock.version>2.0.2</powermock.version>
     <slf4j.version>1.7.5</slf4j.version>
-    <spark.version>2.3.1</spark.version>
+    <spark.version>3.1.1</spark.version>
+    <spark-bq-connector.version>0.22.1</spark-bq-connector.version>
   </properties>
 
   <dependencyManagement>
@@ -170,6 +171,27 @@
       <artifactId>cdap-etl-api</artifactId>
       <version>${cdap.version}</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-etl-api-spark</artifactId>
+      <version>${cdap.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-api-spark3_2.12</artifactId>
+      <version>${cdap.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud.spark</groupId>
+      <artifactId>spark-bigquery-with-dependencies_2.12</artifactId>
+      <version>${spark-bq-connector.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
@@ -407,9 +429,9 @@
       <version>${gcs.connector.version}</version>
     </dependency>
     <dependency>
-    <groupId>com.google.cloud</groupId>
-    <artifactId>google-cloud-kms</artifactId>
-    <version>${google.cloud.kms.version}</version>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-kms</artifactId>
+      <version>${google.cloud.kms.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
@@ -487,13 +509,13 @@
     <!-- End: Testing dependencies -->
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_2.11</artifactId>
+      <artifactId>spark-streaming_2.12</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.11</artifactId>
+      <artifactId>spark-core_2.12</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
       <exclusions>
@@ -543,7 +565,7 @@
     <!-- Start: dependency for Google PubSub Streaming Source -->
     <dependency>
       <groupId>org.apache.bahir</groupId>
-      <artifactId>spark-streaming-pubsub_2.11</artifactId>
+      <artifactId>spark-streaming-pubsub_2.12</artifactId>
       <version>2.4.0</version>
     </dependency>
     <!-- End: dependency for Google PubSub Streaming Source -->
@@ -563,6 +585,22 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>${httpclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_2.12</artifactId>
+      <version>${spark.version}</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
   </dependencies>
@@ -644,6 +682,9 @@
               org.apache.spark.streaming.pubsub*;
               org.apache.hadoop.hbase.mapreduce.*;
               org.apache.hadoop.hbase.security.token.*;
+              com.google.cloud.spark.bigquery.*;
+              org.apache.spark.sql.*;
+              org.apache.spark.internal.*;
             </_exportcontents>
           </instructions>
         </configuration>

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQuerySQLEngine.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQuerySQLEngine.java
@@ -29,11 +29,13 @@ import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
-import io.cdap.cdap.etl.api.engine.sql.BatchSQLEngine;
+import io.cdap.cdap.etl.api.engine.sql.BatchSparkSQLEngine;
 import io.cdap.cdap.etl.api.engine.sql.SQLEngineException;
 import io.cdap.cdap.etl.api.engine.sql.dataset.SQLDataset;
 import io.cdap.cdap.etl.api.engine.sql.dataset.SQLPullDataset;
 import io.cdap.cdap.etl.api.engine.sql.dataset.SQLPushDataset;
+import io.cdap.cdap.etl.api.engine.sql.dataset.SparkPullDataset;
+import io.cdap.cdap.etl.api.engine.sql.dataset.SparkPushDataset;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLJoinDefinition;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLJoinRequest;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLPullRequest;
@@ -62,13 +64,13 @@ import java.util.stream.Collectors;
 /**
  * SQL Engine implementation using BigQuery as the execution engine.
  */
-@Plugin(type = BatchSQLEngine.PLUGIN_TYPE)
+@Plugin(type = BatchSparkSQLEngine.PLUGIN_TYPE)
 @Name(BigQuerySQLEngine.NAME)
 @Description("BigQuery SQLEngine implementation, used to push down certain pipeline steps into BigQuery. "
   + "A GCS bucket is used as staging for the read/write operations performed by this engine. "
   + "BigQuery is Google's serverless, highly scalable, enterprise data warehouse.")
 public class BigQuerySQLEngine
-  extends BatchSQLEngine<LongWritable, GenericData.Record, StructuredRecord, NullWritable> {
+  extends BatchSparkSQLEngine<LongWritable, GenericData.Record, StructuredRecord, NullWritable> {
 
   private static final Logger LOG = LoggerFactory.getLogger(BigQuerySQLEngine.class);
 
@@ -177,6 +179,13 @@ public class BigQuerySQLEngine
   }
 
   @Override
+  public SparkPushDataset<StructuredRecord> getSparkPushProvider(SQLPushRequest sqlPushRequest)
+    throws SQLEngineException {
+    // Not supported
+    return null;
+  }
+
+  @Override
   public SQLPullDataset<StructuredRecord, LongWritable, GenericData.Record> getPullProvider(
     SQLPullRequest sqlPullRequest) throws SQLEngineException {
     if (!datasets.containsKey(sqlPullRequest.getDatasetName())) {
@@ -197,6 +206,26 @@ public class BigQuerySQLEngine
                                              table,
                                              bucket,
                                              runId);
+    } catch (IOException ioe) {
+      throw new SQLEngineException(ioe);
+    }
+  }
+
+  @Override
+  public SparkPullDataset<StructuredRecord> getSparkPullProvider(SQLPullRequest sqlPullRequest)
+    throws SQLEngineException {
+
+    String table = datasets.get(sqlPullRequest.getDatasetName()).getBigQueryTableName();
+
+    LOG.info("Executing Spark Pull operation for dataset {} stored in table {}",
+             sqlPullRequest.getDatasetName(), table);
+
+    try {
+      return BigQuerySparkPullDataset.getInstance(sqlPullRequest,
+                                                  bigQuery,
+                                                  project,
+                                                  dataset,
+                                                  table);
     } catch (IOException ioe) {
       throw new SQLEngineException(ioe);
     }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQuerySparkPullDataset.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQuerySparkPullDataset.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.gcp.bigquery.sqlengine;
+
+import com.google.cloud.bigquery.BigQuery;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.spark.sql.DataFrames;
+import io.cdap.cdap.etl.api.engine.sql.dataset.SparkPullDataset;
+import io.cdap.cdap.etl.api.engine.sql.request.SQLPullRequest;
+import io.cdap.plugin.gcp.bigquery.sqlengine.transform.RowToStructuredRecordMapper;
+import io.cdap.plugin.gcp.bigquery.sqlengine.util.BigQuerySQLEngineUtils;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+/**
+ * SQL Pull Dataset implementation for BigQuery backed datasets.
+ */
+public class BigQuerySparkPullDataset
+  implements SparkPullDataset<StructuredRecord>, Serializable {
+
+  private final BigQuery bigQuery;
+  private final String datasetName;
+  private final Schema schema;
+  private final String project;
+  private final String bqDataset;
+  private final String bqTable;
+  private Long numRows;
+
+  private BigQuerySparkPullDataset(String datasetName,
+                                   Schema schema,
+                                   BigQuery bigQuery,
+                                   String project,
+                                   String bqDataset,
+                                   String bqTable) {
+    this.datasetName = datasetName;
+    this.schema = schema;
+    this.bigQuery = bigQuery;
+    this.project = project;
+    this.bqDataset = bqDataset;
+    this.bqTable = bqTable;
+  }
+
+  public static BigQuerySparkPullDataset getInstance(SQLPullRequest pullRequest,
+                                                     BigQuery bigQuery,
+                                                     String project,
+                                                     String bqDataset,
+                                                     String bqTable) throws IOException {
+
+    return new BigQuerySparkPullDataset(pullRequest.getDatasetName(),
+                                        pullRequest.getDatasetSchema(),
+                                        bigQuery,
+                                        project,
+                                        bqDataset,
+                                        bqTable);
+  }
+
+  @Override
+  public JavaRDD<StructuredRecord> create(JavaSparkContext javaSparkContext) {
+    String path = String.format("%s.%s.%s", project, bqDataset, bqTable);
+
+    SparkSession spark = SparkSession.builder()
+      .sparkContext(javaSparkContext.sc())
+      .getOrCreate();
+
+    //TODO: This should use the credentials from the BQ SQL engine config, right now it uses dataproc config.
+    Dataset<Row> ds = spark.read().format("bigquery").load(path);
+
+    Function<Row, StructuredRecord> mappingFunction = new RowToStructuredRecordMapper(schema);
+
+    return ds.toJavaRDD().map(mappingFunction);
+  }
+
+  @Override
+  public String getDatasetName() {
+    return datasetName;
+  }
+
+  @Override
+  public Schema getSchema() {
+    return schema;
+  }
+
+  @Override
+  public long getNumRows() {
+    // Get the number of rows from BQ if not known at this time.
+    if (numRows == null) {
+      numRows = BigQuerySQLEngineUtils.getNumRows(bigQuery, project, bqDataset, bqTable);
+    }
+
+    return numRows;
+  }
+}

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/transform/RowToStructuredRecordMapper.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/transform/RowToStructuredRecordMapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.gcp.bigquery.sqlengine.transform;
+
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.spark.sql.DataFrames;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.sql.Row;
+
+/**
+ * Mapping function used to transform {@link Row} into {@link StructuredRecord}
+ */
+public class RowToStructuredRecordMapper implements Function<Row, StructuredRecord> {
+
+  private final Schema schema;
+
+  public RowToStructuredRecordMapper(Schema schema) {
+    this.schema = schema;
+  }
+
+  @Override
+  public StructuredRecord call(Row row) throws Exception {
+    return DataFrames.fromRow(row, schema);
+  }
+}


### PR DESCRIPTION
Added dependencies to Spark BQ connector and Spark SQL APIs.

Added support for methods introduced in https://github.com/cdapio/cdap/pull/13664 for the SQL engine.