### PR TITLE
[PLUGIN-897] Adding CMEK as a config in GCS Bucket Create, Copy and Move plugins

### DIFF
--- a/docs/GCS-batchsink.md
+++ b/docs/GCS-batchsink.md
@@ -47,9 +47,8 @@ The delimiter will be ignored if the format is anything other than 'delimited'.
 
 **Location:** The location where the gcs bucket will get created. This value is ignored if the bucket already exists.
 
-**Encryption Key Name:** It is used to encrypt data written to bucket that will be created by pipeline.
-If the bucket already exists, you need to manually apply the CMEK to it.
-The location of bucket and key should be same.
+**Encryption Key Name:** It is used to encrypt data written to any bucket created by the plugin.
+If the bucket already exists, this is ignored.
 
 **Content Type:** The Content Type entity is used to indicate the media type of the resource.
 Defaults to 'application/octet-stream'. The following table shows valid content types for each format.

--- a/docs/GCS-batchsink.md
+++ b/docs/GCS-batchsink.md
@@ -47,7 +47,7 @@ The delimiter will be ignored if the format is anything other than 'delimited'.
 
 **Location:** The location where the gcs bucket will get created. This value is ignored if the bucket already exists.
 
-**Encryption Key Name:** It is used to encrypt data written to any bucket created by the plugin.
+**Encryption Key Name:** Used to encrypt data written to any bucket created by the plugin.
 If the bucket already exists, this is ignored.
 
 **Content Type:** The Content Type entity is used to indicate the media type of the resource.

--- a/docs/GCSBucketCreate-action.md
+++ b/docs/GCSBucketCreate-action.md
@@ -36,6 +36,10 @@ It can be found on the Dashboard in the Google Cloud Platform Console.
 
 **Location:** The location where the gcs buckets will get created. This value is ignored if the bucket already exists.
 
+**Encryption Key Name:** It is used to encrypt data written to bucket that will be created by pipeline.
+If the buckets already exist, you need to manually apply the CMEK to it.
+The location of buckets and key should be same.
+
 **Service Account**  - service account key used for authorization
 
 * **File Path**: Path on the local file system of the service account key used for

--- a/docs/GCSBucketCreate-action.md
+++ b/docs/GCSBucketCreate-action.md
@@ -36,9 +36,8 @@ It can be found on the Dashboard in the Google Cloud Platform Console.
 
 **Location:** The location where the gcs buckets will get created. This value is ignored if the bucket already exists.
 
-**Encryption Key Name:** It is used to encrypt data written to bucket that will be created by pipeline.
-If the buckets already exist, you need to manually apply the CMEK to it.
-The location of buckets and key should be same.
+**Encryption Key Name:** It is used to encrypt data written to any bucket created by the plugin.
+If the bucket already exists, this is ignored.
 
 **Service Account**  - service account key used for authorization
 

--- a/docs/GCSBucketCreate-action.md
+++ b/docs/GCSBucketCreate-action.md
@@ -36,7 +36,7 @@ It can be found on the Dashboard in the Google Cloud Platform Console.
 
 **Location:** The location where the gcs buckets will get created. This value is ignored if the bucket already exists.
 
-**Encryption Key Name:** It is used to encrypt data written to any bucket created by the plugin.
+**Encryption Key Name:** Used to encrypt data written to any bucket created by the plugin.
 If the bucket already exists, this is ignored.
 
 **Service Account**  - service account key used for authorization

--- a/docs/GCSCopy-action.md
+++ b/docs/GCSCopy-action.md
@@ -46,7 +46,7 @@ When running on other clusters, the file must be present on every node in the cl
 **Location:** The location where the destination gcs bucket will get created. 
 This value is ignored if the bucket already exists.
 
-**Encryption Key Name:** It is used to encrypt data written to any bucket created by the plugin.
+**Encryption Key Name:** Used to encrypt data written to any bucket created by the plugin.
 If the bucket already exists, this is ignored.
 
 Example

--- a/docs/GCSCopy-action.md
+++ b/docs/GCSCopy-action.md
@@ -46,6 +46,10 @@ When running on other clusters, the file must be present on every node in the cl
 **Location:** The location where the destination gcs bucket will get created. 
 This value is ignored if the bucket already exists.
 
+**Encryption Key Name:** It is used to encrypt data written to bucket that will be created by pipeline.
+If the bucket already exists, you need to manually apply the CMEK to it.
+The location of bucket and key should be same.
+
 Example
 -------
 

--- a/docs/GCSCopy-action.md
+++ b/docs/GCSCopy-action.md
@@ -26,7 +26,7 @@ It can be found on the Dashboard in the Google Cloud Platform Console.
 
 **Source Path**: Path to a source object or directory.
 
-**Destination Path**: Path to the destination. The bucket must already exist.
+**Destination Path**: Path to the destination.
 
 **Copy All Subdirectories**: If the source is a directory, copy all subdirectories.
 
@@ -42,6 +42,9 @@ authorization. Can be set to 'auto-detect' when running on a Dataproc cluster.
 When running on other clusters, the file must be present on every node in the cluster.
 
 * **JSON**: Contents of the service account JSON file.
+
+**Location:** The location where the destination gcs bucket will get created. 
+This value is ignored if the bucket already exists.
 
 Example
 -------

--- a/docs/GCSCopy-action.md
+++ b/docs/GCSCopy-action.md
@@ -46,9 +46,8 @@ When running on other clusters, the file must be present on every node in the cl
 **Location:** The location where the destination gcs bucket will get created. 
 This value is ignored if the bucket already exists.
 
-**Encryption Key Name:** It is used to encrypt data written to bucket that will be created by pipeline.
-If the bucket already exists, you need to manually apply the CMEK to it.
-The location of bucket and key should be same.
+**Encryption Key Name:** It is used to encrypt data written to any bucket created by the plugin.
+If the bucket already exists, this is ignored.
 
 Example
 -------

--- a/docs/GCSMove-action.md
+++ b/docs/GCSMove-action.md
@@ -47,7 +47,7 @@ When running on other clusters, the file must be present on every node in the cl
 **Location:** The location where the destination gcs bucket will get created. 
 This value is ignored if the bucket already exists.
 
-**Encryption Key Name:** It is used to encrypt data written to any bucket created by the plugin.
+**Encryption Key Name:** Used to encrypt data written to any bucket created by the plugin.
 If the bucket already exists, this is ignored.
 
 Example

--- a/docs/GCSMove-action.md
+++ b/docs/GCSMove-action.md
@@ -47,6 +47,10 @@ When running on other clusters, the file must be present on every node in the cl
 **Location:** The location where the destination gcs bucket will get created. 
 This value is ignored if the bucket already exists.
 
+**Encryption Key Name:** It is used to encrypt data written to bucket that will be created by pipeline.
+If the bucket already exists, you need to manually apply the CMEK to it.
+The location of bucket and key should be same.
+
 Example
 -------
 

--- a/docs/GCSMove-action.md
+++ b/docs/GCSMove-action.md
@@ -47,9 +47,8 @@ When running on other clusters, the file must be present on every node in the cl
 **Location:** The location where the destination gcs bucket will get created. 
 This value is ignored if the bucket already exists.
 
-**Encryption Key Name:** It is used to encrypt data written to bucket that will be created by pipeline.
-If the bucket already exists, you need to manually apply the CMEK to it.
-The location of bucket and key should be same.
+**Encryption Key Name:** It is used to encrypt data written to any bucket created by the plugin.
+If the bucket already exists, this is ignored.
 
 Example
 -------

--- a/docs/GCSMove-action.md
+++ b/docs/GCSMove-action.md
@@ -27,7 +27,7 @@ It can be found on the Dashboard in the Google Cloud Platform Console.
 
 **Source Path**: Path to a source object or directory.
 
-**Destination Path**: Path to the destination. The bucket must already exist.
+**Destination Path**: Path to the destination.
 
 **Copy All Subdirectories**: If the source is a directory, move all subdirectories.
 
@@ -43,6 +43,9 @@ authorization. Can be set to 'auto-detect' when running on a Dataproc cluster.
 When running on other clusters, the file must be present on every node in the cluster.
 
 * **JSON**: Contents of the service account JSON file.
+
+**Location:** The location where the destination gcs bucket will get created. 
+This value is ignored if the bucket already exists.
 
 Example
 -------

--- a/docs/GCSMultiFiles-batchsink.md
+++ b/docs/GCSMultiFiles-batchsink.md
@@ -57,9 +57,8 @@ The delimiter will be ignored if the format is anything other than 'delimited'.
 
 **Location:** The location where the gcs buckets will get created. This value is ignored if the bucket already exists.
 
-**Encryption Key Name:** It is used to encrypt data written to bucket that will be created by pipeline.
-If the bucket already exists, you need to manually apply the CMEK to it.
-The location of bucket and key should be same.
+**Encryption Key Name:** Used to encrypt data written to any bucket created by the plugin.
+If the bucket already exists, this is ignored.
 
 **Service Account**  - service account key used for authorization
 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
@@ -24,6 +24,7 @@ import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.hadoop.io.bigquery.BigQueryConfiguration;
 import com.google.cloud.hadoop.io.bigquery.output.BigQueryTableFieldSchema;
+import com.google.cloud.kms.v1.CryptoKeyName;
 import com.google.common.base.Strings;
 import io.cdap.cdap.api.data.batch.Output;
 import io.cdap.cdap.api.data.batch.OutputFormatProvider;
@@ -89,11 +90,15 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, S
     String datasetProjectId = config.getDatasetProject();
     bigQuery = GCPUtils.getBigQuery(datasetProjectId, credentials);
     String cmekKey = context.getArguments().get(GCPUtils.CMEK_KEY);
+    CryptoKeyName cmekKeyName = null;
+    if (!Strings.isNullOrEmpty(cmekKey)) {
+      cmekKeyName = CryptoKeyName.parse(cmekKey);
+    }
     baseConfiguration = getBaseConfiguration(cmekKey);
     String bucket = BigQuerySinkUtils.configureBucket(baseConfiguration, config.getBucket(), runUUID.toString());
     if (!context.isPreviewEnabled()) {
       BigQuerySinkUtils.createResources(bigQuery, GCPUtils.getStorage(project, credentials), config.getDataset(),
-                                        bucket, config.getLocation(), cmekKey);
+                                        bucket, config.getLocation(), cmekKeyName);
     }
 
     prepareRunInternal(context, bigQuery, bucket);

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
@@ -26,9 +26,11 @@ import com.google.cloud.hadoop.io.bigquery.BigQueryFileFormat;
 import com.google.cloud.hadoop.io.bigquery.output.BigQueryOutputConfiguration;
 import com.google.cloud.hadoop.io.bigquery.output.BigQueryTableFieldSchema;
 import com.google.cloud.hadoop.io.bigquery.output.BigQueryTableSchema;
