### PR TITLE
CDAP-18501 fix gcs browse

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/gcs/connector/GCSConnector.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/connector/GCSConnector.java
@@ -192,7 +192,10 @@ public class GCSConnector extends AbstractFileConnector<GCPConnectorConfig> {
         break;
       }
 
-      boolean directory = blob.isDirectory();
+      // this call will return false for the prefix blob(which intuitively should be true), this is because there
+      // is no concept for directory on gcs, so if a prefix search is performed, this blob will be considered as a
+      // file with no name and size 0, see https://stackoverflow.com/questions/66161833/ for detailed explanation.
+      boolean directory = blobName.equals(pathBlobName) ? pathBlobName.endsWith("/") : blob.isDirectory();
       BrowseEntity.Builder entity =
         BrowseEntity.builder(new File(blobName).getName(), String.format("%s/%s", blob.getBucket(), blobName),
                              directory ? DIRECTORY_TYPE : FILE_TYPE).canBrowse(directory).canSample(directory);


### PR DESCRIPTION
When a blob is empty, it is represented as a file with empty name and size 0, so when a prefix search is performed on the blob, the gcs client will assume it as a file and isDirectory will return false. So need to handle this case to ensure the folder is not returned as file.