### PR TITLE
[Cherry-Pick][0.18] Fixed issue which causes schema updates to fail when CMEK is used on the table and the input is empty.

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
@@ -284,9 +284,8 @@ public class BigQueryOutputFormat extends ForwardingBigQueryFileOutputFormat<Str
             .execute();
         } else if (allowSchemaRelaxationOnEmptyOutput) {
           // If the table requires a schema update, apply if even when there are no records to write.
-          Table table = new Table();
+          Table table = bigQueryHelper.getTable(tableRef);
           table.setSchema(schema);
-          table.setTableReference(tableRef);
           bigQueryHelper.getRawBigquery().tables()
             .update(tableRef.getProjectId(), tableRef.getDatasetId(), tableRef.getTableId(), table)
             .execute();


### PR DESCRIPTION
Cherry Pick of https://github.com/data-integrations/google-cloud/pull/831 into 0.18