### PR TITLE
[PLUGIN-989] GCS Multi File Sink has Browse connection button when Use Connection is set to No

### DIFF
--- a/widgets/GCSMultiFiles-batchsink.json
+++ b/widgets/GCSMultiFiles-batchsink.json
@@ -346,6 +346,18 @@
       ]
     },
     {
+      "name": "showConnectionId",
+      "condition": {
+        "expression": "useConnection == true"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "connection"
+        }
+      ]
+    },
+    {
       "name": "CustomContentType",
       "condition": {
         "expression": "contentType == 'other'"


### PR DESCRIPTION
[PLUGIN-989](https://cdap.atlassian.net/browse/PLUGIN-989)
After fix:-
![image](https://user-images.githubusercontent.com/88528384/144115693-dea7a92f-3e23-4b75-9c40-43df1a611ffe.png)