### PR TITLE
[PLUGIN-733] Use cursor pagination for Datastore API

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/datastore/source/DatastoreRecordReader.java
+++ b/src/main/java/io/cdap/plugin/gcp/datastore/source/DatastoreRecordReader.java
@@ -28,6 +28,7 @@ import io.cdap.plugin.gcp.datastore.source.util.DatastoreSourceConstants;
 import io.cdap.plugin.gcp.datastore.util.DatastoreUtil;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.mapreduce.Counter;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
@@ -36,9 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
 
 /**
  * Datastore read reader instantiates a record reader that will read the entities from Datastore,
@@ -48,59 +47,52 @@ public class DatastoreRecordReader extends RecordReader<LongWritable, Entity> {
 
   private static final Logger LOG = LoggerFactory.getLogger(DatastoreRecordReader.class);
 
+  private ByteString cursor = ByteString.EMPTY;
+  private Counter batchSizeCounter;
+  private Datastore datastore;
   private Iterator<EntityResult> results;
   private Entity entity;
   private long index;
   private LongWritable key;
+  private PartitionId.Builder partitionIdBuilder;
+  private Query.Builder queryBuilder;
+  private QueryResultBatch.MoreResultsType lastBatchMoreResultsType;
 
   @Override
   public void initialize(InputSplit inputSplit, TaskAttemptContext taskAttemptContext) throws IOException {
     Configuration config = taskAttemptContext.getConfiguration();
     Query query = ((QueryInputSplit) inputSplit).getQuery();
-    Datastore datastore = DatastoreUtil.getDatastoreV1(
+    LOG.trace("Executing query split: {}", query);
+    batchSizeCounter = taskAttemptContext.getCounter(FileInputFormatCounter.BYTES_READ);
+    datastore = DatastoreUtil.getDatastoreV1(
       config.get(DatastoreSourceConstants.CONFIG_SERVICE_ACCOUNT),
       config.getBoolean(DatastoreSourceConstants.CONFIG_SERVICE_ACCOUNT_IS_FILE, true),
       config.get(DatastoreSourceConstants.CONFIG_PROJECT));
-    LOG.trace("Executing query split: {}", query);
-
-    Query.Builder queryBuilder = query.toBuilder();
-    PartitionId.Builder partitionIdBuilder = PartitionId.newBuilder()
+    partitionIdBuilder = PartitionId.newBuilder()
       .setNamespaceId(config.get(DatastoreSourceConstants.CONFIG_NAMESPACE))
       .setProjectId(config.get(DatastoreSourceConstants.CONFIG_PROJECT));
-    List<EntityResult> entityResultList = new ArrayList<>();
-    QueryResultBatch batch;
-    try {
-      // Datastore API only returns up to 300 items. Need to use cursor pagination if there is more results
-      do {
-        RunQueryRequest request = RunQueryRequest.newBuilder()
-          .setQuery(queryBuilder)
-          // partition id needs to be set in the RunQueryRequest in addition to being passed to QuerySplitter.getSplits.
-          // This is a quirk of the V1 API.
-          .setPartitionId(partitionIdBuilder)
-          .build();
-        batch = datastore.runQuery(request).getBatch();
-        taskAttemptContext.getCounter(FileInputFormatCounter.BYTES_READ).increment(batch.getSerializedSize());
-        entityResultList.addAll(batch.getEntityResultsList());
-        LOG.debug("Batch moreResultsType: {}", batch.getMoreResults());
-        ByteString cursor = batch.getEndCursor();
-        queryBuilder.setStartCursor(cursor);
-      } while (batch.getMoreResults() == QueryResultBatch.MoreResultsType.NOT_FINISHED);
-    } catch (DatastoreException e) {
-      throw new IOException("Failed to run query", e);
-    }
-    results = entityResultList.iterator();
+    queryBuilder = query.toBuilder();
+
+    loadPage();
     index = 0;
   }
 
   @Override
-  public boolean nextKeyValue() {
-    if (!results.hasNext()) {
+  public boolean nextKeyValue() throws IOException {
+    if (!results.hasNext() && lastBatchMoreResultsType != QueryResultBatch.MoreResultsType.NO_MORE_RESULTS) {
+      // Load next page from Datastore if current page is depleted and there are more results
+      loadPage();
+    }
+    if (results.hasNext()) {
+      // Increment to next element within current page
+      entity = results.next().getEntity();
+      key = new LongWritable(index);
+      ++index;
+      return true;
+    } else {
+      // No more elements in current page and no more pages to load from Datastore
       return false;
     }
-    entity = results.next().getEntity();
-    key = new LongWritable(index);
-    ++index;
-    return true;
   }
 
   @Override
@@ -122,4 +114,24 @@ public class DatastoreRecordReader extends RecordReader<LongWritable, Entity> {
   public void close() {
   }
 
+  // Datastore API only returns up to 300 items. Need to use cursor pagination if there is more results
+  private void loadPage() throws IOException {
+    queryBuilder.setStartCursor(cursor);
+    RunQueryRequest request = RunQueryRequest.newBuilder()
+      .setQuery(queryBuilder)
+      // partition id needs to be set in the RunQueryRequest in addition to being passed to QuerySplitter.getSplits.
+      // This is a quirk of the V1 API.
+      .setPartitionId(partitionIdBuilder)
+      .build();
+    try {
+      QueryResultBatch batch = datastore.runQuery(request).getBatch();
+      batchSizeCounter.increment(batch.getSerializedSize());
+      lastBatchMoreResultsType = batch.getMoreResults();
+      LOG.debug("Batch page moreResultsType: {}", lastBatchMoreResultsType);
+      cursor = batch.getEndCursor();
+      results = batch.getEntityResultsList().iterator();
+    } catch (DatastoreException e) {
+      throw new IOException("Failed to run query", e);
+    }
+  }
 }


### PR DESCRIPTION
Use cursor pagination when reading from Datastore API in order to handle when response contains over 300 records

JIRA: https://cdap.atlassian.net/browse/PLUGIN-733