+import com.google.cloud.kms.v1.CryptoKeyName;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
+import com.google.common.base.Strings;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryConstants;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryTypeSize.Numeric;
@@ -137,7 +139,8 @@ public final class BigQuerySinkUtils {
   private static void createBucket(Storage storage, String bucket, @Nullable String location,
                                    @Nullable String cmekKey, Supplier<String> errorMessage) throws IOException {
     try {
-      GCPUtils.createBucket(storage, bucket, location, cmekKey);
+      GCPUtils.createBucket(storage, bucket, location,
+                            Strings.isNullOrEmpty(cmekKey) ? null : CryptoKeyName.parse(cmekKey));
     } catch (StorageException e) {
       if (e.getCode() != 409) {
         // A conflict means the bucket already exists

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySource.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySource.java
@@ -24,6 +24,8 @@ import com.google.cloud.bigquery.StandardTableDefinition;
 import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableDefinition.Type;
 import com.google.cloud.bigquery.TimePartitioning;
+import com.google.cloud.kms.v1.CryptoKeyName;
+import com.google.common.base.Strings;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Metadata;
 import io.cdap.cdap.api.annotation.MetadataProperty;
@@ -128,6 +130,10 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
     // Get Configuration for this run
     bucketPath = UUID.randomUUID().toString();
     String cmekKey = context.getArguments().get(GCPUtils.CMEK_KEY);
+    CryptoKeyName cmekKeyName = null;
+    if (!Strings.isNullOrEmpty(cmekKey)) {
+      cmekKeyName = CryptoKeyName.parse(cmekKey);
+    }
     configuration = BigQueryUtil.getBigQueryConfig(serviceAccount, config.getProject(), cmekKey,
                                                    config.getServiceAccountType());
 
@@ -137,7 +143,7 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
                                                           bigQuery,
                                                           credentials,
                                                           bucketPath,
-                                                          cmekKey);
+                                                          cmekKeyName);
 
     // Configure Service account credentials
     BigQuerySourceUtils.configureServiceAccount(configuration, config.getConnection());

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySourceUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySourceUtils.java
@@ -22,6 +22,8 @@ import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.hadoop.io.bigquery.BigQueryConfiguration;
+import com.google.cloud.kms.v1.CryptoKeyName;
+import com.google.common.base.Strings;
 import io.cdap.plugin.gcp.bigquery.connector.BigQueryConnectorConfig;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryConstants;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;
@@ -87,7 +89,7 @@ public class BigQuerySourceUtils {
       GCPUtils.createBucket(GCPUtils.getStorage(config.getProject(), credentials),
                             bucket,
                             dataset.getLocation(),
-                            cmekKey);
+                            Strings.isNullOrEmpty(cmekKey) ? null : CryptoKeyName.parse(cmekKey));
     }
 
     return bucket;

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySourceUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySourceUtils.java
@@ -66,7 +66,7 @@ public class BigQuerySourceUtils {
    * @param bigQuery BigQuery client.
    * @param credentials Google Cloud Credentials.
    * @param bucketPath bucket path to use. Will be used as a bucket name if needed..
-   * @param cmekKey CMEK key to use for the auto-created bucket.
+   * @param cmekKeyName CMEK key to use for the auto-created bucket.
    * @return Bucket name.
    */
   public static String getOrCreateBucket(Configuration configuration,
@@ -74,7 +74,7 @@ public class BigQuerySourceUtils {
                                          BigQuery bigQuery,
                                          Credentials credentials,
                                          String bucketPath,
-                                         @Nullable String cmekKey) {
+                                         @Nullable CryptoKeyName cmekKeyName) {
     String bucket = config.getBucket();
 
     // Create a new bucket if needed
@@ -88,8 +88,7 @@ public class BigQuerySourceUtils {
       Dataset dataset = bigQuery.getDataset(DatasetId.of(config.getDatasetProject(), config.getDataset()));
       GCPUtils.createBucket(GCPUtils.getStorage(config.getProject(), credentials),
                             bucket,
-                            dataset.getLocation(),
-                            Strings.isNullOrEmpty(cmekKey) ? null : CryptoKeyName.parse(cmekKey));
+                            dataset.getLocation(), cmekKeyName);
     }
 
     return bucket;

--- a/src/main/java/io/cdap/plugin/gcp/common/CmekUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/CmekUtils.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.gcp.common;
+
+import com.google.api.pathtemplate.ValidationException;
+import com.google.cloud.kms.v1.CryptoKeyName;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
+import com.google.common.base.Strings;
+import io.cdap.cdap.etl.api.FailureCollector;
+import io.cdap.plugin.gcp.gcs.GCSPath;
+
+import javax.annotation.Nullable;
+
+
+/**
+ *  Cmek Key Utility class to validate cmek in gcp plugins.
+ */
+public class CmekUtils {
+
+  /**
+   * This method validates the cmek formatted string.
+   *
+   * @param key cmek key formatted string
+   * @param collector  failure collector
+   * @return parsed CryptoKeyName object.
+   */
+  public static CryptoKeyName parseCmekKey(String key, FailureCollector collector) {
+    CryptoKeyName cmekKeyName = null;
+    try {
+      cmekKeyName = CryptoKeyName.parse(key);
+    } catch (ValidationException e) {
+      collector.addFailure(e.getMessage(), null)
+        .withConfigProperty(GCPConfig.NAME_CMEK_KEY).withStacktrace(e.getStackTrace());
+    }
+    return cmekKeyName;
+  }
+
+  /**
+   * This method validates the location of cmek key and bucket if it doesn't exists.
+   *
+   * @param storage GCS storage
+   * @param path the path of bucket to validate
+   * @param cmekKey the cmek key name
+   * @param location the location to create the bucket in if it doesn't exists
+   * @param collector failure collector
+   * @return true if bucket does not exist, otherwise false
+   */
+  public static boolean validateCmekKeyAndBucketLocation(Storage storage, String path, CryptoKeyName cmekKey,
+                                                  @Nullable String location, FailureCollector collector) {
+    GCSPath gcsPath = GCSPath.from(path);
+    Bucket bucket = null;
+    try {
+      bucket = storage.get(gcsPath.getBucket());
+    } catch (StorageException e) {
+          /* Ignoring the exception because we don't want the validation to fail if there is an exception getting
+          the bucket information either because the service account used during validation can be different than
+          the service account that will be used at runtime (the dataproc service account)
+          (assuming the user has auto-detect for the service account) */
+      return false;
+    }
+    if (bucket == null) {
+      String cmekKeyLocation = cmekKey.getLocation();
+      if ((Strings.isNullOrEmpty(location) && !"US".equalsIgnoreCase(cmekKeyLocation))
+        || (!Strings.isNullOrEmpty(location) && !cmekKeyLocation.equalsIgnoreCase(location))) {
+        String bucketLocation = location;
+        if (Strings.isNullOrEmpty(bucketLocation)) {
+          bucketLocation = "US";
+        }
+        collector.addFailure(String.format("CMEK key '%s' is in location '%s' while the GCS bucket '%s' will"
+                                             + " be created in location '%s'.", cmekKey,
+                                           cmekKeyLocation, gcsPath.getBucket(), bucketLocation)
+          , "Modify the CMEK key or bucket location to be the same")
+          .withConfigProperty(GCPConfig.NAME_CMEK_KEY);
+      }
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/main/java/io/cdap/plugin/gcp/common/CmekUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/CmekUtils.java
@@ -77,16 +77,11 @@ public class CmekUtils {
    * This method validates the cmek key formatted string.
    *
    * @param cmekKey cmek key raw string
-   * @param arguments runtime arguments
    * @param collector  failure collector
    * @return parsed CryptoKeyName object if the formatted string is valid otherwise null.
    */
   @Nullable
-  public static CryptoKeyName getCmekKey(@Nullable String cmekKey, @Nullable Arguments arguments,
-                                         FailureCollector collector) {
-    if (Strings.isNullOrEmpty(cmekKey)) {
-      cmekKey = arguments == null ? null : arguments.get("gcp.cmek.key.name");
-    }
+  public static CryptoKeyName getCmekKey(@Nullable String cmekKey, FailureCollector collector) {
     CryptoKeyName cmekKeyName = null;
     if (Strings.isNullOrEmpty(cmekKey)) {
       return cmekKeyName;

--- a/src/main/java/io/cdap/plugin/gcp/common/GCPConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCPConfig.java
@@ -209,7 +209,8 @@ public class GCPConfig extends PluginConfig {
           , "Modify the CMEK key or bucket location to be the same")
           .withConfigProperty(NAME_CMEK_KEY);
       }
+      return true;
     }
-    return true;
+    return false;
   }
 }

--- a/src/main/java/io/cdap/plugin/gcp/common/GCPConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCPConfig.java
@@ -145,6 +145,14 @@ public class GCPConfig extends PluginConfig {
     return false;
   }
 
+  public CryptoKeyName getCmekKey(Arguments arguments, FailureCollector collector) {
+    String cmekKey = getProperties().getProperties().get(NAME_CMEK_KEY);
+    if (Strings.isNullOrEmpty(cmekKey)) {
+      cmekKey = arguments.get("gcp.cmek.key.name");
+    }
+    return CmekUtils.getCmekKey(cmekKey, collector);
+  }
+
   public boolean projectOrServiceAccountContainsMacro() {
     return containsMacro(NAME_PROJECT) || containsMacro(NAME_SERVICE_ACCOUNT_TYPE) ||
       containsMacro(NAME_SERVICE_ACCOUNT_JSON) || containsMacro(NAME_SERVICE_ACCOUNT_FILE_PATH);

--- a/src/main/java/io/cdap/plugin/gcp/common/GCPConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCPConfig.java
@@ -168,7 +168,7 @@ public class GCPConfig extends PluginConfig {
     return cmekKeyName;
   }
 
-  public Storage getStorage() {
+  public Credentials getCredentials() {
     Boolean isServiceAccountFilePath = isServiceAccountFilePath();
     Credentials credentials = null;
     try {
@@ -177,9 +177,8 @@ public class GCPConfig extends PluginConfig {
     } catch (Exception e) {
       /* Ignoring the exception because we don't want to highlight config if an exception occurs while
         loading credentials */
-      return null;
     }
-    return GCPUtils.getStorage(getProject(), credentials);
+    return credentials;
   }
 
   public boolean validateCmekKeyAndBucketLocation(Storage storage, String path, CryptoKeyName cmekKey,

--- a/src/main/java/io/cdap/plugin/gcp/common/GCPConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCPConfig.java
@@ -169,8 +169,8 @@ public class GCPConfig extends PluginConfig {
   }
 
   public boolean requiredFieldsContainsMacro() {
-    return containsMacro(NAME_SERVICE_ACCOUNT_TYPE) || containsMacro(NAME_SERVICE_ACCOUNT_JSON) ||
-      containsMacro(NAME_SERVICE_ACCOUNT_FILE_PATH);
+    return containsMacro(NAME_PROJECT) || containsMacro(NAME_SERVICE_ACCOUNT_TYPE) ||
+      containsMacro(NAME_SERVICE_ACCOUNT_JSON) || containsMacro(NAME_SERVICE_ACCOUNT_FILE_PATH);
   }
 
   public Credentials getCredentials() {

--- a/src/main/java/io/cdap/plugin/gcp/common/GCPConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCPConfig.java
@@ -1,13 +1,21 @@
 package io.cdap.plugin.gcp.common;
 
+import com.google.api.pathtemplate.ValidationException;
+import com.google.auth.Credentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.ServiceOptions;
+import com.google.cloud.kms.v1.CryptoKeyName;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
 import com.google.common.base.Strings;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.plugin.PluginConfig;
 import io.cdap.cdap.etl.api.Arguments;
+import io.cdap.cdap.etl.api.FailureCollector;
+import io.cdap.plugin.gcp.gcs.GCSPath;
 
 import java.io.IOException;
 import javax.annotation.Nullable;
@@ -147,5 +155,61 @@ public class GCPConfig extends PluginConfig {
       return configKey;
     }
     return arguments.get("gcp.cmek.key.name");
+  }
+
+  public CryptoKeyName parseCmekKey(String key, FailureCollector collector) {
+    CryptoKeyName cmekKeyName = null;
+    try {
+      cmekKeyName = CryptoKeyName.parse(key);
+    } catch (ValidationException e) {
+      collector.addFailure(e.getMessage(), null)
+        .withConfigProperty(NAME_CMEK_KEY).withStacktrace(e.getStackTrace());
+    }
+    return cmekKeyName;
+  }
+
+  public Storage getStorage() {
+    Boolean isServiceAccountFilePath = isServiceAccountFilePath();
+    Credentials credentials = null;
+    try {
+      credentials = getServiceAccount() == null ?
+        null : GCPUtils.loadServiceAccountCredentials(getServiceAccount(), isServiceAccountFilePath);
+    } catch (Exception e) {
+      /* Ignoring the exception because we don't want to highlight config if an exception occurs while
+        loading credentials */
+      return null;
+    }
+    return GCPUtils.getStorage(getProject(), credentials);
+  }
+
+  public boolean validateCmekKeyAndBucketLocation(Storage storage, String path, CryptoKeyName cmekKey,
+                                                  @Nullable String location, FailureCollector collector) {
+    GCSPath gcsPath = GCSPath.from(path);
+    Bucket bucket = null;
+    try {
+      bucket = storage.get(gcsPath.getBucket());
+    } catch (StorageException e) {
+          /* Ignoring the exception because we don't want the validation to fail if there is an exception getting
+          the bucket information either because the service account used during validation can be different than
+          the service account that will be used at runtime (the dataproc service account)
+          (assuming the user has auto-detect for the service account) */
+      return false;
+    }
+    if (bucket == null) {
+      String cmekKeyLocation = cmekKey.getLocation();
+      if ((Strings.isNullOrEmpty(location) && !"US".equalsIgnoreCase(cmekKeyLocation))
+        || (!Strings.isNullOrEmpty(location) && !cmekKeyLocation.equalsIgnoreCase(location))) {
+        String bucketLocation = location;
+        if (Strings.isNullOrEmpty(bucketLocation)) {
+          bucketLocation = "US";
+        }
+        collector.addFailure(String.format("CMEK key '%s' is in location '%s' while the GCS bucket '%s' will"
+                                             + " be created in location '%s'.", cmekKey,
+                                           cmekKeyLocation, gcsPath.getBucket(), bucketLocation)
+          , "Modify the CMEK key or bucket location to be the same")
+          .withConfigProperty(NAME_CMEK_KEY);
+      }
+    }
+    return true;
   }
 }

--- a/src/main/java/io/cdap/plugin/gcp/common/GCPConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCPConfig.java
@@ -145,32 +145,6 @@ public class GCPConfig extends PluginConfig {
     return false;
   }
 
-  /**
-   * This method validates the cmek key formatted string.
-   *
-   * @param cmekKey cmek key raw string
-   * @param arguments runtime arguments
-   * @param collector  failure collector
-   * @return parsed CryptoKeyName object if the formatted string is valid otherwise null.
-   */
-  @Nullable
-  public CryptoKeyName getCmekKey(@Nullable String cmekKey, @Nullable Arguments arguments, FailureCollector collector) {
-    if (Strings.isNullOrEmpty(cmekKey)) {
-      cmekKey = arguments == null ? null : arguments.get("gcp.cmek.key.name");
-    }
-    CryptoKeyName cmekKeyName = null;
-    if (Strings.isNullOrEmpty(cmekKey)) {
-      return cmekKeyName;
-    }
-    try {
-      cmekKeyName = CryptoKeyName.parse(cmekKey);
-    } catch (ValidationException e) {
-      collector.addFailure(e.getMessage(), null)
-        .withConfigProperty(GCPConfig.NAME_CMEK_KEY).withStacktrace(e.getStackTrace());
-    }
-    return cmekKeyName;
-  }
-
   public boolean projectOrServiceAccountContainsMacro() {
     return containsMacro(NAME_PROJECT) || containsMacro(NAME_SERVICE_ACCOUNT_TYPE) ||
       containsMacro(NAME_SERVICE_ACCOUNT_JSON) || containsMacro(NAME_SERVICE_ACCOUNT_FILE_PATH);

--- a/src/main/java/io/cdap/plugin/gcp/common/GCPConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCPConfig.java
@@ -1,13 +1,8 @@
 package io.cdap.plugin.gcp.common;
 
-import com.google.api.pathtemplate.ValidationException;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.ServiceOptions;
-import com.google.cloud.kms.v1.CryptoKeyName;
-import com.google.cloud.storage.Bucket;
-import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
 import com.google.common.base.Strings;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
@@ -15,7 +10,6 @@ import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.plugin.PluginConfig;
 import io.cdap.cdap.etl.api.Arguments;
 import io.cdap.cdap.etl.api.FailureCollector;
-import io.cdap.plugin.gcp.gcs.GCSPath;
 
 import java.io.IOException;
 import javax.annotation.Nullable;

--- a/src/main/java/io/cdap/plugin/gcp/common/GCPConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCPConfig.java
@@ -162,15 +162,14 @@ public class GCPConfig extends PluginConfig {
       containsMacro(NAME_SERVICE_ACCOUNT_JSON) || containsMacro(NAME_SERVICE_ACCOUNT_FILE_PATH);
   }
 
-  public Credentials getCredentials() {
+  public Credentials getCredentials(FailureCollector collector) {
     Boolean isServiceAccountFilePath = isServiceAccountFilePath();
     Credentials credentials = null;
     try {
       credentials = getServiceAccount() == null ?
         null : GCPUtils.loadServiceAccountCredentials(getServiceAccount(), isServiceAccountFilePath);
-    } catch (Exception e) {
-      /* Ignoring the exception because we don't want to highlight config if an exception occurs while
-        loading credentials */
+    } catch (IOException e) {
+      collector.addFailure(e.getMessage(), null);
     }
     return credentials;
   }

--- a/src/main/java/io/cdap/plugin/gcp/common/GCPConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCPConfig.java
@@ -146,25 +146,27 @@ public class GCPConfig extends PluginConfig {
   }
 
   /**
-   * This method validates the cmek key raw string.
+   * This method validates the cmek key formatted string.
    *
    * @param cmekKey cmek key raw string
    * @param arguments runtime arguments
    * @param collector  failure collector
-   * @return parsed CryptoKeyName object.
+   * @return parsed CryptoKeyName object if the formatted string is valid otherwise null.
    */
+  @Nullable
   public CryptoKeyName getCmekKey(@Nullable String cmekKey, @Nullable Arguments arguments, FailureCollector collector) {
     if (Strings.isNullOrEmpty(cmekKey)) {
       cmekKey = arguments == null ? null : arguments.get("gcp.cmek.key.name");
     }
     CryptoKeyName cmekKeyName = null;
-    if (!Strings.isNullOrEmpty(cmekKey)) {
-      try {
-        cmekKeyName = CryptoKeyName.parse(cmekKey);
-      } catch (ValidationException e) {
-        collector.addFailure(e.getMessage(), null)
-          .withConfigProperty(GCPConfig.NAME_CMEK_KEY).withStacktrace(e.getStackTrace());
-      }
+    if (Strings.isNullOrEmpty(cmekKey)) {
+      return cmekKeyName;
+    }
+    try {
+      cmekKeyName = CryptoKeyName.parse(cmekKey);
+    } catch (ValidationException e) {
+      collector.addFailure(e.getMessage(), null)
+        .withConfigProperty(GCPConfig.NAME_CMEK_KEY).withStacktrace(e.getStackTrace());
     }
     return cmekKeyName;
   }

--- a/src/main/java/io/cdap/plugin/gcp/common/GCPConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCPConfig.java
@@ -168,6 +168,11 @@ public class GCPConfig extends PluginConfig {
     return cmekKeyName;
   }
 
+  public boolean requiredFieldsContainsMacro() {
+    return containsMacro(NAME_SERVICE_ACCOUNT_TYPE) || containsMacro(NAME_SERVICE_ACCOUNT_JSON) ||
+      containsMacro(NAME_SERVICE_ACCOUNT_FILE_PATH);
+  }
+
   public Credentials getCredentials() {
     Boolean isServiceAccountFilePath = isServiceAccountFilePath();
     Credentials credentials = null;

--- a/src/main/java/io/cdap/plugin/gcp/common/GCPUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCPUtils.java
@@ -22,6 +22,7 @@ import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS;
 import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem;
+import com.google.cloud.kms.v1.CryptoKeyName;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
@@ -177,13 +178,13 @@ public class GCPUtils {
   }
 
   public static void createBucket(Storage storage, String bucket, @Nullable String location,
-                                  @Nullable String cmekKey) throws StorageException {
+                                  @Nullable CryptoKeyName cmekKeyName) throws StorageException {
     BucketInfo.Builder builder = BucketInfo.newBuilder(bucket);
     if (location != null) {
       builder.setLocation(location);
     }
-    if (cmekKey != null) {
-      builder.setDefaultKmsKeyName(cmekKey);
+    if (cmekKeyName != null) {
+      builder.setDefaultKmsKeyName(cmekKeyName.toString());
     }
     storage.create(builder.build());
   }

--- a/src/main/java/io/cdap/plugin/gcp/gcs/StorageClient.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/StorageClient.java
@@ -43,7 +43,7 @@ import javax.annotation.Nullable;
  */
 public class StorageClient {
   private static final Logger LOG = LoggerFactory.getLogger(StorageClient.class);
-  private final Storage storage;
+  public final Storage storage;
 
   private StorageClient(Storage storage) {
     this.storage = storage;

--- a/src/main/java/io/cdap/plugin/gcp/gcs/StorageClient.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/StorageClient.java
@@ -46,10 +46,6 @@ public class StorageClient {
   private final Storage storage;
   private List<GCSPath> undoBucket = new ArrayList<>();
 
-  public Storage getStorage() {
-    return storage;
-  }
-
   private StorageClient(Storage storage) {
     this.storage = storage;
   }

--- a/src/main/java/io/cdap/plugin/gcp/gcs/StorageClient.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/StorageClient.java
@@ -44,7 +44,6 @@ import javax.annotation.Nullable;
 public class StorageClient {
   private static final Logger LOG = LoggerFactory.getLogger(StorageClient.class);
   private final Storage storage;
-  private List<GCSPath> undoBucket = new ArrayList<>();
 
   private StorageClient(Storage storage) {
     this.storage = storage;
@@ -113,7 +112,7 @@ public class StorageClient {
    * @param location the location of bucket
    * @param cmekKey  the name of the cmek key
    */
-  public void createBucket(GCSPath path, @Nullable String location, @Nullable String cmekKey) {
+  public void createBucketIfNotExists(GCSPath path, @Nullable String location, @Nullable String cmekKey) {
     Bucket bucket = null;
     try {
       bucket = storage.get(path.getBucket());
@@ -124,16 +123,6 @@ public class StorageClient {
     }
     if (bucket == null) {
       GCPUtils.createBucket(storage, path.getBucket(), location, cmekKey);
-      undoBucket.add(path);
-    }
-  }
-
-  /**
-   * Deletes any bucket created by the client. It is called when the operation failed.
-   */
-  public void deleteBucket() {
-    for (GCSPath bucket : undoBucket) {
-      storage.delete(bucket.getBucket());
     }
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/gcs/StorageClient.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/StorageClient.java
@@ -43,7 +43,11 @@ import javax.annotation.Nullable;
  */
 public class StorageClient {
   private static final Logger LOG = LoggerFactory.getLogger(StorageClient.class);
-  public final Storage storage;
+  private final Storage storage;
+
+  public Storage getStorage() {
+    return storage;
+  }
 
   private StorageClient(Storage storage) {
     this.storage = storage;

--- a/src/main/java/io/cdap/plugin/gcp/gcs/StorageClient.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/StorageClient.java
@@ -17,6 +17,7 @@
 package io.cdap.plugin.gcp.gcs;
 
 import com.google.api.gax.paging.Page;
+import com.google.cloud.kms.v1.CryptoKeyName;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
@@ -110,9 +111,9 @@ public class StorageClient {
    *
    * @param path the path of the bucket 
    * @param location the location of bucket
-   * @param cmekKey  the name of the cmek key
+   * @param cmekKeyName  the name of the cmek key
    */
-  public void createBucketIfNotExists(GCSPath path, @Nullable String location, @Nullable String cmekKey) {
+  public void createBucketIfNotExists(GCSPath path, @Nullable String location, @Nullable CryptoKeyName cmekKeyName) {
     Bucket bucket = null;
     try {
       bucket = storage.get(path.getBucket());
@@ -122,7 +123,7 @@ public class StorageClient {
           + "Ensure you entered the correct bucket path and have permissions for it.", e);
     }
     if (bucket == null) {
-      GCPUtils.createBucket(storage, path.getBucket(), location, cmekKey);
+      GCPUtils.createBucket(storage, path.getBucket(), location, cmekKeyName);
     }
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketCreate.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketCreate.java
@@ -134,8 +134,7 @@ public final class GCSBucketCreate extends Action {
           CryptoKeyName cmekKeyName = config.getCmekKey(config.cmekKey, context.getArguments(),
                                                         context.getFailureCollector());
           context.getFailureCollector().getOrThrowException();
-          GCPUtils.createBucket(storage, gcsPath.getBucket(), config.location,
-                                cmekKeyName == null ? null : cmekKeyName.toString());
+          GCPUtils.createBucket(storage, gcsPath.getBucket(), config.location, cmekKeyName);
           undoBucket.add(bucketPath);
         } else if (gcsPath.equals(bucketPath) && config.failIfExists()) {
           // if the gcs path is just a bucket, and it exists, fail the pipeline

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketCreate.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketCreate.java
@@ -33,6 +33,7 @@ import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.action.Action;
 import io.cdap.cdap.etl.api.action.ActionContext;
+import io.cdap.plugin.gcp.common.CmekUtils;
 import io.cdap.plugin.gcp.common.GCPConfig;
 import io.cdap.plugin.gcp.common.GCPUtils;
 import io.cdap.plugin.gcp.gcs.GCSPath;
@@ -256,11 +257,11 @@ public final class GCSBucketCreate extends Action {
 
     //This method validated the pattern of CMEK Key resource ID.
     void validateCmekKey(FailureCollector failureCollector) {
-      CryptoKeyName cmekKeyName = parseCmekKey(cmekKey, failureCollector);
+      CryptoKeyName cmekKeyName = CmekUtils.parseCmekKey(cmekKey, failureCollector);
 
       //these fields are needed to check if bucket exists or not and for location validation
       if (cmekKeyName == null || containsMacro(NAME_PATHS) || containsMacro(NAME_LOCATION) ||
-        requiredFieldsContainsMacro()) {
+        projectOrServiceAccountContainsMacro()) {
         return;
       }
       Storage storage = GCPUtils.getStorage(getProject(), getCredentials());
@@ -269,7 +270,7 @@ public final class GCSBucketCreate extends Action {
       }
       for (String path : getPaths()) {
         //only need to check one bucket that is to be created as all others will have same location.
-        if (validateCmekKeyAndBucketLocation(storage, path, cmekKeyName, location, failureCollector)) {
+        if (CmekUtils.validateCmekKeyAndBucketLocation(storage, path, cmekKeyName, location, failureCollector)) {
           break;
         }
       }

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketCreate.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketCreate.java
@@ -260,8 +260,7 @@ public final class GCSBucketCreate extends Action {
 
       //these fields are needed to check if bucket exists or not and for location validation
       if (cmekKeyName == null || containsMacro(NAME_PATHS) || containsMacro(NAME_LOCATION) ||
-        containsMacro(NAME_SERVICE_ACCOUNT_TYPE) || containsMacro(NAME_SERVICE_ACCOUNT_JSON) ||
-        containsMacro(NAME_SERVICE_ACCOUNT_FILE_PATH)) {
+        requiredFieldsContainsMacro()) {
         return;
       }
       Storage storage = GCPUtils.getStorage(getProject(), getCredentials());

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketCreate.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketCreate.java
@@ -264,7 +264,7 @@ public final class GCSBucketCreate extends Action {
         projectOrServiceAccountContainsMacro()) {
         return;
       }
-      Storage storage = GCPUtils.getStorage(getProject(), getCredentials());
+      Storage storage = GCPUtils.getStorage(getProject(), getCredentials(failureCollector));
       if (storage == null) {
         return;
       }

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketCreate.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketCreate.java
@@ -131,8 +131,7 @@ public final class GCSBucketCreate extends Action {
               + "Ensure you entered the correct bucket path and have permissions for it.", e);
         }
         if (bucket == null) {
-          CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(config.cmekKey, context.getArguments(),
-                                                        context.getFailureCollector());
+          CryptoKeyName cmekKeyName = config.getCmekKey(context.getArguments(), context.getFailureCollector());
           context.getFailureCollector().getOrThrowException();
           GCPUtils.createBucket(storage, gcsPath.getBucket(), config.location, cmekKeyName);
           undoBucket.add(bucketPath);
@@ -260,7 +259,7 @@ public final class GCSBucketCreate extends Action {
 
     //This method validated the pattern of CMEK Key resource ID.
     void validateCmekKey(FailureCollector failureCollector) {
-      CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(cmekKey, null, failureCollector);
+      CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(cmekKey, failureCollector);
 
       //these fields are needed to check if bucket exists or not and for location validation
       if (cmekKeyName == null || containsMacro(NAME_PATHS) || containsMacro(NAME_LOCATION) ||

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketCreate.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketCreate.java
@@ -264,7 +264,7 @@ public final class GCSBucketCreate extends Action {
         containsMacro(NAME_SERVICE_ACCOUNT_FILE_PATH)) {
         return;
       }
-      Storage storage = getStorage();
+      Storage storage = GCPUtils.getStorage(getProject(), getCredentials());
       if (storage == null) {
         return;
       }

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketCreate.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketCreate.java
@@ -133,6 +133,7 @@ public final class GCSBucketCreate extends Action {
         if (bucket == null) {
           CryptoKeyName cmekKeyName = config.getCmekKey(config.cmekKey, context.getArguments(),
                                                         context.getFailureCollector());
+          context.getFailureCollector().getOrThrowException();
           GCPUtils.createBucket(storage, gcsPath.getBucket(), config.location,
                                 cmekKeyName == null ? null : cmekKeyName.toString());
           undoBucket.add(bucketPath);

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketCreate.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketCreate.java
@@ -131,7 +131,7 @@ public final class GCSBucketCreate extends Action {
               + "Ensure you entered the correct bucket path and have permissions for it.", e);
         }
         if (bucket == null) {
-          CryptoKeyName cmekKeyName = config.getCmekKey(config.cmekKey, context.getArguments(),
+          CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(config.cmekKey, context.getArguments(),
                                                         context.getFailureCollector());
           context.getFailureCollector().getOrThrowException();
           GCPUtils.createBucket(storage, gcsPath.getBucket(), config.location, cmekKeyName);
@@ -260,7 +260,7 @@ public final class GCSBucketCreate extends Action {
 
     //This method validated the pattern of CMEK Key resource ID.
     void validateCmekKey(FailureCollector failureCollector) {
-      CryptoKeyName cmekKeyName = getCmekKey(cmekKey, null, failureCollector);
+      CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(cmekKey, null, failureCollector);
 
       //these fields are needed to check if bucket exists or not and for location validation
       if (cmekKeyName == null || containsMacro(NAME_PATHS) || containsMacro(NAME_LOCATION) ||

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketCreate.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketCreate.java
@@ -23,6 +23,7 @@ import com.google.cloud.kms.v1.CryptoKeyName;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
@@ -35,6 +36,7 @@ import io.cdap.cdap.etl.api.action.ActionContext;
 import io.cdap.plugin.gcp.common.GCPConfig;
 import io.cdap.plugin.gcp.common.GCPUtils;
 import io.cdap.plugin.gcp.gcs.GCSPath;
+import io.cdap.plugin.gcp.gcs.sink.GCSBatchSink;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -214,6 +216,18 @@ public final class GCSBucketCreate extends Action {
     @Description("The GCP customer managed encryption key (CMEK) name used by Cloud Dataproc")
     private String cmekKey;
 
+    public Config(@Nullable String project, @Nullable String serviceAccountType, @Nullable String serviceFilePath,
+                  @Nullable String serviceAccountJson, @Nullable String paths, @Nullable String location,
+                  @Nullable String cmekKey) {
+      this.serviceAccountType = serviceAccountType;
+      this.serviceAccountJson = serviceAccountJson;
+      this.serviceFilePath = serviceFilePath;
+      this.project = project;
+      this.paths = paths;
+      this.location = location;
+      this.cmekKey = cmekKey;
+    }
+
     public List<String> getPaths() {
       return Arrays.stream(paths.split(",")).map(String::trim).collect(Collectors.toList());
     }
@@ -297,6 +311,70 @@ public final class GCSBucketCreate extends Action {
           //only need to check one bucket that is to be created as all others will have same location.
           break;
         }
+      }
+    }
+
+    public static Config.Builder builder() {
+      return new Config.Builder();
+    }
+
+    /**
+     * GCS Bucket Create configuration builder.
+     */
+    public static class Builder {
+      private String serviceAccountType;
+      private String serviceFilePath;
+      private String serviceAccountJson;
+      private String project;
+      private String gcsPaths;
+      private String cmekKey;
+      private String location;
+
+      public GCSBucketCreate.Config.Builder setProject(@Nullable String project) {
+        this.project = project;
+        return this;
+      }
+
+      public GCSBucketCreate.Config.Builder setServiceAccountType(@Nullable String serviceAccountType) {
+        this.serviceAccountType = serviceAccountType;
+        return this;
+      }
+
+      public GCSBucketCreate.Config.Builder setServiceFilePath(@Nullable String serviceFilePath) {
+        this.serviceFilePath = serviceFilePath;
+        return this;
+      }
+
+      public GCSBucketCreate.Config.Builder setServiceAccountJson(@Nullable String serviceAccountJson) {
+        this.serviceAccountJson = serviceAccountJson;
+        return this;
+      }
+
+      public GCSBucketCreate.Config.Builder setGcsPath(@Nullable String gcsPaths) {
+        this.gcsPaths = gcsPaths;
+        return this;
+      }
+
+      public GCSBucketCreate.Config.Builder setCmekKey(@Nullable String cmekKey) {
+        this.cmekKey = cmekKey;
+        return this;
+      }
+
+      public GCSBucketCreate.Config.Builder setLocation(@Nullable String location) {
+        this.location = location;
+        return this;
+      }
+
+      public GCSBucketCreate.Config build() {
+        return new GCSBucketCreate.Config(
+          project,
+          serviceAccountType,
+          serviceFilePath,
+          serviceAccountJson,
+          gcsPaths,
+          location,
+          cmekKey
+        );
       }
     }
   }

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSCopy.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSCopy.java
@@ -65,7 +65,7 @@ public class GCSCopy extends Action {
 
     GCSPath destPath = config.getDestPath();
     GCSPath undo = null;
-    Storage storage = storageClient.storage;
+    Storage storage = storageClient.getStorage();
 
     // create the destination bucket if not exist
     Bucket bucket = null;
@@ -73,7 +73,7 @@ public class GCSCopy extends Action {
       bucket = storage.get(destPath.getBucket());
     } catch (StorageException e) {
       throw new RuntimeException(
-        String.format("Unable to access or create bucket %s. ", destPath.getBucket())
+        String.format("Unable to access destination bucket %s. ", destPath.getBucket())
           + "Ensure you entered the correct bucket path and have permissions for it.", e);
     }
     if (bucket == null) {

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSCopy.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSCopy.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.action.Action;
 import io.cdap.cdap.etl.api.action.ActionContext;
+import io.cdap.plugin.gcp.common.CmekUtils;
 import io.cdap.plugin.gcp.common.GCPUtils;
 import io.cdap.plugin.gcp.gcs.GCSPath;
 import io.cdap.plugin.gcp.gcs.StorageClient;
@@ -65,8 +66,8 @@ public class GCSCopy extends Action {
                                                        isServiceAccountFilePath);
 
     GCSPath destPath = config.getDestPath();
-    CryptoKeyName cmekKeyName = config.getCmekKey(config.cmekKey, context.getArguments(),
-                                                  context.getFailureCollector());
+    CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(config.cmekKey, context.getArguments(),
+                                                     context.getFailureCollector());
     context.getFailureCollector().getOrThrowException();
 
     // create the destination bucket if not exist

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSCopy.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSCopy.java
@@ -66,8 +66,7 @@ public class GCSCopy extends Action {
                                                        isServiceAccountFilePath);
 
     GCSPath destPath = config.getDestPath();
-    CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(config.cmekKey, context.getArguments(),
-                                                     context.getFailureCollector());
+    CryptoKeyName cmekKeyName = config.getCmekKey(context.getArguments(), context.getFailureCollector());
     context.getFailureCollector().getOrThrowException();
 
     // create the destination bucket if not exist

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSCopy.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSCopy.java
@@ -78,7 +78,7 @@ public class GCSCopy extends Action {
     }
     if (bucket == null) {
       GCPUtils.createBucket(storage, destPath.getBucket(), config.location,
-                            context.getArguments().get(GCPUtils.CMEK_KEY));
+                            config.getCmekKey(context.getArguments()));
       undo = destPath;
     }
 

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSCopy.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSCopy.java
@@ -67,6 +67,7 @@ public class GCSCopy extends Action {
     GCSPath destPath = config.getDestPath();
     CryptoKeyName cmekKeyName = config.getCmekKey(config.cmekKey, context.getArguments(),
                                                   context.getFailureCollector());
+    context.getFailureCollector().getOrThrowException();
 
     // create the destination bucket if not exist
     storageClient.createBucketIfNotExists(destPath, config.location,

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSCopy.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSCopy.java
@@ -70,8 +70,7 @@ public class GCSCopy extends Action {
     context.getFailureCollector().getOrThrowException();
 
     // create the destination bucket if not exist
-    storageClient.createBucketIfNotExists(destPath, config.location,
-                                          cmekKeyName == null ? null : cmekKeyName.toString());
+    storageClient.createBucketIfNotExists(destPath, config.location, cmekKeyName);
 
     //noinspection ConstantConditions
     storageClient.copy(config.getSourcePath(), config.getDestPath(), config.recursive, config.shouldOverwrite());

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSCopy.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSCopy.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.gcp.gcs.actions;
 
+import com.google.cloud.kms.v1.CryptoKeyName;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
@@ -64,17 +65,15 @@ public class GCSCopy extends Action {
                                                        isServiceAccountFilePath);
 
     GCSPath destPath = config.getDestPath();
+    CryptoKeyName cmekKeyName = config.getCmekKey(config.cmekKey, context.getArguments(),
+                                                  context.getFailureCollector());
 
     // create the destination bucket if not exist
-    storageClient.createBucket(destPath, config.location, config.getCmekKey(context.getArguments()));
+    storageClient.createBucketIfNotExists(destPath, config.location,
+                                          cmekKeyName == null ? null : cmekKeyName.toString());
 
-    try {
-      storageClient.copy(config.getSourcePath(), config.getDestPath(), config.recursive, config.shouldOverwrite());
-    } catch (Exception e) {
-      //deleting the destination bucket that was auto-created if the operation failed.
-      storageClient.deleteBucket();
-      throw e;
-    }
+    //noinspection ConstantConditions
+    storageClient.copy(config.getSourcePath(), config.getDestPath(), config.recursive, config.shouldOverwrite());
 
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSDoneFileMarker.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSDoneFileMarker.java
@@ -160,6 +160,10 @@ public class GCSDoneFileMarker extends PostAction {
                                        BatchActionContext context) {
 
     String cmekKey = context.getArguments().get(GCPUtils.CMEK_KEY);
+    CryptoKeyName cmekKeyName = null;
+    if (!Strings.isNullOrEmpty(cmekKey)) {
+      cmekKeyName = CryptoKeyName.parse(cmekKey);
+    }
     Credentials credentials = null;
     if (serviceAccount != null) {
       try {
@@ -173,8 +177,7 @@ public class GCSDoneFileMarker extends PostAction {
     Storage storage = GCPUtils.getStorage(project, credentials);
     if (storage.get(path.getBucket()) == null) {
       try {
-        GCPUtils.createBucket(storage, path.getBucket(), null,
-                              Strings.isNullOrEmpty(cmekKey) ? null : CryptoKeyName.parse(cmekKey));
+        GCPUtils.createBucket(storage, path.getBucket(), null, cmekKeyName);
       } catch (StorageException e) {
         throw new RuntimeException(String.format("Failed to create bucket %s: %s.", path.getBucket(),
                                                  e.getMessage()), e);

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSDoneFileMarker.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSDoneFileMarker.java
@@ -17,6 +17,7 @@
 package io.cdap.plugin.gcp.gcs.actions;
 
 import com.google.auth.Credentials;
+import com.google.cloud.kms.v1.CryptoKeyName;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
@@ -172,7 +173,8 @@ public class GCSDoneFileMarker extends PostAction {
     Storage storage = GCPUtils.getStorage(project, credentials);
     if (storage.get(path.getBucket()) == null) {
       try {
-        GCPUtils.createBucket(storage, path.getBucket(), null, cmekKey);
+        GCPUtils.createBucket(storage, path.getBucket(), null,
+                              Strings.isNullOrEmpty(cmekKey) ? null : CryptoKeyName.parse(cmekKey));
       } catch (StorageException e) {
         throw new RuntimeException(String.format("Failed to create bucket %s: %s.", path.getBucket(),
                                                  e.getMessage()), e);

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
@@ -65,7 +65,7 @@ public class GCSMove extends Action {
 
     GCSPath destPath = config.getDestPath();
     GCSPath undo = null;
-    Storage storage = storageClient.storage;
+    Storage storage = storageClient.getStorage();
 
     // create the destination bucket if not exist
     Bucket bucket = null;
@@ -73,7 +73,7 @@ public class GCSMove extends Action {
       bucket = storage.get(destPath.getBucket());
     } catch (StorageException e) {
       throw new RuntimeException(
-        String.format("Unable to access or create bucket %s. ", destPath.getBucket())
+        String.format("Unable to access destination bucket %s. ", destPath.getBucket())
           + "Ensure you entered the correct bucket path and have permissions for it.", e);
     }
     if (bucket == null) {

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
@@ -62,33 +62,16 @@ public class GCSMove extends Action {
     }
     StorageClient storageClient = StorageClient.create(config.getProject(), config.getServiceAccount(),
                                                        isServiceAccountFilePath);
-
     GCSPath destPath = config.getDestPath();
-    GCSPath undo = null;
-    Storage storage = storageClient.getStorage();
 
     // create the destination bucket if not exist
-    Bucket bucket = null;
-    try {
-      bucket = storage.get(destPath.getBucket());
-    } catch (StorageException e) {
-      throw new RuntimeException(
-        String.format("Unable to access destination bucket %s. ", destPath.getBucket())
-          + "Ensure you entered the correct bucket path and have permissions for it.", e);
-    }
-    if (bucket == null) {
-      GCPUtils.createBucket(storage, destPath.getBucket(), config.location,
-                            config.getCmekKey(context.getArguments()));
-      undo = destPath;
-    }
+    storageClient.createBucket(destPath, config.location, config.getCmekKey(context.getArguments()));
 
     try {
       storageClient.move(config.getSourcePath(), config.getDestPath(), config.recursive, config.shouldOverwrite());
     } catch (Exception e) {
       //deleting the destination bucket that was auto-created if the operation failed.
-      if (undo != null) {
-        storage.delete(undo.getBucket());
-      }
+      storageClient.deleteBucket();
       throw e;
     }
   }

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
@@ -66,6 +66,7 @@ public class GCSMove extends Action {
     GCSPath destPath = config.getDestPath();
     CryptoKeyName cmekKeyName = config.getCmekKey(config.cmekKey, context.getArguments(),
                                                   context.getFailureCollector());
+    context.getFailureCollector().getOrThrowException();
 
     // create the destination bucket if not exist
     storageClient.createBucketIfNotExists(destPath, config.location,

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.action.Action;
 import io.cdap.cdap.etl.api.action.ActionContext;
+import io.cdap.plugin.gcp.common.CmekUtils;
 import io.cdap.plugin.gcp.common.GCPUtils;
 import io.cdap.plugin.gcp.gcs.GCSPath;
 import io.cdap.plugin.gcp.gcs.StorageClient;
@@ -64,8 +65,8 @@ public class GCSMove extends Action {
     StorageClient storageClient = StorageClient.create(config.getProject(), config.getServiceAccount(),
                                                        isServiceAccountFilePath);
     GCSPath destPath = config.getDestPath();
-    CryptoKeyName cmekKeyName = config.getCmekKey(config.cmekKey, context.getArguments(),
-                                                  context.getFailureCollector());
+    CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(config.cmekKey, context.getArguments(),
+                                                     context.getFailureCollector());
     context.getFailureCollector().getOrThrowException();
 
     // create the destination bucket if not exist

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
@@ -69,8 +69,7 @@ public class GCSMove extends Action {
     context.getFailureCollector().getOrThrowException();
 
     // create the destination bucket if not exist
-    storageClient.createBucketIfNotExists(destPath, config.location,
-                                          cmekKeyName == null ? null : cmekKeyName.toString());
+    storageClient.createBucketIfNotExists(destPath, config.location, cmekKeyName);
 
     //noinspection ConstantConditions
     storageClient.move(config.getSourcePath(), config.getDestPath(), config.recursive, config.shouldOverwrite());

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
@@ -78,7 +78,7 @@ public class GCSMove extends Action {
     }
     if (bucket == null) {
       GCPUtils.createBucket(storage, destPath.getBucket(), config.location,
-                            context.getArguments().get(GCPUtils.CMEK_KEY));
+                            config.getCmekKey(context.getArguments()));
       undo = destPath;
     }
 

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
@@ -16,6 +16,9 @@
 
 package io.cdap.plugin.gcp.gcs.actions;
 
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
@@ -23,6 +26,8 @@ import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.action.Action;
 import io.cdap.cdap.etl.api.action.ActionContext;
+import io.cdap.plugin.gcp.common.GCPUtils;
+import io.cdap.plugin.gcp.gcs.GCSPath;
 import io.cdap.plugin.gcp.gcs.StorageClient;
 
 import java.io.IOException;
@@ -57,8 +62,35 @@ public class GCSMove extends Action {
     }
     StorageClient storageClient = StorageClient.create(config.getProject(), config.getServiceAccount(),
                                                        isServiceAccountFilePath);
-    //noinspection ConstantConditions
-    storageClient.move(config.getSourcePath(), config.getDestPath(), config.recursive, config.shouldOverwrite());
+
+    GCSPath destPath = config.getDestPath();
+    GCSPath undo = null;
+    Storage storage = storageClient.storage;
+
+    // create the destination bucket if not exist
+    Bucket bucket = null;
+    try {
+      bucket = storage.get(destPath.getBucket());
+    } catch (StorageException e) {
+      throw new RuntimeException(
+        String.format("Unable to access or create bucket %s. ", destPath.getBucket())
+          + "Ensure you entered the correct bucket path and have permissions for it.", e);
+    }
+    if (bucket == null) {
+      GCPUtils.createBucket(storage, destPath.getBucket(), config.location,
+                            context.getArguments().get(GCPUtils.CMEK_KEY));
+      undo = destPath;
+    }
+
+    try {
+      storageClient.move(config.getSourcePath(), config.getDestPath(), config.recursive, config.shouldOverwrite());
+    } catch (Exception e) {
+      //deleting the destination bucket that was auto-created if the operation failed.
+      if (undo != null) {
+        storage.delete(undo.getBucket());
+      }
+      throw e;
+    }
   }
 
   /**

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
@@ -65,8 +65,7 @@ public class GCSMove extends Action {
     StorageClient storageClient = StorageClient.create(config.getProject(), config.getServiceAccount(),
                                                        isServiceAccountFilePath);
     GCSPath destPath = config.getDestPath();
-    CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(config.cmekKey, context.getArguments(),
-                                                     context.getFailureCollector());
+    CryptoKeyName cmekKeyName = config.getCmekKey(context.getArguments(), context.getFailureCollector());
     context.getFailureCollector().getOrThrowException();
 
     // create the destination bucket if not exist

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/SourceDestConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/SourceDestConfig.java
@@ -31,6 +31,7 @@ import javax.annotation.Nullable;
 public class SourceDestConfig extends GCPConfig {
   public static final String NAME_SOURCE_PATH = "sourcePath";
   public static final String NAME_DEST_PATH = "destPath";
+  public static final String NAME_LOCATION = "location";
 
   @Name(NAME_SOURCE_PATH)
   @Macro
@@ -46,6 +47,13 @@ public class SourceDestConfig extends GCPConfig {
   @Nullable
   @Description("Whether to overwrite existing objects.")
   private Boolean overwrite;
+
+  @Name(NAME_LOCATION)
+  @Macro
+  @Nullable
+  @Description("The location where the gcs buckets will get created. " +
+    "This value is ignored if the bucket already exists.")
+  protected String location;
 
   public SourceDestConfig() {
     overwrite = false;

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/SourceDestConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/SourceDestConfig.java
@@ -69,7 +69,7 @@ public class SourceDestConfig extends GCPConfig {
   @Nullable
   @Description("The GCP customer managed encryption key (CMEK) name used to encrypt data written to " +
     "any bucket created by the plugin. If the bucket already exists, this is ignored.")
-  private String cmekKey;
+  protected String cmekKey;
 
   public SourceDestConfig(@Nullable String project, @Nullable String serviceAccountType,
                           @Nullable String serviceFilePath, @Nullable String serviceAccountJson,
@@ -123,7 +123,7 @@ public class SourceDestConfig extends GCPConfig {
 
   //This method validated the pattern of CMEK Key resource ID.
   void validateCmekKey(FailureCollector failureCollector) {
-    CryptoKeyName cmekKeyName = CmekUtils.parseCmekKey(cmekKey, failureCollector);
+    CryptoKeyName cmekKeyName = getCmekKey(cmekKey, null, failureCollector);
 
     //these fields are needed to check if bucket exists or not and for location validation
     if (cmekKeyName == null || containsMacro(NAME_DEST_PATH) || containsMacro(NAME_LOCATION) ||
@@ -135,7 +135,8 @@ public class SourceDestConfig extends GCPConfig {
     if (storage == null) {
       return;
     }
-    CmekUtils.validateCmekKeyAndBucketLocation(storage, destPath, cmekKeyName, location, failureCollector);
+    CmekUtils.validateCmekKeyAndBucketLocation(storage, GCSPath.from(destPath),
+                                               cmekKeyName, location, failureCollector);
   }
 
   public static SourceDestConfig.Builder builder() {

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/SourceDestConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/SourceDestConfig.java
@@ -123,7 +123,7 @@ public class SourceDestConfig extends GCPConfig {
 
   //This method validated the pattern of CMEK Key resource ID.
   void validateCmekKey(FailureCollector failureCollector) {
-    CryptoKeyName cmekKeyName = getCmekKey(cmekKey, null, failureCollector);
+    CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(cmekKey, null, failureCollector);
 
     //these fields are needed to check if bucket exists or not and for location validation
     if (cmekKeyName == null || containsMacro(NAME_DEST_PATH) || containsMacro(NAME_LOCATION) ||

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/SourceDestConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/SourceDestConfig.java
@@ -66,7 +66,8 @@ public class SourceDestConfig extends GCPConfig {
   @Name(NAME_CMEK_KEY)
   @Macro
   @Nullable
-  @Description("The GCP customer managed encryption key (CMEK) name used by Cloud Dataproc")
+  @Description("The GCP customer managed encryption key (CMEK) name used to encrypt data written to " +
+    "any bucket created by the plugin. If the bucket already exists, this is ignored.")
   private String cmekKey;
 
   public SourceDestConfig(@Nullable String project, @Nullable String serviceAccountType,
@@ -121,56 +122,20 @@ public class SourceDestConfig extends GCPConfig {
 
   //This method validated the pattern of CMEK Key resource ID.
   void validateCmekKey(FailureCollector failureCollector) {
-    CryptoKeyName cmekKeyName = null;
-    try {
-      cmekKeyName = CryptoKeyName.parse(cmekKey);
-    } catch (ValidationException e) {
-      failureCollector.addFailure(e.getMessage(), null)
-        .withConfigProperty(NAME_CMEK_KEY).withStacktrace(e.getStackTrace());
-      return;
-    }
+    CryptoKeyName cmekKeyName = parseCmekKey(cmekKey, failureCollector);
 
     //these fields are needed to check if bucket exists or not and for location validation
-    if (containsMacro(NAME_DEST_PATH) || containsMacro(NAME_LOCATION) || containsMacro(NAME_SERVICE_ACCOUNT_TYPE)
-      || containsMacro(NAME_SERVICE_ACCOUNT_JSON) || containsMacro(NAME_SERVICE_ACCOUNT_FILE_PATH)) {
+    if (cmekKeyName == null || containsMacro(NAME_DEST_PATH) || containsMacro(NAME_LOCATION) ||
+      containsMacro(NAME_SERVICE_ACCOUNT_TYPE) || containsMacro(NAME_SERVICE_ACCOUNT_JSON) ||
+      containsMacro(NAME_SERVICE_ACCOUNT_FILE_PATH)) {
       return;
     }
-    Boolean isServiceAccountFilePath = isServiceAccountFilePath();
-    Credentials credentials = null;
-    try {
-      credentials = getServiceAccount() == null ?
-        null : GCPUtils.loadServiceAccountCredentials(getServiceAccount(), isServiceAccountFilePath);
-    } catch (Exception e) {
-        /*Ignoring the exception because we don't want to highlight cmek key if an exception occurs while
-        loading credentials*/
+    
+    Storage storage = getStorage();
+    if (storage == null) {
       return;
     }
-    Storage storage = GCPUtils.getStorage(getProject(), credentials);
-    Bucket bucket = null;
-    try {
-      bucket = storage.get(getDestPath().getBucket());
-    } catch (StorageException e) {
-        /* Ignoring the exception because we don't want the validation to fail if there is an exception getting
-          the bucket information either because the service account used during validation can be different than
-          the service account that will be used at runtime (the dataproc service account)
-          (assuming the user has auto-detect for the service account) */
-      return;
-    }
-    if (bucket == null) {
-      String cmekKeyLocation = cmekKeyName.getLocation();
-      if ((Strings.isNullOrEmpty(location) && !"US".equalsIgnoreCase(cmekKeyLocation))
-        || (!Strings.isNullOrEmpty(location) && !cmekKeyLocation.equalsIgnoreCase(location))) {
-        String bucketLocation = location;
-        if (Strings.isNullOrEmpty(bucketLocation)) {
-          bucketLocation = "US";
-        }
-        failureCollector.addFailure(String.format("CMEK key '%s' is in location '%s' while the GCS bucket will " +
-                                                    "be created in location '%s'.", cmekKey,
-                                                  cmekKeyLocation, bucketLocation)
-          , "Modify the CMEK key or bucket location to be the same")
-          .withConfigProperty(NAME_CMEK_KEY);
-      }
-    }
+    validateCmekKeyAndBucketLocation(storage, destPath, cmekKeyName, location, failureCollector);
   }
 
   public static SourceDestConfig.Builder builder() {

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/SourceDestConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/SourceDestConfig.java
@@ -126,8 +126,7 @@ public class SourceDestConfig extends GCPConfig {
 
     //these fields are needed to check if bucket exists or not and for location validation
     if (cmekKeyName == null || containsMacro(NAME_DEST_PATH) || containsMacro(NAME_LOCATION) ||
-      containsMacro(NAME_SERVICE_ACCOUNT_TYPE) || containsMacro(NAME_SERVICE_ACCOUNT_JSON) ||
-      containsMacro(NAME_SERVICE_ACCOUNT_FILE_PATH)) {
+      requiredFieldsContainsMacro()) {
       return;
     }
     

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/SourceDestConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/SourceDestConfig.java
@@ -131,7 +131,7 @@ public class SourceDestConfig extends GCPConfig {
       return;
     }
     
-    Storage storage = GCPUtils.getStorage(getProject(), getCredentials());
+    Storage storage = GCPUtils.getStorage(getProject(), getCredentials(failureCollector));
     if (storage == null) {
       return;
     }

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/SourceDestConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/SourceDestConfig.java
@@ -131,7 +131,7 @@ public class SourceDestConfig extends GCPConfig {
       return;
     }
     
-    Storage storage = getStorage();
+    Storage storage = GCPUtils.getStorage(getProject(), getCredentials());
     if (storage == null) {
       return;
     }

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/SourceDestConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/SourceDestConfig.java
@@ -69,6 +69,18 @@ public class SourceDestConfig extends GCPConfig {
   @Description("The GCP customer managed encryption key (CMEK) name used by Cloud Dataproc")
   private String cmekKey;
 
+  public SourceDestConfig(@Nullable String project, @Nullable String serviceAccountType,
+                          @Nullable String serviceFilePath, @Nullable String serviceAccountJson,
+                          @Nullable String destPath, @Nullable String location, @Nullable String cmekKey) {
+    this.serviceAccountType = serviceAccountType;
+    this.serviceAccountJson = serviceAccountJson;
+    this.serviceFilePath = serviceFilePath;
+    this.project = project;
+    this.destPath = destPath;
+    this.location = location;
+    this.cmekKey = cmekKey;
+  }
+
   public SourceDestConfig() {
     overwrite = false;
   }
@@ -158,6 +170,70 @@ public class SourceDestConfig extends GCPConfig {
           , "Modify the CMEK key or bucket location to be the same")
           .withConfigProperty(NAME_CMEK_KEY);
       }
+    }
+  }
+
+  public static SourceDestConfig.Builder builder() {
+    return new SourceDestConfig.Builder();
+  }
+
+  /**
+   * SourceDest configuration builder.
+   */
+  public static class Builder {
+    private String serviceAccountType;
+    private String serviceFilePath;
+    private String serviceAccountJson;
+    private String project;
+    private String destPath;
+    private String cmekKey;
+    private String location;
+
+    public SourceDestConfig.Builder setProject(@Nullable String project) {
+      this.project = project;
+      return this;
+    }
+
+    public SourceDestConfig.Builder setServiceAccountType(@Nullable String serviceAccountType) {
+      this.serviceAccountType = serviceAccountType;
+      return this;
+    }
+
+    public SourceDestConfig.Builder setServiceFilePath(@Nullable String serviceFilePath) {
+      this.serviceFilePath = serviceFilePath;
+      return this;
+    }
+
+    public SourceDestConfig.Builder setServiceAccountJson(@Nullable String serviceAccountJson) {
+      this.serviceAccountJson = serviceAccountJson;
+      return this;
+    }
+
+    public SourceDestConfig.Builder setGcsPath(@Nullable String destPath) {
+      this.destPath = destPath;
+      return this;
+    }
+
+    public SourceDestConfig.Builder setCmekKey(@Nullable String cmekKey) {
+      this.cmekKey = cmekKey;
+      return this;
+    }
+
+    public SourceDestConfig.Builder setLocation(@Nullable String location) {
+      this.location = location;
+      return this;
+    }
+
+    public SourceDestConfig build() {
+      return new SourceDestConfig(
+        project,
+        serviceAccountType,
+        serviceFilePath,
+        serviceAccountJson,
+        destPath,
+        location,
+        cmekKey
+      );
     }
   }
 }

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/SourceDestConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/SourceDestConfig.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.etl.api.FailureCollector;
+import io.cdap.plugin.gcp.common.CmekUtils;
 import io.cdap.plugin.gcp.common.GCPConfig;
 import io.cdap.plugin.gcp.common.GCPUtils;
 import io.cdap.plugin.gcp.gcs.GCSPath;
@@ -122,11 +123,11 @@ public class SourceDestConfig extends GCPConfig {
 
   //This method validated the pattern of CMEK Key resource ID.
   void validateCmekKey(FailureCollector failureCollector) {
-    CryptoKeyName cmekKeyName = parseCmekKey(cmekKey, failureCollector);
+    CryptoKeyName cmekKeyName = CmekUtils.parseCmekKey(cmekKey, failureCollector);
 
     //these fields are needed to check if bucket exists or not and for location validation
     if (cmekKeyName == null || containsMacro(NAME_DEST_PATH) || containsMacro(NAME_LOCATION) ||
-      requiredFieldsContainsMacro()) {
+      projectOrServiceAccountContainsMacro()) {
       return;
     }
     
@@ -134,7 +135,7 @@ public class SourceDestConfig extends GCPConfig {
     if (storage == null) {
       return;
     }
-    validateCmekKeyAndBucketLocation(storage, destPath, cmekKeyName, location, failureCollector);
+    CmekUtils.validateCmekKeyAndBucketLocation(storage, destPath, cmekKeyName, location, failureCollector);
   }
 
   public static SourceDestConfig.Builder builder() {

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/SourceDestConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/SourceDestConfig.java
@@ -123,7 +123,7 @@ public class SourceDestConfig extends GCPConfig {
 
   //This method validated the pattern of CMEK Key resource ID.
   void validateCmekKey(FailureCollector failureCollector) {
-    CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(cmekKey, null, failureCollector);
+    CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(cmekKey, failureCollector);
 
     //these fields are needed to check if bucket exists or not and for location validation
     if (cmekKeyName == null || containsMacro(NAME_DEST_PATH) || containsMacro(NAME_LOCATION) ||

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
@@ -103,6 +103,7 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
     super.prepareRun(context);
     CryptoKeyName cmekKeyName = config.getCmekKey(config.cmekKey, context.getArguments(),
                                                   context.getFailureCollector());
+    context.getFailureCollector().getOrThrowException();
 
     Boolean isServiceAccountFilePath = config.isServiceAccountFilePath();
     if (isServiceAccountFilePath == null) {

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
@@ -101,7 +101,7 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
   @Override
   public void prepareRun(BatchSinkContext context) throws Exception {
     super.prepareRun(context);
-    CryptoKeyName cmekKeyName = config.getCmekKey(config.cmekKey, context.getArguments(),
+    CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(config.cmekKey, context.getArguments(),
                                                   context.getFailureCollector());
     context.getFailureCollector().getOrThrowException();
 
@@ -576,7 +576,7 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
 
     //This method validated the pattern of CMEK Key resource ID.
     void validateCmekKey(FailureCollector failureCollector) {
-      CryptoKeyName cmekKeyName = getCmekKey(cmekKey, null, failureCollector);
+      CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(cmekKey, null, failureCollector);
 
       //these fields are needed to check if bucket exists or not and for location validation
       if (cmekKeyName == null || containsMacro(NAME_PATH) || containsMacro(NAME_LOCATION) ||

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
@@ -334,7 +334,8 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
     @Name(NAME_CMEK_KEY)
     @Macro
     @Nullable
-    @Description("The GCP customer managed encryption key (CMEK) name used by Cloud Dataproc")
+    @Description("The GCP customer managed encryption key (CMEK) name used to encrypt data written to " +
+      "any bucket created by the plugin. If the bucket already exists, this is ignored.")
     private String cmekKey;
 
     @Override
@@ -572,56 +573,20 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
 
     //This method validated the pattern of CMEK Key resource ID.
     void validateCmekKey(FailureCollector failureCollector) {
-      CryptoKeyName cmekKeyName = null;
-      try {
-        cmekKeyName = CryptoKeyName.parse(cmekKey);
-      } catch (ValidationException e) {
-        failureCollector.addFailure(e.getMessage(), null)
-          .withConfigProperty(NAME_CMEK_KEY).withStacktrace(e.getStackTrace());
+      CryptoKeyName cmekKeyName = parseCmekKey(cmekKey, failureCollector);
+
+      //these fields are needed to check if bucket exists or not and for location validation
+      if (cmekKeyName == null || containsMacro(NAME_PATH) || containsMacro(NAME_LOCATION) ||
+        containsMacro(NAME_SERVICE_ACCOUNT_TYPE) || containsMacro(NAME_SERVICE_ACCOUNT_JSON) ||
+        containsMacro(NAME_SERVICE_ACCOUNT_FILE_PATH)) {
         return;
       }
 
-      //these fields are needed to check if bucket exists or not and for location validation
-      if (containsMacro(NAME_PATH) || containsMacro(NAME_LOCATION) || containsMacro(NAME_SERVICE_ACCOUNT_TYPE)
-        || containsMacro(NAME_SERVICE_ACCOUNT_JSON) || containsMacro(NAME_SERVICE_ACCOUNT_FILE_PATH)) {
+      Storage storage = getStorage();
+      if (storage == null) {
         return;
       }
-      Boolean isServiceAccountFilePath = isServiceAccountFilePath();
-      Credentials credentials = null;
-      try {
-        credentials = getServiceAccount() == null ?
-          null : GCPUtils.loadServiceAccountCredentials(getServiceAccount(), isServiceAccountFilePath);
-      } catch (Exception e) {
-        /*Ignoring the exception because we don't want to highlight cmek key if an exception occurs while
-        loading credentials*/
-        return;
-      }
-      Storage storage = GCPUtils.getStorage(getProject(), credentials);
-      Bucket bucket = null;
-      try {
-        bucket = storage.get(getBucket());
-      } catch (StorageException e) {
-        /* Ignoring the exception because we don't want the validation to fail if there is an exception getting
-          the bucket information either because the service account used during validation can be different than
-          the service account that will be used at runtime (the dataproc service account)
-          (assuming the user has auto-detect for the service account) */
-        return;
-      }
-      if (bucket == null) {
-        String cmekKeyLocation = cmekKeyName.getLocation();
-        if ((Strings.isNullOrEmpty(location) && !"US".equalsIgnoreCase(cmekKeyLocation))
-          || (!Strings.isNullOrEmpty(location) && !cmekKeyLocation.equalsIgnoreCase(location))) {
-          String bucketLocation = location;
-          if (Strings.isNullOrEmpty(bucketLocation)) {
-            bucketLocation = "US";
-          }
-          failureCollector.addFailure(String.format("CMEK key '%s' is in location '%s' while the GCS bucket will " +
-                                                      "be created in location '%s'.", cmekKey,
-                                                    cmekKeyLocation, bucketLocation)
-            , "Modify the CMEK key or bucket location to be the same")
-            .withConfigProperty(NAME_CMEK_KEY);
-        }
-      }
+      validateCmekKeyAndBucketLocation(storage, path, cmekKeyName, location, failureCollector);
     }
 
     public static Builder builder() {

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
@@ -101,8 +101,7 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
   @Override
   public void prepareRun(BatchSinkContext context) throws Exception {
     super.prepareRun(context);
-    CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(config.cmekKey, context.getArguments(),
-                                                  context.getFailureCollector());
+    CryptoKeyName cmekKeyName = config.getCmekKey(context.getArguments(), context.getFailureCollector());
     context.getFailureCollector().getOrThrowException();
 
     Boolean isServiceAccountFilePath = config.isServiceAccountFilePath();
@@ -576,7 +575,7 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
 
     //This method validated the pattern of CMEK Key resource ID.
     void validateCmekKey(FailureCollector failureCollector) {
-      CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(cmekKey, null, failureCollector);
+      CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(cmekKey, failureCollector);
 
       //these fields are needed to check if bucket exists or not and for location validation
       if (cmekKeyName == null || containsMacro(NAME_PATH) || containsMacro(NAME_LOCATION) ||

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
@@ -124,8 +124,7 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
           + "Ensure you entered the correct bucket path and have permissions for it.", e);
     }
     if (bucket == null) {
-      GCPUtils.createBucket(storage, config.getBucket(), config.getLocation(),
-                            cmekKeyName == null ? null : cmekKeyName.toString());
+      GCPUtils.createBucket(storage, config.getBucket(), config.getLocation(), cmekKeyName);
     }
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
@@ -582,7 +582,7 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
         return;
       }
 
-      Storage storage = GCPUtils.getStorage(getProject(), getCredentials());
+      Storage storage = GCPUtils.getStorage(getProject(), getCredentials(failureCollector));
       if (storage == null) {
         return;
       }

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
@@ -577,8 +577,7 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
 
       //these fields are needed to check if bucket exists or not and for location validation
       if (cmekKeyName == null || containsMacro(NAME_PATH) || containsMacro(NAME_LOCATION) ||
-        containsMacro(NAME_SERVICE_ACCOUNT_TYPE) || containsMacro(NAME_SERVICE_ACCOUNT_JSON) ||
-        containsMacro(NAME_SERVICE_ACCOUNT_FILE_PATH)) {
+        requiredFieldsContainsMacro()) {
         return;
       }
 

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
@@ -580,6 +580,12 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
           .withConfigProperty(NAME_CMEK_KEY).withStacktrace(e.getStackTrace());
         return;
       }
+
+      //these fields are needed to check if bucket exists or not and for location validation
+      if (containsMacro(NAME_PATH) || containsMacro(NAME_LOCATION) || containsMacro(NAME_SERVICE_ACCOUNT_TYPE)
+        || containsMacro(NAME_SERVICE_ACCOUNT_JSON) || containsMacro(NAME_SERVICE_ACCOUNT_FILE_PATH)) {
+        return;
+      }
       Boolean isServiceAccountFilePath = isServiceAccountFilePath();
       Credentials credentials = null;
       try {

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
@@ -41,6 +41,7 @@ import io.cdap.plugin.common.LineageRecorder;
 import io.cdap.plugin.format.FileFormat;
 import io.cdap.plugin.format.plugin.AbstractFileSink;
 import io.cdap.plugin.format.plugin.FileSinkProperties;
+import io.cdap.plugin.gcp.common.CmekUtils;
 import io.cdap.plugin.gcp.common.GCPReferenceSinkConfig;
 import io.cdap.plugin.gcp.common.GCPUtils;
 import io.cdap.plugin.gcp.gcs.GCSPath;
@@ -573,11 +574,11 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
 
     //This method validated the pattern of CMEK Key resource ID.
     void validateCmekKey(FailureCollector failureCollector) {
-      CryptoKeyName cmekKeyName = parseCmekKey(cmekKey, failureCollector);
+      CryptoKeyName cmekKeyName = CmekUtils.parseCmekKey(cmekKey, failureCollector);
 
       //these fields are needed to check if bucket exists or not and for location validation
       if (cmekKeyName == null || containsMacro(NAME_PATH) || containsMacro(NAME_LOCATION) ||
-        requiredFieldsContainsMacro()) {
+        projectOrServiceAccountContainsMacro()) {
         return;
       }
 
@@ -585,7 +586,7 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
       if (storage == null) {
         return;
       }
-      validateCmekKeyAndBucketLocation(storage, path, cmekKeyName, location, failureCollector);
+      CmekUtils.validateCmekKeyAndBucketLocation(storage, path, cmekKeyName, location, failureCollector);
     }
 
     public static Builder builder() {

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
@@ -582,7 +582,7 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
         return;
       }
 
-      Storage storage = getStorage();
+      Storage storage = GCPUtils.getStorage(getProject(), getCredentials());
       if (storage == null) {
         return;
       }

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSMultiBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSMultiBatchSink.java
@@ -107,6 +107,7 @@ public class GCSMultiBatchSink extends BatchSink<StructuredRecord, NullWritable,
 
     CryptoKeyName cmekKeyName = config.getCmekKey(config.cmekKey, context.getArguments(),
                                                   context.getFailureCollector());
+    context.getFailureCollector().getOrThrowException();
     Boolean isServiceAccountFilePath = config.isServiceAccountFilePath();
     if (isServiceAccountFilePath == null) {
       context.getFailureCollector().addFailure("Service account type is undefined.",

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSMultiBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSMultiBatchSink.java
@@ -106,8 +106,7 @@ public class GCSMultiBatchSink extends BatchSink<StructuredRecord, NullWritable,
     Map<String, String> baseProperties = GCPUtils.getFileSystemProperties(config, config.getPath(), new HashMap<>());
     Map<String, String> argumentCopy = new HashMap<>(context.getArguments().asMap());
 
-    CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(config.cmekKey, context.getArguments(),
-                                                     context.getFailureCollector());
+    CryptoKeyName cmekKeyName = config.getCmekKey(context.getArguments(), context.getFailureCollector());
     context.getFailureCollector().getOrThrowException();
     Boolean isServiceAccountFilePath = config.isServiceAccountFilePath();
     if (isServiceAccountFilePath == null) {

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSMultiBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSMultiBatchSink.java
@@ -39,6 +39,7 @@ import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.cdap.etl.api.validation.ValidatingOutputFormat;
 import io.cdap.plugin.common.batch.sink.SinkOutputFormatProvider;
 import io.cdap.plugin.format.FileFormat;
+import io.cdap.plugin.gcp.common.CmekUtils;
 import io.cdap.plugin.gcp.common.GCPUtils;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
@@ -105,8 +106,8 @@ public class GCSMultiBatchSink extends BatchSink<StructuredRecord, NullWritable,
     Map<String, String> baseProperties = GCPUtils.getFileSystemProperties(config, config.getPath(), new HashMap<>());
     Map<String, String> argumentCopy = new HashMap<>(context.getArguments().asMap());
 
-    CryptoKeyName cmekKeyName = config.getCmekKey(config.cmekKey, context.getArguments(),
-                                                  context.getFailureCollector());
+    CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(config.cmekKey, context.getArguments(),
+                                                     context.getFailureCollector());
     context.getFailureCollector().getOrThrowException();
     Boolean isServiceAccountFilePath = config.isServiceAccountFilePath();
     if (isServiceAccountFilePath == null) {

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSMultiBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSMultiBatchSink.java
@@ -120,8 +120,7 @@ public class GCSMultiBatchSink extends BatchSink<StructuredRecord, NullWritable,
     Storage storage = GCPUtils.getStorage(config.getProject(), credentials);
     try {
       if (storage.get(config.getBucket()) == null) {
-        GCPUtils.createBucket(storage, config.getBucket(), config.getLocation(),
-                              cmekKeyName == null ? null : cmekKeyName.toString());
+        GCPUtils.createBucket(storage, config.getBucket(), config.getLocation(), cmekKeyName);
       }
     } catch (StorageException e) {
       // Add more descriptive error message

--- a/src/test/java/io/cdap/plugin/gcp/gcs/actions/CmekKeyTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/gcs/actions/CmekKeyTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright © 2015-2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.gcp.gcs.actions;
+
+import io.cdap.cdap.etl.api.validation.CauseAttributes;
+import io.cdap.cdap.etl.api.validation.ValidationFailure;
+import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
+import io.cdap.plugin.gcp.common.GCPConfig;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * Cmek Key unit test for GCSBucketCreate.Config and SourceDestConfig.
+ * This test will only be run when below property is provided:
+ * project.id -- the name of the project where staging bucket may be created or new resource needs to be created.
+ * It will default to active google project if you have google cloud client installed.
+ * service.account.file -- the path to the service account key file
+ */
+public class CmekKeyTest {
+  private static String serviceAccountKey;
+  private static String project;
+  private static String serviceAccountFilePath;
+  private static String destPath;
+
+  @BeforeClass
+  public static void setupTestClass() throws Exception {
+    // Certain properties need to be configured otherwise the whole tests will be skipped.
+
+    String messageTemplate = "%s is not configured, please refer to javadoc of this class for details.";
+
+    project = System.getProperty("project.id");
+    if (project == null) {
+      project = System.getProperty("GOOGLE_CLOUD_PROJECT");
+    }
+    if (project == null) {
+      project = System.getProperty("GCLOUD_PROJECT");
+    }
+    Assume.assumeFalse(String.format(messageTemplate, "project id"), project == null);
+    System.setProperty("GCLOUD_PROJECT", project);
+
+    serviceAccountFilePath = System.getProperty("service.account.file");
+    Assume.assumeFalse(String.format(messageTemplate, "service account key file"), serviceAccountFilePath == null);
+
+    destPath = getDestPath(project);
+
+    serviceAccountKey = new String(Files.readAllBytes(Paths.get(new File(serviceAccountFilePath).getAbsolutePath())),
+                                   StandardCharsets.UTF_8);
+
+  }
+
+  //This method creates a unique GCS bucket path.
+  private static String getDestPath(@Nullable String project) {
+    return String.format("gs://%s%s", project, new SimpleDateFormat("-yyyy-MM-dd-HH-mm-ss").format(new Date()));
+  }
+
+  private GCSBucketCreate.Config.Builder getGCSBucketCreateConfigBuilder() {
+    return GCSBucketCreate.Config.builder()
+      .setProject(project)
+      .setGcsPath(destPath);
+  }
+
+  private SourceDestConfig.Builder getSourceDestConfigBuilder() {
+    return SourceDestConfig.builder()
+      .setProject(project)
+      .setGcsPath(destPath);
+  }
+
+  @Test
+  public void testServiceAccountPath() throws Exception {
+    GCSBucketCreate.Config.Builder gcsBucketCreateBuilder = getGCSBucketCreateConfigBuilder()
+      .setServiceAccountType(GCPConfig.SERVICE_ACCOUNT_FILE_PATH)
+      .setServiceFilePath(serviceAccountFilePath);
+    SourceDestConfig.Builder sourceDestConfigBuilder = getSourceDestConfigBuilder()
+      .setServiceAccountType(GCPConfig.SERVICE_ACCOUNT_FILE_PATH)
+      .setServiceFilePath(serviceAccountFilePath);
+
+    testValidCmekKey(gcsBucketCreateBuilder, sourceDestConfigBuilder);
+    testInvalidCmekKeyName(gcsBucketCreateBuilder, sourceDestConfigBuilder);
+    testInvalidCmekKeyLocation(gcsBucketCreateBuilder, sourceDestConfigBuilder);
+  }
+
+  @Test
+  public void testServiceAccountJson() throws Exception {
+    GCSBucketCreate.Config.Builder gcsBucketCreateBuilder = getGCSBucketCreateConfigBuilder()
+      .setServiceAccountType(GCPConfig.SERVICE_ACCOUNT_JSON)
+      .setServiceAccountJson(serviceAccountKey);
+    SourceDestConfig.Builder sourceDestConfigBuilder = getSourceDestConfigBuilder()
+      .setServiceAccountType(GCPConfig.SERVICE_ACCOUNT_JSON)
+      .setServiceAccountJson(serviceAccountKey);
+
+    testValidCmekKey(gcsBucketCreateBuilder, sourceDestConfigBuilder);
+    testInvalidCmekKeyName(gcsBucketCreateBuilder, sourceDestConfigBuilder);
+    testInvalidCmekKeyLocation(gcsBucketCreateBuilder, sourceDestConfigBuilder);
+  }
+
+  private void testValidCmekKey(GCSBucketCreate.Config.Builder gcsBucketCreateBuilder,
+                                SourceDestConfig.Builder sourceDestConfigBuilder) {
+    MockFailureCollector collector = new MockFailureCollector();
+    GCSBucketCreate.Config gcsBucketCreateConfig = gcsBucketCreateBuilder
+      .setCmekKey(String.format("projects/%s/locations/us-east1/keyRings/my_ring/cryptoKeys/test_key", project))
+      .setLocation("us-east1")
+      .build();
+    gcsBucketCreateConfig.validateCmekKey(collector);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+
+    SourceDestConfig sourceDestConfig = sourceDestConfigBuilder
+      .setCmekKey(String.format("projects/%s/locations/us-east1/keyRings/my_ring/cryptoKeys/test_key", project))
+      .setLocation("us-east1")
+      .build();
+    sourceDestConfig.validateCmekKey(collector);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+  private void testInvalidCmekKeyName(GCSBucketCreate.Config.Builder gcsBucketCreateBuilder,
+                                      SourceDestConfig.Builder sourceDestConfigBuilder) {
+    MockFailureCollector collector = new MockFailureCollector();
+    GCSBucketCreate.Config gcsBucketCreateConfig = gcsBucketCreateBuilder
+      .setCmekKey(String.format("projects/%s/locations/us-east1/keyRings", project))
+      .build();
+    gcsBucketCreateConfig.validateCmekKey(collector);
+    ValidationFailure failure = collector.getValidationFailures().get(0);
+    List<ValidationFailure.Cause> causes = failure.getCauses();
+    Assert.assertEquals(2, causes.size());
+    Assert.assertEquals("cmekKey", causes.get(0).getAttribute(CauseAttributes.STAGE_CONFIG));
+
+    SourceDestConfig sourceDestConfig = sourceDestConfigBuilder
+      .setCmekKey(String.format("projects/%s/locations/us-east1/keyRings", project))
+      .setLocation("us-east1")
+      .build();
+    sourceDestConfig.validateCmekKey(collector);
+    failure = collector.getValidationFailures().get(1);
+    causes = failure.getCauses();
+    Assert.assertEquals(2, causes.size());
+    Assert.assertEquals("cmekKey", causes.get(0).getAttribute(CauseAttributes.STAGE_CONFIG));
+  }
+
+  private void testInvalidCmekKeyLocation(GCSBucketCreate.Config.Builder gcsBucketCreateBuilder,
+                                          SourceDestConfig.Builder sourceDestConfigBuilder) {
+    MockFailureCollector collector = new MockFailureCollector();
+    GCSBucketCreate.Config gcsBucketCreateConfig = gcsBucketCreateBuilder
+      .setCmekKey(String.format("projects/%s/locations/us-east1/keyRings/my_ring/cryptoKeys/test_key", project))
+      .setLocation("us")
+      .build();
+    gcsBucketCreateConfig.validateCmekKey(collector);
+    ValidationFailure failure = collector.getValidationFailures().get(0);
+    List<ValidationFailure.Cause> causes = failure.getCauses();
+    Assert.assertEquals(1, causes.size());
+    Assert.assertEquals("cmekKey", causes.get(0).getAttribute(CauseAttributes.STAGE_CONFIG));
+
+    //testing the default location of the bucket ("US") if location config is empty or null
+    gcsBucketCreateConfig = gcsBucketCreateBuilder
+      .setCmekKey(String.format("projects/%s/locations/us-east1/keyRings/my_ring/cryptoKeys/test_key", project))
+      .setLocation("")
+      .build();
+    gcsBucketCreateConfig.validateCmekKey(collector);
+    failure = collector.getValidationFailures().get(1);
+    causes = failure.getCauses();
+    Assert.assertEquals(1, causes.size());
+    Assert.assertEquals("cmekKey", causes.get(0).getAttribute(CauseAttributes.STAGE_CONFIG));
+
+    SourceDestConfig sourceDestConfig = sourceDestConfigBuilder
+      .setCmekKey(String.format("projects/%s/locations/us-east1/keyRings/my_ring/cryptoKeys/test_key", project))
+      .setLocation("us")
+      .build();
+    sourceDestConfig.validateCmekKey(collector);
+    failure = collector.getValidationFailures().get(2);
+    causes = failure.getCauses();
+    Assert.assertEquals(1, causes.size());
+    Assert.assertEquals("cmekKey", causes.get(0).getAttribute(CauseAttributes.STAGE_CONFIG));
+
+    //testing the default location of the bucket ("US") if location config is empty or null
+    sourceDestConfig = sourceDestConfigBuilder
+      .setCmekKey(String.format("projects/%s/locations/us-east1/keyRings/my_ring/cryptoKeys/test_key", project))
+      .setLocation("")
+      .build();
+    sourceDestConfig.validateCmekKey(collector);
+    failure = collector.getValidationFailures().get(3);
+    causes = failure.getCauses();
+    Assert.assertEquals(1, causes.size());
+    Assert.assertEquals("cmekKey", causes.get(0).getAttribute(CauseAttributes.STAGE_CONFIG));
+  }
+}

--- a/src/test/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSinkCmekKeyTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSinkCmekKeyTest.java
@@ -157,8 +157,8 @@ public class GCSBatchSinkCmekKeyTest {
   @Test
   public void testGetCmekKey() throws NoSuchFieldException {
     MockFailureCollector collector = new MockFailureCollector("gcssink");
-    String configKey = "projects/%s/locations/us-east1/keyRings/my_ring/cryptoKeys/test_key";
-    String key = "projects/%s/locations/us/keyRings/my_ring/cryptoKeys/test_key";
+    String configKey = String.format("projects/%s/locations/us-east1/keyRings/my_ring/cryptoKeys/test_key", project);
+    String key = String.format("projects/%s/locations/us/keyRings/my_ring/cryptoKeys/test_key", project);
     GCSBatchSinkConfig config = getBuilder().setCmekKey(configKey).build();
     MockArguments arguments = new MockArguments();
     arguments.set("gcp.cmek.key.name", key);

--- a/src/test/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSinkCmekKeyTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSinkCmekKeyTest.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.etl.api.validation.CauseAttributes;
 import io.cdap.cdap.etl.api.validation.ValidationFailure;
 import io.cdap.cdap.etl.mock.common.MockArguments;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
+import io.cdap.plugin.gcp.common.CmekUtils;
 import io.cdap.plugin.gcp.common.GCPConfig;
 import io.cdap.plugin.gcp.gcs.sink.GCSBatchSink.GCSBatchSinkConfig;
 import org.junit.Assert;
@@ -162,7 +163,7 @@ public class GCSBatchSinkCmekKeyTest {
     GCSBatchSinkConfig config = getBuilder().setCmekKey(configKey).build();
     MockArguments arguments = new MockArguments();
     arguments.set("gcp.cmek.key.name", key);
-    CryptoKeyName keyReturned = config.getCmekKey(configKey, arguments, collector);
+    CryptoKeyName keyReturned = CmekUtils.getCmekKey(configKey, arguments, collector);
     Assert.assertEquals(configKey, keyReturned.toString());
   }
 }

--- a/src/test/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSinkCmekKeyTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSinkCmekKeyTest.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.gcp.gcs.sink;
 
+import com.google.cloud.kms.v1.CryptoKeyName;
 import io.cdap.cdap.api.plugin.PluginProperties;
 import io.cdap.cdap.etl.api.validation.CauseAttributes;
 import io.cdap.cdap.etl.api.validation.ValidationFailure;
@@ -163,6 +164,7 @@ public class GCSBatchSinkCmekKeyTest {
 
   @Test
   public void testGetCmekKey() {
+    MockFailureCollector collector = new MockFailureCollector("gcssink");
     String configKey = "projects/%s/locations/us-east1/keyRings/my_ring/cryptoKeys/test_key";
     String key = "projects/%s/locations/us/keyRings/my_ring/cryptoKeys/test_key";
 
@@ -171,11 +173,11 @@ public class GCSBatchSinkCmekKeyTest {
     PluginProperties properties = builder.add("cmekKey", configKey).build();
     MockArguments arguments = new MockArguments();
     arguments.set("gcp.cmek.key.name", key);
-    PowerMockito.when(config.getCmekKey(arguments)).thenCallRealMethod();
+    PowerMockito.when(config.getCmekKey(configKey, arguments, collector)).thenCallRealMethod();
     PowerMockito.when(config.getProperties()).thenReturn(properties);
 
-    String keyReturned = config.getCmekKey(arguments);
+    CryptoKeyName keyReturned = config.getCmekKey(configKey, arguments, collector);
     Mockito.verify(config).getProperties();
-    Assert.assertEquals(configKey, keyReturned);
+    Assert.assertEquals(configKey, keyReturned.toString());
   }
 }

--- a/src/test/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSinkCmekKeyTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSinkCmekKeyTest.java
@@ -155,7 +155,7 @@ public class GCSBatchSinkCmekKeyTest {
   }
 
   @Test
-  public void testGetCmekKey() throws NoSuchFieldException{
+  public void testGetCmekKey() throws NoSuchFieldException {
     MockFailureCollector collector = new MockFailureCollector("gcssink");
     String configKey = "projects/%s/locations/us-east1/keyRings/my_ring/cryptoKeys/test_key";
     String key = "projects/%s/locations/us/keyRings/my_ring/cryptoKeys/test_key";

--- a/src/test/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSinkCmekKeyTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSinkCmekKeyTest.java
@@ -17,7 +17,6 @@
 package io.cdap.plugin.gcp.gcs.sink;
 
 import com.google.cloud.kms.v1.CryptoKeyName;
-import io.cdap.cdap.api.plugin.PluginProperties;
 import io.cdap.cdap.etl.api.validation.CauseAttributes;
 import io.cdap.cdap.etl.api.validation.ValidationFailure;
 import io.cdap.cdap.etl.mock.common.MockArguments;
@@ -28,11 +27,6 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -49,8 +43,6 @@ import javax.annotation.Nullable;
  * It will default to active google project if you have google cloud client installed.
  * service.account.file -- the path to the service account key file
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(GCSBatchSinkConfig.class)
 public class GCSBatchSinkCmekKeyTest {
   private static String serviceAccountKey;
   private static String project;
@@ -163,21 +155,14 @@ public class GCSBatchSinkCmekKeyTest {
   }
 
   @Test
-  public void testGetCmekKey() {
+  public void testGetCmekKey() throws NoSuchFieldException{
     MockFailureCollector collector = new MockFailureCollector("gcssink");
     String configKey = "projects/%s/locations/us-east1/keyRings/my_ring/cryptoKeys/test_key";
     String key = "projects/%s/locations/us/keyRings/my_ring/cryptoKeys/test_key";
-
-    GCSBatchSinkConfig config = PowerMockito.mock(GCSBatchSinkConfig.class);
-    PluginProperties.Builder builder = PluginProperties.builder();
-    PluginProperties properties = builder.add("cmekKey", configKey).build();
+    GCSBatchSinkConfig config = getBuilder().setCmekKey(configKey).build();
     MockArguments arguments = new MockArguments();
     arguments.set("gcp.cmek.key.name", key);
-    PowerMockito.when(config.getCmekKey(configKey, arguments, collector)).thenCallRealMethod();
-    PowerMockito.when(config.getProperties()).thenReturn(properties);
-
     CryptoKeyName keyReturned = config.getCmekKey(configKey, arguments, collector);
-    Mockito.verify(config).getProperties();
     Assert.assertEquals(configKey, keyReturned.toString());
   }
 }

--- a/widgets/GCSBucketCreate-action.json
+++ b/widgets/GCSBucketCreate-action.json
@@ -91,6 +91,14 @@
           "widget-attributes": {
             "default": "us"
           }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Encryption Key Name",
+          "name": "cmekKey",
+          "widget-attributes": {
+            "placeholder": "projects/<gcp-project-id>/locations/<key-location>/keyRings/<key-ring-name>/cryptoKeys/<key-name>"
+          }
         }
       ]
     }

--- a/widgets/GCSCopy-action.json
+++ b/widgets/GCSCopy-action.json
@@ -107,6 +107,19 @@
           "name": "serviceAccountJSON"
         }
       ]
+    },
+    {
+      "label": "Auto Create",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Location",
+          "name": "location",
+          "widget-attributes": {
+            "default": "us"
+          }
+        }
+      ]
     }
   ],
   "filters": [

--- a/widgets/GCSCopy-action.json
+++ b/widgets/GCSCopy-action.json
@@ -118,6 +118,14 @@
           "widget-attributes": {
             "default": "us"
           }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Encryption Key Name",
+          "name": "cmekKey",
+          "widget-attributes": {
+            "placeholder": "projects/<gcp-project-id>/locations/<key-location>/keyRings/<key-ring-name>/cryptoKeys/<key-name>"
+          }
         }
       ]
     }

--- a/widgets/GCSMove-action.json
+++ b/widgets/GCSMove-action.json
@@ -107,6 +107,19 @@
           "name": "serviceAccountJSON"
         }
       ]
+    },
+    {
+      "label": "Auto Create",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Location",
+          "name": "location",
+          "widget-attributes": {
+            "default": "us"
+          }
+        }
+      ]
     }
   ],
   "filters": [

--- a/widgets/GCSMove-action.json
+++ b/widgets/GCSMove-action.json
@@ -118,6 +118,14 @@
           "widget-attributes": {
             "default": "us"
           }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Encryption Key Name",
+          "name": "cmekKey",
+          "widget-attributes": {
+            "placeholder": "projects/<gcp-project-id>/locations/<key-location>/keyRings/<key-ring-name>/cryptoKeys/<key-name>"
+          }
         }
       ]
     }


### PR DESCRIPTION
[PLUGIN-897](https://cdap.atlassian.net/browse/PLUGIN-897)
CMEK key as a config in GCP action plugins - GCS Bucket Create, GCS Copy, GCS Move 
Validation should fail with a proper message if they are not in the same location

Subtask-
[PLUGIN-898](https://cdap.atlassian.net/browse/PLUGIN-898)
Support for auto-creation of destination buckets in GCSMove and GCSCopy Plugins if they do not exist.