### PR TITLE
[PLUGIN-990] Spanner and BQ sources missing Connection information in markdown docs

### DIFF
--- a/docs/BigQueryMultiTable-batchsink.md
+++ b/docs/BigQueryMultiTable-batchsink.md
@@ -22,11 +22,10 @@ Properties
 ----------
 **Reference Name:** Name used to uniquely identify this sink for lineage, annotating metadata, etc.
 
-**Use Connection:** Whether to use a connection, if a connection is used,
-the credentials does not need to be provided.
+**Use Connection** Whether to use a connection. If a connection is used, you do not need to provide the credentials.
 
-**Connection:** Name of the connection to use, should use the macro function ${conn(connection-name)} to provide.
-Project and service account information will be provided by the connection.
+**Connection** Name of the connection to use. Project and service account information will be provided by the connection.
+You also can use the macro function ${conn(connection-name)}.
 
 **Project ID:** Google Cloud Project ID, which uniquely identifies a project.
 It can be found on the Dashboard in the Google Cloud Platform Console. This is the project

--- a/docs/BigQueryTable-batchsink.md
+++ b/docs/BigQueryTable-batchsink.md
@@ -23,11 +23,10 @@ Properties
 ----------
 **Reference Name:** Name used to uniquely identify this sink for lineage, annotating metadata, etc.
 
-**Use Connection:** Whether to use a connection, if a connection is used,
-the credentials does not need to be provided.
+**Use Connection** Whether to use a connection. If a connection is used, you do not need to provide the credentials.
 
-**Connection:** Name of the connection to use, should use the macro function ${conn(connection-name)} to provide.
-Project and service account information will be provided by the connection.
+**Connection** Name of the connection to use. Project and service account information will be provided by the connection.
+You also can use the macro function ${conn(connection-name)}.
 
 **Project ID**: Google Cloud Project ID, which uniquely identifies a project.
 It can be found on the Dashboard in the Google Cloud Platform Console. This is the project

--- a/docs/BigQueryTable-batchsource.md
+++ b/docs/BigQueryTable-batchsource.md
@@ -23,6 +23,11 @@ Properties
 ----------
 **Reference Name:** Name used to uniquely identify this source for lineage, annotating metadata, etc.
 
+**Use Connection** Whether to use a connection. If a connection is used, you do not need to provide the credentials.
+
+**Connection** Name of the connection to use. Project and service account information will be provided by the connection.
+You also can use the macro function ${conn(connection-name)}.
+
 **Project ID**: Google Cloud Project ID, which uniquely identifies a project.
 It can be found on the Dashboard in the Google Cloud Platform Console. This is the project
 that the BigQuery job will run in. `BigQuery Job User` role on this project must be granted to the specified service

--- a/docs/GCS-batchsink.md
+++ b/docs/GCS-batchsink.md
@@ -26,11 +26,10 @@ Properties
 ----------
 **Reference Name:** Name used to uniquely identify this sink for lineage, annotating metadata, etc.
 
-**Use Connection** Whether to use a connection, if a connection is used,
-the credentials does not need to be provided.
+**Use Connection** Whether to use a connection. If a connection is used, you do not need to provide the credentials.
 
-**Connection** Name of the connection to use, should use the macro function ${conn(connection-name)} to provide.
-Project and service account information will be provided by the connection.
+**Connection** Name of the connection to use. Project and service account information will be provided by the connection.
+You also can use the macro function ${conn(connection-name)}.
 
 **Project ID**: Google Cloud Project ID, which uniquely identifies a project.
 It can be found on the Dashboard in the Google Cloud Platform Console.

--- a/docs/GCSFile-batchsource.md
+++ b/docs/GCSFile-batchsource.md
@@ -25,11 +25,10 @@ Properties
 ----------
 **Reference Name:** Name used to uniquely identify this source for lineage, annotating metadata, etc.
 
-**Use Connection** Whether to use a connection, if a connection is used, 
-the credentials does not need to be provided.
+**Use Connection** Whether to use a connection. If a connection is used, you do not need to provide the credentials.
 
-**Connection** Name of the connection to use, should use the macro function ${conn(connection-name)} to provide. 
-Project and service account information will be provided by the connection.
+**Connection** Name of the connection to use. Project and service account information will be provided by the connection.
+You also can use the macro function ${conn(connection-name)}.
 
 **Project ID**: Google Cloud Project ID, which uniquely identifies a project.
 It can be found on the Dashboard in the Google Cloud Platform Console.

--- a/docs/GCSMultiFiles-batchsink.md
+++ b/docs/GCSMultiFiles-batchsink.md
@@ -38,11 +38,10 @@ Properties
 **Reference Name:** This along with the table name will be used to uniquely identify this sink for lineage, 
 annotating metadata, etc.
 
-**Use Connection** Whether to use a connection, if a connection is used,
-the credentials does not need to be provided.
+**Use Connection** Whether to use a connection. If a connection is used, you do not need to provide the credentials.
 
-**Connection** Name of the connection to use, should use the macro function ${conn(connection-name)} to provide.
-Project and service account information will be provided by the connection.
+**Connection** Name of the connection to use. Project and service account information will be provided by the connection.
+You also can use the macro function ${conn(connection-name)}.
 
 **Project ID:** The Google Cloud Project ID, which uniquely identifies a project.
 It can be found on the Dashboard in the Google Cloud Platform Console.

--- a/docs/Spanner-batchsink.md
+++ b/docs/Spanner-batchsink.md
@@ -23,11 +23,10 @@ Properties
 ----------
 **Reference Name:** Name used to uniquely identify this sink for lineage, annotating metadata, etc.
 
-**Use Connection** Whether to use a connection, if a connection is used,
-the credentials does not need to be provided.
+**Use Connection** Whether to use a connection. If a connection is used, you do not need to provide the credentials.
 
-**Connection** Name of the connection to use, should use the macro function ${conn(connection-name)} to provide.
-Project and service account information will be provided by the connection.
+**Connection** Name of the connection to use. Project and service account information will be provided by the connection.
+You also can use the macro function ${conn(connection-name)}.
 
 **Project ID**: Google Cloud Project ID, which uniquely identifies a project.
 It can be found on the Dashboard in the Google Cloud Platform Console.

--- a/docs/Spanner-batchsource.md
+++ b/docs/Spanner-batchsource.md
@@ -23,6 +23,11 @@ Properties
 ----------
 **Reference Name:** Name used to uniquely identify this source for lineage, annotating metadata, etc.
 
+**Use Connection** Whether to use a connection. If a connection is used, you do not need to provide the credentials.
+
+**Connection** Name of the connection to use. Project and service account information will be provided by the connection.
+You also can use the macro function ${conn(connection-name)}.
+
 **Project ID**: Google Cloud Project ID, which uniquely identifies a project.
 It can be found on the Dashboard in the Google Cloud Platform Console.
 


### PR DESCRIPTION
[PLUGIN-990](https://cdap.atlassian.net/browse/PLUGIN-990)

Updated the connection information in markdown docs according to changes suggested by @rrielley76.