### PR TITLE
Change to allow the temporary export table and temporary export dataset to be explicitly set

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>io.cdap.plugin</groupId>
-  <artifactId>ocado-google-cloud</artifactId>
-  <version>0.19.3</version>
+  <artifactId>google-cloud</artifactId>
+  <version>0.20.0-SNAPSHOT</version>
   <name>Google Cloud Plugins</name>
   <packaging>jar</packaging>
   <description>Plugins for Google Big Query</description>
@@ -644,8 +644,7 @@
             <Embed-Directory>lib</Embed-Directory>
             <!--Only @Plugin classes in the export packages will be included as plugin-->
             <_exportcontents>
-              io.cdap.plugin.gcp.bigquery.source.*;
-              <!-- io.cdap.plugin.gcp.*;-->
+              io.cdap.plugin.gcp.*;
               com.google.cloud.hadoop.*;
               org.apache.spark.streaming.pubsub*;
               org.apache.hadoop.hbase.mapreduce.*;

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>io.cdap.plugin</groupId>
-  <artifactId>google-cloud</artifactId>
-  <version>0.20.0-SNAPSHOT</version>
+  <artifactId>ocado-google-cloud</artifactId>
+  <version>0.19.3</version>
   <name>Google Cloud Plugins</name>
   <packaging>jar</packaging>
   <description>Plugins for Google Big Query</description>
@@ -644,7 +644,8 @@
             <Embed-Directory>lib</Embed-Directory>
             <!--Only @Plugin classes in the export packages will be included as plugin-->
             <_exportcontents>
-              io.cdap.plugin.gcp.*;
+              io.cdap.plugin.gcp.bigquery.source.*;
+              <!-- io.cdap.plugin.gcp.*;-->
               com.google.cloud.hadoop.*;
               org.apache.spark.streaming.pubsub*;
               org.apache.hadoop.hbase.mapreduce.*;

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySource.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySource.java
@@ -211,6 +211,14 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
     if (config.getViewMaterializationDataset() != null) {
       configuration.set(BigQueryConstants.CONFIG_VIEW_MATERIALIZATION_DATASET, config.getViewMaterializationDataset());
     }
+
+    if (config.getTemporaryExportTableProject() != null) {
+      configuration.set(BigQueryConstants.CONFIG_TEMPORARY_TABLE_PROJECT_ID, config.getTemporaryExportTableProject());
+    }
+
+    if (config.getTemporaryExportTableDataset() != null) {
+      configuration.set(BigQueryConstants.CONFIG_TEMPORARY_TABLE_DATESET_ID, config.getTemporaryExportTableDataset());
+    }
   }
 
   public Schema getSchema(FailureCollector collector) {

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySourceConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySourceConfig.java
@@ -60,6 +60,9 @@ public final class BigQuerySourceConfig extends PluginConfig {
     ImmutableSet.of(Schema.Type.LONG, Schema.Type.STRING, Schema.Type.DOUBLE, Schema.Type.BOOLEAN, Schema.Type.BYTES,
                     Schema.Type.ARRAY, Schema.Type.RECORD);
 
+  public static final String NAME_TEMPORARY_EXPORT_TABLE_PROJECT = "temporaryExportTableProject";
+  public static final String NAME_TEMPORARY_EXPORT_TABLE_DATASET = "temporaryExportTableDataset";
+
   public static final String NAME_DATASET = "dataset";
   public static final String NAME_TABLE = "table";
   public static final String NAME_BUCKET = "bucket";
@@ -71,6 +74,22 @@ public final class BigQuerySourceConfig extends PluginConfig {
   public static final String NAME_VIEW_MATERIALIZATION_PROJECT = "viewMaterializationProject";
   public static final String NAME_VIEW_MATERIALIZATION_DATASET = "viewMaterializationDataset";
   public static final String NAME_CMEK_KEY = "cmekKey";
+
+  @Name(NAME_TEMPORARY_EXPORT_TABLE_PROJECT)
+  @Macro
+  @Nullable
+  @Description("The BigQuery source splits partitions across temporary table, by default this will be in the same "
+      + "project as the dataset."
+      + "This property allows the project in which the temporary tables are created to be explicitly set.")
+  private String temporaryExportTableProject;
+
+  @Name(NAME_TEMPORARY_EXPORT_TABLE_DATASET)
+  @Macro
+  @Nullable
+  @Description("The BigQuery source splits partitions across temporary table, by default the temporary table will be "
+      + "created in the same dataset as the source dataset."
+      + "This property allows the dataset in which the temporary tables are created to be explicitly set.")
+  private String temporaryExportTableDataset;
 
   @Name(Constants.Reference.REFERENCE_NAME)
   @Description("This will be used to uniquely identify this source for lineage, annotating metadata, etc.")
@@ -164,6 +183,22 @@ public final class BigQuerySourceConfig extends PluginConfig {
     "any bucket created by the plugin. If the bucket already exists, this is ignored.")
   protected String cmekKey;
 
+  public String getTemporaryExportTableDataset() {
+    if (temporaryExportTableDataset == null) {
+      return getDataset();
+    }
+
+    return temporaryExportTableDataset;
+  }
+
+
+  public String getTemporaryExportTableProject() {
+    if (temporaryExportTableProject == null) {
+      return getDatasetProject();
+    }
+
+    return temporaryExportTableProject;
+  }
 
   public String getDataset() {
     return dataset;

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/PartitionedBigQueryInputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/PartitionedBigQueryInputFormat.java
@@ -60,6 +60,12 @@ public class PartitionedBigQueryInputFormat extends AbstractBigQueryInputFormat<
   public List<InputSplit> getSplits(JobContext context) throws IOException, InterruptedException {
     processQuery(context);
 
+    context.getConfiguration().set(BigQueryConfiguration.INPUT_PROJECT_ID_KEY,
+        context.getConfiguration().get(BigQueryConstants.CONFIG_TEMPORARY_TABLE_PROJECT_ID));
+
+    context.getConfiguration().set(BigQueryConfiguration.INPUT_DATASET_ID_KEY,
+        context.getConfiguration().get(BigQueryConstants.CONFIG_TEMPORARY_TABLE_DATESET_ID));
+
     return delegateInputFormat.getSplits(context);
   }
 
@@ -112,8 +118,10 @@ public class PartitionedBigQueryInputFormat extends AbstractBigQueryInputFormat<
         .setTableId(tableName);
       String location = bigQueryHelper.getTable(sourceTable).getLocation();
       String temporaryTableName = configuration.get(BigQueryConstants.CONFIG_TEMPORARY_TABLE_NAME);
-      TableReference exportTableReference = createExportTableReference(type, datasetProjectId, datasetId,
-                                                                       temporaryTableName, configuration);
+      String tempTableProjectId = context.getConfiguration().get(BigQueryConstants.CONFIG_TEMPORARY_TABLE_PROJECT_ID);
+      String tempTableDatasetId = context.getConfiguration().get(BigQueryConstants.CONFIG_TEMPORARY_TABLE_DATESET_ID);
+      TableReference exportTableReference = createExportTableReference(type, tempTableProjectId, tempTableDatasetId,
+          temporaryTableName, configuration);
       runQuery(configuration, bigQueryHelper, projectId, exportTableReference, query, location);
       if (type == Type.VIEW || type == Type.MATERIALIZED_VIEW) {
         configuration.set(BigQueryConfiguration.INPUT_PROJECT_ID_KEY,

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
@@ -20,6 +20,8 @@ package io.cdap.plugin.gcp.bigquery.util;
  */
 public interface BigQueryConstants {
 
+  String CONFIG_TEMPORARY_TABLE_PROJECT_ID = "cdap.bq.source.temp.table.project.id";
+  String CONFIG_TEMPORARY_TABLE_DATESET_ID = "cdap.bq.source.temp.table.dataset.id";
   String CONFIG_ALLOW_SCHEMA_RELAXATION = "cdap.bq.sink.allow.schema.relaxation";
   String CONFIG_ALLOW_SCHEMA_RELAXATION_ON_EMPTY_OUTPUT = "cdap.bq.sink.allow.schema.relaxationoemptyoutput";
   String CONFIG_DESTINATION_TABLE_EXISTS = "cdap.bq.sink.destination.table.exists";

--- a/widgets/BigQueryTable-batchsource.json
+++ b/widgets/BigQueryTable-batchsource.json
@@ -166,6 +166,22 @@
           "widget-attributes": {
             "placeholder": "projects/<gcp-project-id>/locations/<key-location>/keyRings/<key-ring-name>/cryptoKeys/<key-name>"
           }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Temporary Export Table Project",
+          "name": "temporaryExportTableProject",
+          "widget-attributes": {
+            "placeholder": "The project to use to create temporary export tables, defaults to source dataset project id"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Temporary Export Table Dataset",
+          "name": "temporaryExportTableDataset",
+          "widget-attributes": {
+            "placeholder": "The dataset to use to create temporary export tables, defaults to source dataset"
+          }
         }
       ]
     },


### PR DESCRIPTION
Change to allow the temporary export table and temporary export dataset to be explicitly set in the config of the BigQuerySource source plugin.  Currently the plugin requires write permissions on the source dataset, it does this as it creates a temporary table as part of the export process.  This change allows the dataset and table in which to store the temporary data to be explicitly specified, thus no longer requiring write permission on the source dataset.