### PR TITLE
BigQueryBaseConfig refactor

### DIFF
--- a/docs/BigQueryExecute-action.md
+++ b/docs/BigQueryExecute-action.md
@@ -49,7 +49,8 @@ cache that will be flushed whenever tables in the query are modified.
 **Job Location**: Location of the job. It must match the location of the dataset specified in the query.
 
 **Encryption Key Name**: Used to encrypt data written to any dataset or table created by the plugin.
-If the dataset or table already exists, this is ignored.
+If the dataset or table already exists, this is ignored. More information can be found at 
+https://cloud.google.com/data-fusion/docs/how-to/customer-managed-encryption-keys"
 
 **Row As Arguments**: Row as arguments. For example, if the query is 'select min(id) as min_id, max(id) as max_id from my_dataset.my_table',
 an arguments for 'min_id' and 'max_id' will be set based on the query results. Plugins further down the pipeline can then

--- a/docs/BigQueryMultiTable-batchsink.md
+++ b/docs/BigQueryMultiTable-batchsink.md
@@ -55,7 +55,8 @@ Should only be used with the Insert operation.
 if the dataset or temporary bucket already exist.
 
 **Encryption Key Name**: Used to encrypt data written to any bucket, dataset, or table created by the plugin.
-If the bucket, dataset, or table already exists, this is ignored.
+If the bucket, dataset, or table already exists, this is ignored. More information can be found at 
+https://cloud.google.com/data-fusion/docs/how-to/customer-managed-encryption-keys"
 
 **Split Field:** The name of the field that will be used to determine which table to write to. If unspecified, it
 defaults to `tablename`. This field is used when Allow Flexible Schemas in Output configuration is enabled.

--- a/docs/BigQueryPushdownEngine-sqlengine.md
+++ b/docs/BigQueryPushdownEngine-sqlengine.md
@@ -49,7 +49,8 @@ bucket will be created and then deleted after the run finishes.
 if the dataset or temporary bucket already exist.
 
 **Encryption Key Name**: Used to encrypt data written to any bucket, dataset, or table created by the plugin.
-If the bucket, dataset, or table already exists, this is ignored.
+If the bucket, dataset, or table already exists, this is ignored. More information can be found at 
+https://cloud.google.com/data-fusion/docs/how-to/customer-managed-encryption-keys"
 
 **Retain BigQuery tables after completion**: By Default, the temporary BigQuery tables used to execute operations
 will be deleted after execution is completed. Use this setting to override the default behavior and retain tables.

--- a/docs/BigQueryTable-batchsink.md
+++ b/docs/BigQueryTable-batchsink.md
@@ -77,7 +77,8 @@ the update operation will be performed only in the partitions meeting the criter
 if the dataset or temporary bucket already exist.
 
 **Encryption Key Name**: Used to encrypt data written to any bucket, dataset, or table created by the plugin.
-If the bucket, dataset, or table already exists, this is ignored.
+If the bucket, dataset, or table already exists, this is ignored. More information can be found at 
+https://cloud.google.com/data-fusion/docs/how-to/customer-managed-encryption-keys"
 
 **Create Partitioned Table  [DEPRECATED]**: Whether to create the BigQuery table with time partitioning. This value
 is ignored if the table already exists.

--- a/docs/BigQueryTable-batchsource.md
+++ b/docs/BigQueryTable-batchsource.md
@@ -71,7 +71,8 @@ Temporary data will be deleted after it has been read. If it is not provided, a 
 created and then deleted after the run finishes.
 
 **Encryption Key Name**: Used to encrypt data written to any bucket created by the plugin.
-If the bucket already exists, this is ignored.
+If the bucket already exists, this is ignored. More information can be found at 
+https://cloud.google.com/data-fusion/docs/how-to/customer-managed-encryption-keys"
 
 **Service Account**  - service account key used for authorization
 

--- a/docs/GCS-batchsink.md
+++ b/docs/GCS-batchsink.md
@@ -53,7 +53,8 @@ The delimiter will be ignored if the format is anything other than 'delimited'.
 **Location:** The location where the gcs bucket will get created. This value is ignored if the bucket already exists.
 
 **Encryption Key Name:** Used to encrypt data written to any bucket created by the plugin.
-If the bucket already exists, this is ignored.
+If the bucket already exists, this is ignored. More information can be found at 
+https://cloud.google.com/data-fusion/docs/how-to/customer-managed-encryption-keys"
 
 **Content Type:** The Content Type entity is used to indicate the media type of the resource.
 Defaults to 'application/octet-stream'. The following table shows valid content types for each format.

--- a/docs/GCSBucketCreate-action.md
+++ b/docs/GCSBucketCreate-action.md
@@ -37,7 +37,8 @@ It can be found on the Dashboard in the Google Cloud Platform Console.
 **Location:** The location where the gcs buckets will get created. This value is ignored if the bucket already exists.
 
 **Encryption Key Name:** Used to encrypt data written to any bucket created by the plugin.
-If the bucket already exists, this is ignored.
+If the bucket already exists, this is ignored. More information can be found at 
+https://cloud.google.com/data-fusion/docs/how-to/customer-managed-encryption-keys"
 
 **Service Account**  - service account key used for authorization
 

--- a/docs/GCSCopy-action.md
+++ b/docs/GCSCopy-action.md
@@ -47,7 +47,8 @@ When running on other clusters, the file must be present on every node in the cl
 This value is ignored if the bucket already exists.
 
 **Encryption Key Name:** Used to encrypt data written to any bucket created by the plugin.
-If the bucket already exists, this is ignored.
+If the bucket already exists, this is ignored. More information can be found at 
+https://cloud.google.com/data-fusion/docs/how-to/customer-managed-encryption-keys"
 
 Example
 -------

--- a/docs/GCSDoneFileMarker-postaction.md
+++ b/docs/GCSDoneFileMarker-postaction.md
@@ -50,7 +50,8 @@ When running on other clusters, the file must be present on every node in the cl
 This value is ignored if the bucket already exists.
 
 **Encryption Key Name**: Used to encrypt data written to any bucket created by the plugin.
-If the bucket already exists, this is ignored.
+If the bucket already exists, this is ignored. More information can be found at 
+https://cloud.google.com/data-fusion/docs/how-to/customer-managed-encryption-keys"
 
 Example
 -------

--- a/docs/GCSMove-action.md
+++ b/docs/GCSMove-action.md
@@ -48,7 +48,8 @@ When running on other clusters, the file must be present on every node in the cl
 This value is ignored if the bucket already exists.
 
 **Encryption Key Name:** Used to encrypt data written to any bucket created by the plugin.
-If the bucket already exists, this is ignored.
+If the bucket already exists, this is ignored. More information can be found at 
+https://cloud.google.com/data-fusion/docs/how-to/customer-managed-encryption-keys"
 
 Example
 -------

--- a/docs/GCSMultiFiles-batchsink.md
+++ b/docs/GCSMultiFiles-batchsink.md
@@ -63,7 +63,8 @@ The delimiter will be ignored if the format is anything other than 'delimited'.
 **Location:** The location where the gcs buckets will get created. This value is ignored if the bucket already exists.
 
 **Encryption Key Name:** Used to encrypt data written to any bucket created by the plugin.
-If the bucket already exists, this is ignored.
+If the bucket already exists, this is ignored. More information can be found at 
+https://cloud.google.com/data-fusion/docs/how-to/customer-managed-encryption-keys"
 
 **Service Account**  - service account key used for authorization
 

--- a/docs/GooglePublisher-batchsink.md
+++ b/docs/GooglePublisher-batchsink.md
@@ -32,7 +32,8 @@ It can be found on the Dashboard in the Google Cloud Platform Console.
 parquet, and text. Default is text.
 
 **Encryption Key Name**: Used to encrypt data written to any topic created by the plugin.
-If the topic already exists, this is ignored.
+If the topic already exists, this is ignored. More information can be found at 
+https://cloud.google.com/data-fusion/docs/how-to/customer-managed-encryption-keys"
 
 **Service Account**  - service account key used for authorization
 * **File Path**: Path on the local file system of the service account key used for

--- a/docs/Spanner-batchsink.md
+++ b/docs/Spanner-batchsink.md
@@ -46,7 +46,8 @@ If the table does not exist, it will get created.
 The key can be a composite key of multiple fields in the schema. This is not required if the table already exists.
 
 **Encryption Key Name**: Used to encrypt data written to any database created by the plugin.
-If the database already exists, this is ignored.
+If the database already exists, this is ignored. More information can be found at 
+https://cloud.google.com/data-fusion/docs/how-to/customer-managed-encryption-keys"
 
 **Service Account**  - service account key used for authorization
 * **File Path**: Path on the local file system of the service account key used for

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/common/BigQueryBaseConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/common/BigQueryBaseConfig.java
@@ -17,7 +17,7 @@
 package io.cdap.plugin.gcp.bigquery.common;
 
 import com.google.auth.Credentials;
-import com.google.cloud.ServiceOptions;
+import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.DatasetId;
@@ -30,113 +30,200 @@ import com.google.common.base.Strings;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.plugin.PluginConfig;
 import io.cdap.cdap.etl.api.FailureCollector;
+import io.cdap.plugin.common.ConfigUtil;
+import io.cdap.plugin.gcp.bigquery.connector.BigQueryConnectorConfig;
 import io.cdap.plugin.gcp.common.CmekUtils;
-import io.cdap.plugin.gcp.common.GCPConfig;
 import io.cdap.plugin.gcp.common.GCPUtils;
 import io.cdap.plugin.gcp.gcs.GCSPath;
 
+import java.io.IOException;
 import javax.annotation.Nullable;
+
 
 /**
  * Common configuration class for BigQuery sources, sinks and engines.
  */
-public class BigQueryBaseConfig extends GCPConfig {
-  private static final String SCHEME = "gs://";
+public class BigQueryBaseConfig extends PluginConfig {
+    private static final String SCHEME = "gs://";
 
-  public static final String DATASET_PROJECT_ID = "datasetProject";
-  public static final String NAME_DATASET = "dataset";
-  public static final String NAME_BUCKET = "bucket";
+    public static final String NAME_DATASET = "dataset";
+    public static final String NAME_BUCKET = "bucket";
+    public static final String NAME_CMEK_KEY = "cmekKey";
 
-  @Name(DATASET_PROJECT_ID)
-  @Macro
-  @Nullable
-  @Description("The project in which the dataset is located/should be created."
-    + " Defaults to the project specified in the Project Id property.")
-  private String datasetProject;
+    @Name(NAME_DATASET)
+    @Macro
+    @Description("The dataset to write to. A dataset is contained within a specific project. "
+            + "Datasets are top-level containers that are used to organize and control access to tables and views.")
+    public String dataset;
 
-  @Name(NAME_DATASET)
-  @Macro
-  @Description("The dataset to write to. A dataset is contained within a specific project. "
-    + "Datasets are top-level containers that are used to organize and control access to tables and views.")
-  protected String dataset;
+    @Name(NAME_BUCKET)
+    @Macro
+    @Nullable
+    @Description("The Google Cloud Storage bucket to store temporary data in. "
+            + "Cloud Storage data will be deleted after it is loaded into BigQuery. "
+            + "If it is not provided, a unique bucket will be automatically created and then deleted after the run " +
+            "finishes. The service account must have permission to create buckets in the configured project.")
+    public String bucket;
 
-  @Name(NAME_BUCKET)
-  @Macro
-  @Nullable
-  @Description("The Google Cloud Storage bucket to store temporary data in. "
-    + "Cloud Storage data will be deleted after it is loaded into BigQuery. "
-    + "If it is not provided, a unique bucket will be automatically created and then deleted after the run finishes. "
-    + "The service account must have permission to create buckets in the configured project.")
-  protected String bucket;
+    @Name(NAME_CMEK_KEY)
+    @Macro
+    @Nullable
+    @Description("The GCP customer managed encryption key (CMEK) name used to encrypt data written to " +
+            "any bucket, dataset or table created by the plugin. If the bucket, dataset or table already exists, " +
+            "this is ignored. More information can be found at " +
+            "https://cloud.google.com/data-fusion/docs/how-to/customer-managed-encryption-keys")
+    public String cmekKey;
 
-  @Nullable
-  public String getDatasetProject() {
-    if (GCPConfig.AUTO_DETECT.equalsIgnoreCase(datasetProject)) {
-      return ServiceOptions.getDefaultProjectId();
+    @Name(ConfigUtil.NAME_USE_CONNECTION)
+    @Nullable
+    @Description("Whether to use an existing connection.")
+    public Boolean useConnection;
+
+    @Name(ConfigUtil.NAME_CONNECTION)
+    @Macro
+    @Nullable
+    @Description("The existing connection to use.")
+    public BigQueryConnectorConfig connection;
+
+    public BigQueryBaseConfig(BigQueryConnectorConfig connection, String dataset, String cmekKey,
+                              String bucket) {
+        this.connection = connection;
+        this.dataset = dataset;
+        this.cmekKey = cmekKey;
+        this.bucket = bucket;
     }
-    return Strings.isNullOrEmpty(datasetProject) ? getProject() : datasetProject;
-  }
 
-  public String getDataset() {
-    return dataset;
-  }
+    @Nullable
+    public BigQueryConnectorConfig getConnection() {
+        return connection;
+    }
 
-  @Nullable
-  public String getBucket() {
-    if (bucket != null) {
-      bucket = bucket.trim();
-      if (bucket.isEmpty()) {
-        return null;
-      }
-      // remove the gs:// scheme from the bucket name
-      if (bucket.startsWith(SCHEME)) {
-        bucket = bucket.substring(SCHEME.length());
-      }
+    /**
+     * Return true if the service account is set to auto-detect but it can't be fetched from the environment.
+     * This shouldn't result in a deployment failure, as the credential could be detected at runtime if the pipeline
+     * runs on dataproc. This should primarily be used to check whether certain validation logic should be skipped.
+     *
+     * @return true if the service account is set to auto-detect but it can't be fetched from the environment.
+     */
+    public boolean autoServiceAccountUnavailable() {
+        if (connection == null || connection.getServiceAccountFilePath() == null &&
+                connection.isServiceAccountFilePath()) {
+            try {
+                ServiceAccountCredentials.getApplicationDefault();
+            } catch (IOException e) {
+                return true;
+            }
+        }
+        return false;
     }
-    return bucket;
-  }
 
-  /* returns the bucket if it exists otherwise null.
-   */
-  private Bucket getBucketIfExists(Storage storage, String bucketName) {
-    Bucket bucket = null;
-    try {
-      bucket = storage.get(bucketName);
-    } catch (StorageException e) {
-      // If there is an exception getting bucket information during config validation, it will be ignored because
-      // service account used can be different.
+    @Nullable
+    public String getProject() {
+        if (connection == null) {
+            throw new IllegalArgumentException(
+                    "Could not get project information, connection should not be null!");
+        }
+        return connection.getProject();
     }
-    return bucket;
-  }
 
-  public void validateCmekKeyLocation(@Nullable CryptoKeyName cmekKeyName, @Nullable String tableName,
-                                      @Nullable String location, FailureCollector failureCollector) {
-    if (cmekKeyName == null || containsMacro(NAME_DATASET) || projectOrServiceAccountContainsMacro()
-      || containsMacro(NAME_BUCKET)) {
-      return;
+    @Nullable
+    public String tryGetProject() {
+        return connection == null ? null : connection.tryGetProject();
     }
-    String datasetProjectId = getDatasetProject();
-    String datasetName = getDataset();
-    DatasetId datasetId = DatasetId.of(datasetProjectId, datasetName);
-    TableId tableId = tableName == null ? null : TableId.of(datasetProjectId, datasetName, tableName);
-    Credentials credentials = getCredentials(failureCollector);
-    BigQuery bigQuery = GCPUtils.getBigQuery(getProject(), credentials);
-    Storage storage = GCPUtils.getStorage(getProject(), credentials);
-    if (bigQuery == null || storage == null) {
-      return;
+
+    @Nullable
+    public String getServiceAccount() {
+        return connection == null ? null : connection.getServiceAccount();
     }
-    String bucketName = getBucket();
-    Bucket bucket = bucketName == null ? null : getBucketIfExists(storage, bucketName);
-    // if bucket exists then dataset and table will be created in location of bucket if they do not exist.
-    location = bucket == null ? location : bucket.getLocation();
-    Dataset dataset = CmekUtils.validateCmekKeyAndDatasetOrTableLocation(bigQuery, datasetId, tableId, cmekKeyName,
-                                                                         location, failureCollector);
-    if (bucket == null && dataset != null) {
-      // if dataset exists then bucket will be created in the location of dataset.
-      location = dataset.getLocation();
-      GCSPath gcsPath = Strings.isNullOrEmpty(bucketName) ? null : GCSPath.from(bucketName);
-      CmekUtils.validateCmekKeyAndBucketLocation(storage, gcsPath, cmekKeyName, location, failureCollector);
+
+    @Nullable
+    public String getServiceAccountFilePath() {
+        return connection == null ? null : connection.getServiceAccountFilePath();
     }
-  }
+
+    @Nullable
+    public Boolean isServiceAccountJson() {
+        return connection == null ? null : connection.isServiceAccountJson();
+    }
+
+    @Nullable
+    public String getServiceAccountJson() {
+        return connection == null ? null : connection.getServiceAccountJson();
+    }
+
+    @Nullable
+    public Boolean isServiceAccountFilePath() {
+        return connection == null ? null : connection.isServiceAccountFilePath();
+    }
+
+    @Nullable
+    public String getServiceAccountType() {
+        return connection == null ? null : connection.getServiceAccountType();
+    }
+
+    @Nullable
+    public String getDataset() {
+        return dataset;
+    }
+
+    @Nullable
+    public String getBucket() {
+        if (bucket != null) {
+            bucket = bucket.trim();
+            if (bucket.isEmpty()) {
+                return null;
+            }
+            // remove the gs:// scheme from the bucket name
+            if (bucket.startsWith(SCHEME)) {
+                bucket = bucket.substring(SCHEME.length());
+            }
+        }
+        return bucket;
+    }
+
+    /* returns the bucket if it exists otherwise null.
+     */
+    @Nullable
+    private Bucket getBucketIfExists(Storage storage, String bucketName) {
+        Bucket bucket = null;
+        try {
+            bucket = storage.get(bucketName);
+        } catch (StorageException e) {
+            // If there is an exception getting bucket information during config validation, it will be ignored because
+            // service account used can be different.
+        }
+        return bucket;
+    }
+
+    public void validateCmekKeyLocation(@Nullable CryptoKeyName cmekKeyName, @Nullable String tableName,
+                                        @Nullable String location, FailureCollector failureCollector) {
+        if (cmekKeyName == null || containsMacro(NAME_DATASET) || connection == null || !connection.canConnect()
+                || containsMacro(NAME_BUCKET)) {
+            return;
+        }
+        String datasetProjectId = connection.getDatasetProject();
+        String datasetName = getDataset();
+        DatasetId datasetId = DatasetId.of(datasetProjectId, datasetName);
+        TableId tableId = tableName == null ? null : TableId.of(datasetProjectId, datasetName, tableName);
+        Credentials credentials = connection.getCredentials(failureCollector);
+        BigQuery bigQuery = GCPUtils.getBigQuery(connection.getProject(), credentials);
+        Storage storage = GCPUtils.getStorage(connection.getProject(), credentials);
+        if (bigQuery == null || storage == null) {
+            return;
+        }
+        String bucketName = getBucket();
+        Bucket bucket = bucketName == null ? null : getBucketIfExists(storage, bucketName);
+        // if bucket exists then dataset and table will be created in location of bucket if they do not exist.
+        location = bucket == null ? location : bucket.getLocation();
+        Dataset dataset = CmekUtils.validateCmekKeyAndDatasetOrTableLocation(bigQuery, datasetId, tableId, cmekKeyName,
+                location, failureCollector);
+        if (bucket == null && dataset != null) {
+            // if dataset exists then bucket will be created in the location of dataset.
+            location = dataset.getLocation();
+            GCSPath gcsPath = Strings.isNullOrEmpty(bucketName) ? null : GCSPath.from(bucketName);
+            CmekUtils.validateCmekKeyAndBucketLocation(storage, gcsPath, cmekKeyName, location, failureCollector);
+        }
+    }
 }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
@@ -15,24 +15,13 @@
  */
 package io.cdap.plugin.gcp.bigquery.sink;
 
-import com.google.auth.Credentials;
-import com.google.cloud.ServiceOptions;
-import com.google.cloud.bigquery.BigQuery;
-import com.google.cloud.bigquery.Dataset;
-import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.JobInfo;
-import com.google.cloud.bigquery.TableId;
 import com.google.cloud.kms.v1.CryptoKeyName;
-import com.google.cloud.storage.Bucket;
-import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.data.schema.Schema;
-import io.cdap.cdap.api.plugin.PluginConfig;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.plugin.common.ConfigUtil;
 import io.cdap.plugin.common.Constants;
@@ -41,8 +30,6 @@ import io.cdap.plugin.gcp.bigquery.common.BigQueryBaseConfig;
 import io.cdap.plugin.gcp.bigquery.connector.BigQueryConnectorConfig;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;
 import io.cdap.plugin.gcp.common.CmekUtils;
-import io.cdap.plugin.gcp.common.GCPUtils;
-import io.cdap.plugin.gcp.gcs.GCSPath;
 
 import java.util.Collections;
 import java.util.Map;
@@ -52,7 +39,7 @@ import javax.annotation.Nullable;
 /**
  * Base class for Big Query batch sink configs.
  */
-public abstract class AbstractBigQuerySinkConfig extends PluginConfig {
+public abstract class AbstractBigQuerySinkConfig extends BigQueryBaseConfig {
   public static final Set<Schema.Type> SUPPORTED_TYPES =
     ImmutableSet.of(Schema.Type.INT, Schema.Type.LONG, Schema.Type.STRING, Schema.Type.FLOAT, Schema.Type.DOUBLE,
                     Schema.Type.BOOLEAN, Schema.Type.BYTES, Schema.Type.ARRAY, Schema.Type.RECORD);
@@ -62,28 +49,10 @@ public abstract class AbstractBigQuerySinkConfig extends PluginConfig {
   private static final String NAME_GCS_CHUNK_SIZE = "gcsChunkSize";
   protected static final String NAME_UPDATE_SCHEMA = "allowSchemaRelaxation";
   private static final String SCHEME = "gs://";
-  protected static final String NAME_DATASET = "dataset";
-  private static final String NAME_BUCKET = "bucket";
-  private static final String NAME_CMEK_KEY = "cmekKey";
 
   @Name(Constants.Reference.REFERENCE_NAME)
   @Description(Constants.Reference.REFERENCE_NAME_DESCRIPTION)
   protected String referenceName;
-
-  @Name(NAME_DATASET)
-  @Macro
-  @Description("The dataset to write to. A dataset is contained within a specific project. "
-    + "Datasets are top-level containers that are used to organize and control access to tables and views.")
-  protected String dataset;
-
-  @Name(NAME_BUCKET)
-  @Macro
-  @Nullable
-  @Description("The Google Cloud Storage bucket to store temporary data in. "
-    + "Cloud Storage data will be deleted after it is loaded into BigQuery. "
-    + "If it is not provided, a unique bucket will be automatically created and then deleted after the run finishes. "
-    + "The service account must have permission to create buckets in the configured project.")
-  protected String bucket;
 
   @Name(NAME_GCS_CHUNK_SIZE)
   @Macro
@@ -112,24 +81,9 @@ public abstract class AbstractBigQuerySinkConfig extends PluginConfig {
     "This value is ignored if the dataset or temporary bucket already exist.")
   protected String location;
 
-  @Name(NAME_CMEK_KEY)
-  @Macro
-  @Nullable
-  @Description("The GCP customer managed encryption key (CMEK) name used to encrypt data written to " +
-    "any bucket, dataset, or table created by the plugin. If the bucket, dataset, or table already exists, " +
-    "this is ignored.")
-  protected String cmekKey;
-
-  @Name(ConfigUtil.NAME_USE_CONNECTION)
-  @Nullable
-  @Description("Whether to use an existing connection.")
-  private Boolean useConnection;
-
-  @Name(ConfigUtil.NAME_CONNECTION)
-  @Macro
-  @Nullable
-  @Description("The existing connection to use.")
-  protected BigQueryConnectorConfig connection;
+  public AbstractBigQuerySinkConfig(BigQueryConnectorConfig connection, String dataset, String cmekKey, String bucket) {
+    super(connection, dataset, cmekKey, bucket);
+  }
 
   public String getReferenceName() {
     return referenceName;
@@ -166,7 +120,7 @@ public abstract class AbstractBigQuerySinkConfig extends PluginConfig {
   public void validate(FailureCollector collector) {
     validate(collector, Collections.emptyMap());
   }
-  
+
   public void validate(FailureCollector collector, Map<String, String> arguments) {
     IdUtils.validateReferenceName(referenceName, collector);
     ConfigUtil.validateConnection(this, useConnection, connection, collector);
@@ -194,97 +148,8 @@ public abstract class AbstractBigQuerySinkConfig extends PluginConfig {
     validateCmekKeyLocation(cmekKeyName, null, location, failureCollector);
   }
 
-  public String getDataset() {
-    return dataset;
-  }
-
   public String getDatasetProject() {
     return connection == null ? null : connection.getDatasetProject();
   }
 
-  public String getProject() {
-    if (connection == null) {
-      throw new IllegalArgumentException(
-        "Could not get project information, connection should not be null!");
-    }
-    return connection.getProject();
-  }
-
-  @Nullable
-  public String tryGetProject() {
-    return connection == null ? null : connection.tryGetProject();
-  }
-
-  @Nullable
-  public String getServiceAccount() {
-    return connection == null ? null : connection.getServiceAccount();
-  }
-
-  @Nullable
-  public Boolean isServiceAccountFilePath() {
-    return connection == null ? null : connection.isServiceAccountFilePath();
-  }
-
-  @Nullable
-  public String getServiceAccountType() {
-    return connection == null ? null : connection.getServiceAccountType();
-  }
-
-  @Nullable
-  public String getBucket() {
-    if (bucket != null) {
-      bucket = bucket.trim();
-      if (bucket.isEmpty()) {
-        return null;
-      }
-      // remove the gs:// scheme from the bucket name
-      if (bucket.startsWith(SCHEME)) {
-        bucket = bucket.substring(SCHEME.length());
-      }
-    }
-    return bucket;
-  }
-
-  /* returns the bucket if it exists otherwise null.
-   */
-  private Bucket getBucketIfExists(Storage storage, String bucketName) {
-    Bucket bucket = null;
-    try {
-      bucket = storage.get(bucketName);
-    } catch (StorageException e) {
-      // If there is an exception getting bucket information during config validation, it will be ignored because
-      // service account used can be different.
-    }
-    return bucket;
-  }
-
-  public void validateCmekKeyLocation(@Nullable CryptoKeyName cmekKeyName, @Nullable String tableName,
-                                      @Nullable String location, FailureCollector failureCollector) {
-    if (cmekKeyName == null || containsMacro(NAME_DATASET) || connection == null || !connection.canConnect()
-      || containsMacro(NAME_BUCKET)) {
-      return;
-    }
-    String datasetProjectId = connection.getDatasetProject();
-    String datasetName = getDataset();
-    DatasetId datasetId = DatasetId.of(datasetProjectId, datasetName);
-    TableId tableId = tableName == null ? null : TableId.of(datasetProjectId, datasetName, tableName);
-    Credentials credentials = connection.getCredentials(failureCollector);
-    BigQuery bigQuery = GCPUtils.getBigQuery(connection.getProject(), credentials);
-    Storage storage = GCPUtils.getStorage(connection.getProject(), credentials);
-    if (bigQuery == null || storage == null) {
-      return;
-    }
-    String bucketName = getBucket();
-    Bucket bucket = bucketName == null ? null : getBucketIfExists(storage, bucketName);
-    // if bucket exists then dataset and table will be created in location of bucket if they do not exist.
-    location = bucket == null ? location : bucket.getLocation();
-    Dataset dataset = CmekUtils.validateCmekKeyAndDatasetOrTableLocation(bigQuery, datasetId, tableId, cmekKeyName,
-                                                                         location, failureCollector);
-    if (bucket == null && dataset != null) {
-      // if dataset exists then bucket will be created in the location of dataset.
-      location = dataset.getLocation();
-      GCSPath gcsPath = Strings.isNullOrEmpty(bucketName) ? null : GCSPath.from(bucketName);
-      CmekUtils.validateCmekKeyAndBucketLocation(storage, gcsPath, cmekKeyName, location, failureCollector);
-    }
-  }
 }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSinkConfig.java
@@ -19,6 +19,7 @@ import com.google.common.base.Strings;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
+import io.cdap.plugin.gcp.bigquery.connector.BigQueryConnectorConfig;
 
 import javax.annotation.Nullable;
 
@@ -42,11 +43,53 @@ public class BigQueryMultiSinkConfig extends AbstractBigQuerySinkConfig {
     "arguments will be processed. If enabled, all records will be written as-is.")
   private Boolean allowFlexibleSchema;
 
+  private BigQueryMultiSinkConfig(BigQueryConnectorConfig connection, String dataset, String cmekKey, String bucket) {
+    super(connection, dataset, cmekKey, bucket);
+  }
+
+  public static BigQueryMultiSinkConfig.Builder builder() {
+    return new BigQueryMultiSinkConfig.Builder();
+  }
+
   public String getSplitField() {
     return Strings.isNullOrEmpty(splitField) ? SPLIT_FIELD_DEFAULT : splitField;
   }
 
   public Boolean getAllowFlexibleSchema() {
     return allowFlexibleSchema != null ? allowFlexibleSchema : false;
+  }
+
+  /**
+   * BigQuery MultiSink configuration builder.
+   */
+  public static class Builder {
+    private BigQueryConnectorConfig connection;
+    private String dataset;
+    private String cmekKey;
+    private String bucket;
+
+    public BigQueryMultiSinkConfig.Builder setConnection(@Nullable BigQueryConnectorConfig connection) {
+      this.connection = connection;
+      return this;
+    }
+
+    public BigQueryMultiSinkConfig.Builder setDataset(@Nullable String dataset) {
+      this.dataset = dataset;
+      return this;
+    }
+
+    public BigQueryMultiSinkConfig.Builder setCmekKey(@Nullable String cmekKey) {
+      this.cmekKey = cmekKey;
+      return this;
+    }
+
+    public BigQueryMultiSinkConfig.Builder setBucket(@Nullable String bucket) {
+      this.bucket = bucket;
+      return this;
+    }
+
+    public BigQueryMultiSinkConfig build() {
+      return new BigQueryMultiSinkConfig(connection, dataset, cmekKey, bucket);
+    }
   }
 }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
@@ -40,7 +40,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -176,10 +175,9 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
                             @Nullable String bucket, @Nullable String schema, @Nullable String partitioningType,
                             @Nullable Long rangeStart, @Nullable Long rangeEnd, @Nullable Long rangeInterval,
                             @Nullable String gcsChunkSize) {
+    super(null, dataset, null, bucket);
     this.referenceName = referenceName;
-    this.dataset = dataset;
     this.table = table;
-    this.bucket = bucket;
     this.schema = schema;
     this.partitioningType = partitioningType;
     this.rangeStart = rangeStart;
@@ -192,14 +190,11 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
                             @Nullable String serviceAccountType, @Nullable String serviceFilePath,
                             @Nullable String serviceAccountJson, @Nullable String dataset, @Nullable String table,
                             @Nullable String location, @Nullable String cmekKey, @Nullable String bucket) {
+    super(new BigQueryConnectorConfig(project, project, serviceAccountType,
+            serviceFilePath, serviceAccountJson), dataset, cmekKey, bucket);
     this.referenceName = referenceName;
-    this.connection = new BigQueryConnectorConfig(project, project, serviceAccountType,
-                                                  serviceFilePath, serviceAccountJson);
-    this.dataset = dataset;
     this.table = table;
     this.location = location;
-    this.cmekKey = cmekKey;
-    this.bucket = bucket;
   }
 
   public String getTable() {

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQuerySQLEngineConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQuerySQLEngineConfig.java
@@ -16,29 +16,18 @@
 
 package io.cdap.plugin.gcp.bigquery.sqlengine;
 
-import com.google.auth.Credentials;
-import com.google.cloud.bigquery.BigQuery;
-import com.google.cloud.bigquery.Dataset;
-import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.QueryJobConfiguration;
-import com.google.cloud.bigquery.TableId;
 import com.google.cloud.kms.v1.CryptoKeyName;
-import com.google.cloud.storage.Bucket;
-import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
-import com.google.common.base.Strings;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
-import io.cdap.cdap.api.plugin.PluginConfig;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.engine.sql.SQLEngineException;
 import io.cdap.plugin.common.ConfigUtil;
+import io.cdap.plugin.gcp.bigquery.common.BigQueryBaseConfig;
 import io.cdap.plugin.gcp.bigquery.connector.BigQueryConnectorConfig;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;
 import io.cdap.plugin.gcp.common.CmekUtils;
-import io.cdap.plugin.gcp.common.GCPUtils;
-import io.cdap.plugin.gcp.gcs.GCSPath;
 
 import java.util.Collections;
 import java.util.Map;
@@ -47,350 +36,193 @@ import javax.annotation.Nullable;
 /**
  * Configuration for SQL Engine.
  */
-public class BigQuerySQLEngineConfig extends PluginConfig {
+public class BigQuerySQLEngineConfig extends BigQueryBaseConfig {
 
-  public static final String NAME_LOCATION = "location";
-  public static final String NAME_RETAIN_TABLES = "retainTables";
-  public static final String NAME_TEMP_TABLE_TTL_HOURS = "tempTableTTLHours";
-  public static final String NAME_JOB_PRIORITY = "jobPriority";
-  public static final String NAME_USE_STORAGE_READ_API = "useStorageReadAPI";
-  public static final String NAME_SERVICE_ACCOUNT_FILE_PATH = "serviceFilePath";
-  public static final String NAME_SERVICE_ACCOUNT_JSON = "serviceAccountJSON";
-  public static final String NAME_SERVICE_ACCOUNT_TYPE = "serviceAccountType";
-  public static final String SERVICE_ACCOUNT_JSON = "JSON";
-  public static final String AUTO_DETECT = "auto-detect";
+    public static final String NAME_LOCATION = "location";
+    public static final String NAME_RETAIN_TABLES = "retainTables";
+    public static final String NAME_TEMP_TABLE_TTL_HOURS = "tempTableTTLHours";
+    public static final String NAME_JOB_PRIORITY = "jobPriority";
+    public static final String NAME_USE_STORAGE_READ_API = "useStorageReadAPI";
 
-  // Job priority options
-  public static final String PRIORITY_BATCH = "batch";
-  public static final String PRIORITY_INTERACTIVE = "interactive";
-  private static final String NAME_BUCKET = "bucket";
-  private static final String NAME_CMEK_KEY = "cmekKey";
-  protected static final String NAME_DATASET = "dataset";
-  private static final String SCHEME = "gs://";
+    // Job priority options
+    public static final String PRIORITY_BATCH = "batch";
+    public static final String PRIORITY_INTERACTIVE = "interactive";
+    private static final String SCHEME = "gs://";
 
-  @Name(NAME_DATASET)
-  @Macro
-  @Description("The dataset to write to. A dataset is contained within a specific project. "
-          + "Datasets are top-level containers that are used to organize and control access to tables and views.")
-  protected String dataset;
+    @Name(NAME_LOCATION)
+    @Macro
+    @Nullable
+    @Description("The location where the BigQuery dataset will get created. " +
+            "This value is ignored if the dataset or temporary bucket already exists.")
+    protected String location;
 
-  @Name(NAME_LOCATION)
-  @Macro
-  @Nullable
-  @Description("The location where the BigQuery dataset will get created. " +
-    "This value is ignored if the dataset or temporary bucket already exists.")
-  protected String location;
+    @Name(NAME_RETAIN_TABLES)
+    @Macro
+    @Nullable
+    @Description("Select this option to retain all BigQuery temporary tables created during the pipeline run.")
+    protected Boolean retainTables;
 
-  @Name(NAME_BUCKET)
-  @Macro
-  @Nullable
-  @Description("The Google Cloud Storage bucket to store temporary data in. "
-          + "Cloud Storage data will be deleted after it is loaded into BigQuery. "
-          + "If it is not provided, a unique bucket will be automatically created and then deleted after the run " +
-          "finishes. The service account must have permission to create buckets in the configured project.")
-  protected String bucket;
+    @Name(NAME_TEMP_TABLE_TTL_HOURS)
+    @Macro
+    @Nullable
+    @Description("Set table TTL for temporary BigQuery tables, in number of hours. Tables will be deleted " +
+            "automatically on pipeline completion.")
+    protected Integer tempTableTTLHours;
 
-  @Name(NAME_CMEK_KEY)
-  @Macro
-  @Nullable
-  @Description("The GCP customer managed encryption key (CMEK) name used to encrypt data written to " +
-    "any bucket, dataset, or table created by the plugin. If the bucket, dataset, or table already exists, " +
-    "this is ignored.")
-  protected String cmekKey;
+    @Name(NAME_JOB_PRIORITY)
+    @Macro
+    @Nullable
+    @Description("Priority used to execute BigQuery Jobs. The value must be 'batch' or 'interactive'. " +
+            "An interactive job is executed as soon as possible and counts towards the concurrent rate " +
+            "limit and the daily rate limit. A batch job is queued and started as soon as idle resources " +
+            "are available, usually within a few minutes. If the job hasn't started within 3 hours, " +
+            "its priority is changed to 'interactive'")
+    private String jobPriority;
 
-  @Name(NAME_RETAIN_TABLES)
-  @Macro
-  @Nullable
-  @Description("Select this option to retain all BigQuery temporary tables created during the pipeline run.")
-  protected Boolean retainTables;
-
-  @Name(NAME_TEMP_TABLE_TTL_HOURS)
-  @Macro
-  @Nullable
-  @Description("Set table TTL for temporary BigQuery tables, in number of hours. Tables will be deleted " +
-    "automatically on pipeline completion.")
-  protected Integer tempTableTTLHours;
-
-  @Name(NAME_JOB_PRIORITY)
-  @Macro
-  @Nullable
-  @Description("Priority used to execute BigQuery Jobs. The value must be 'batch' or 'interactive'. " +
-    "An interactive job is executed as soon as possible and counts towards the concurrent rate " +
-    "limit and the daily rate limit. A batch job is queued and started as soon as idle resources " +
-    "are available, usually within a few minutes. If the job hasn't started within 3 hours, " +
-    "its priority is changed to 'interactive'")
-  private String jobPriority;
-  
-  @Name(ConfigUtil.NAME_USE_CONNECTION)
-  @Nullable
-  @Description("Whether to use an existing connection.")
-  private Boolean useConnection;
-
-  @Name(ConfigUtil.NAME_CONNECTION)
-  @Macro
-  @Nullable
-  @Description("The existing connection to use.")
-  protected BigQueryConnectorConfig connection;
-  
-  @Name(NAME_USE_STORAGE_READ_API)
-  @Macro
-  @Nullable
-  @Description("Select this option to use the BigQuery Storage Read API when extracting records from BigQuery " +
-    "during pipeline execution. This option can increase the performance of the BigQuery ELT Transformation " +
-    "Pushdown execution. The usage of this API incurrs in additional costs. This requires Scala version 2.12 to be " +
-    "installed in the execution environment.")
-  private Boolean useStorageReadAPI;
+    @Name(NAME_USE_STORAGE_READ_API)
+    @Macro
+    @Nullable
+    @Description("Select this option to use the BigQuery Storage Read API when extracting records from BigQuery " +
+            "during pipeline execution. This option can increase the performance of the BigQuery ELT Transformation " +
+            "Pushdown execution. The usage of this API incurrs in additional costs. " +
+            "This requires Scala version 2.12 to be installed in the execution environment.")
+    private Boolean useStorageReadAPI;
 
 
-  private BigQuerySQLEngineConfig(@Nullable BigQueryConnectorConfig connection, @Nullable String project,
-                                  @Nullable String dataset, @Nullable String location,
-                                  @Nullable String cmekKey, @Nullable String bucket) {
-    this.dataset = dataset;
-    this.location = location;
-    this.cmekKey = cmekKey;
-    this.bucket = bucket;
-    this.connection = connection;
-  }
-
-  private BigQuerySQLEngineConfig(@Nullable BigQueryConnectorConfig connection, @Nullable String project,
-                                  @Nullable String datasetProject, @Nullable String dataset, @Nullable String location,
-                                  @Nullable String cmekKey, @Nullable String bucket) {
-    this.dataset = dataset;
-    this.location = location;
-    this.cmekKey = cmekKey;
-    this.bucket = bucket;
-    this.connection = connection;
-  }
-
-  public BigQueryConnectorConfig getConnection() {
-    return connection;
-  }
-
-  public Boolean shouldRetainTables() {
-    return retainTables != null ? retainTables : false;
-  }
-
-  public Integer getTempTableTTLHours() {
-    return tempTableTTLHours != null && tempTableTTLHours > 0 ? tempTableTTLHours : 72;
-  }
-
-  public Boolean shouldUseStorageReadAPI() {
-    return useStorageReadAPI != null ? useStorageReadAPI : false;
-  }
-
-  public QueryJobConfiguration.Priority getJobPriority() {
-    String priority = jobPriority != null ? jobPriority : "batch";
-    return QueryJobConfiguration.Priority.valueOf(priority.toUpperCase());
-  }
-
-  /**
-   * Validates configuration properties
-   */
-  public void validate() {
-    // Ensure value for the job priority configuration property is valid
-    if (jobPriority != null && !containsMacro(NAME_JOB_PRIORITY)
-      && !PRIORITY_BATCH.equalsIgnoreCase(jobPriority)
-      && !PRIORITY_INTERACTIVE.equalsIgnoreCase(jobPriority)) {
-      throw new SQLEngineException("Property 'jobPriority' must be 'batch' or 'interactive'");
-    }
-  }
-
-  public void validate(FailureCollector failureCollector) {
-    validate(failureCollector, Collections.emptyMap());
-  }
-
-  public void validate(FailureCollector failureCollector, Map<String, String> arguments) {
-    validate();
-    ConfigUtil.validateConnection(this, useConnection, connection, failureCollector);
-    String bucket = getBucket();
-    if (!containsMacro(NAME_BUCKET)) {
-      BigQueryUtil.validateBucket(bucket, NAME_BUCKET, failureCollector);
-    }
-    if (!containsMacro(NAME_DATASET)) {
-      BigQueryUtil.validateDataset(dataset, NAME_DATASET, failureCollector);
-    }
-    if (!containsMacro(NAME_CMEK_KEY)) {
-      validateCmekKey(failureCollector, arguments);
-    }
-  }
-
-  void validateCmekKey(FailureCollector failureCollector, Map<String, String> arguments) {
-    CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(cmekKey, arguments, failureCollector);
-    if (containsMacro(NAME_LOCATION)) {
-      return;
-    }
-    validateCmekKeyLocation(cmekKeyName, null, location, failureCollector);
-  }
-
-
-  public String getDataset() {
-    return dataset;
-  }
-
-  public String getDatasetProject() {
-    return connection == null ? null : connection.getDatasetProject();
-  }
-
-  public String getProject() {
-    if (connection == null) {
-      throw new IllegalArgumentException(
-              "Could not get project information, connection should not be null!");
-    }
-    return connection.getProject();
-  }
-
-  @Nullable
-  public String tryGetProject() {
-    return connection == null ? null : connection.tryGetProject();
-  }
-
-  @Nullable
-  public String getServiceAccount() {
-    return connection == null ? null : connection.getServiceAccount();
-  }
-
-  @Nullable
-  public Boolean isServiceAccountFilePath() {
-    return connection == null ? null : connection.isServiceAccountFilePath();
-  }
-
-  @Nullable
-  public String getServiceAccountType() {
-    return connection == null ? null : connection.getServiceAccountType();
-  }
-
-  @Nullable
-  public String getServiceAccountFilePath() {
-    return connection == null ? null : connection.getServiceAccountFilePath();
-  }
-
-  @Nullable
-  public Boolean isServiceAccountJson() {
-    return connection == null ? null : connection.isServiceAccountJson();
-  }
-
-  @Nullable
-  public String getServiceAccountJson() {
-    return connection == null ? null : connection.getServiceAccountJson();
-  }
-
-  @Nullable
-  public String getLocation() {
-    return location;
-  }
-
-  @Nullable
-  public String getBucket() {
-    if (bucket != null) {
-      bucket = bucket.trim();
-      if (bucket.isEmpty()) {
-        return null;
-      }
-      // remove the gs:// scheme from the bucket name
-      if (bucket.startsWith(SCHEME)) {
-        bucket = bucket.substring(SCHEME.length());
-      }
-    }
-    return bucket;
-  }
-
-  /* returns the bucket if it exists otherwise null.
-   */
-  private Bucket getBucketIfExists(Storage storage, String bucketName) {
-    Bucket bucket = null;
-    try {
-      bucket = storage.get(bucketName);
-    } catch (StorageException e) {
-      // If there is an exception getting bucket information during config validation, it will be ignored because
-      // service account used can be different.
-    }
-    return bucket;
-  }
-
-  public void validateCmekKeyLocation(@Nullable CryptoKeyName cmekKeyName, @Nullable String tableName,
-                                      @Nullable String location, FailureCollector failureCollector) {
-    if (cmekKeyName == null || containsMacro(NAME_DATASET) || connection == null || !connection.canConnect()
-            || containsMacro(NAME_BUCKET)) {
-      return;
-    }
-    String datasetProjectId = connection.getDatasetProject();
-    String datasetName = getDataset();
-    DatasetId datasetId = DatasetId.of(datasetProjectId, datasetName);
-    TableId tableId = tableName == null ? null : TableId.of(datasetProjectId, datasetName, tableName);
-    Credentials credentials = connection.getCredentials(failureCollector);
-    BigQuery bigQuery = GCPUtils.getBigQuery(connection.getProject(), credentials);
-    Storage storage = GCPUtils.getStorage(connection.getProject(), credentials);
-    if (bigQuery == null || storage == null) {
-      return;
-    }
-    String bucketName = getBucket();
-    Bucket bucket = bucketName == null ? null : getBucketIfExists(storage, bucketName);
-    // if bucket exists then dataset and table will be created in location of bucket if they do not exist.
-    location = bucket == null ? location : bucket.getLocation();
-    Dataset dataset = CmekUtils.validateCmekKeyAndDatasetOrTableLocation(bigQuery, datasetId, tableId, cmekKeyName,
-            location, failureCollector);
-    if (bucket == null && dataset != null) {
-      // if dataset exists then bucket will be created in the location of dataset.
-      location = dataset.getLocation();
-      GCSPath gcsPath = Strings.isNullOrEmpty(bucketName) ? null : GCSPath.from(bucketName);
-      CmekUtils.validateCmekKeyAndBucketLocation(storage, gcsPath, cmekKeyName, location, failureCollector);
-    }
-  }
-
-  public static Builder builder() {
-    return new Builder();
-  }
-
-  /**
-   * BigQuery SQlEngine configuration builder.
-   */
-  public static class Builder {
-    private String project;
-    private String dataset;
-    private String cmekKey;
-    private String location;
-    private String bucket;
-    private BigQueryConnectorConfig connection;
-
-    public Builder setConnection(@Nullable BigQueryConnectorConfig connection) {
-      this.connection = connection;
-      return this;
+    private BigQuerySQLEngineConfig(@Nullable BigQueryConnectorConfig connection,
+                                    @Nullable String dataset, @Nullable String location,
+                                    @Nullable String cmekKey, @Nullable String bucket) {
+        super(connection, dataset, cmekKey, bucket);
+        this.location = location;
     }
 
-    public Builder setProject(@Nullable String project) {
-      this.project = project;
-      return this;
+    private BigQuerySQLEngineConfig(@Nullable BigQueryConnectorConfig connection,
+                                    @Nullable String datasetProject, @Nullable String dataset,
+                                    @Nullable String location, @Nullable String cmekKey, @Nullable String bucket) {
+        super(connection, dataset, cmekKey, bucket);
+        this.location = location;
     }
 
-    public Builder setDataset(@Nullable String dataset) {
-      this.dataset = dataset;
-      return this;
+    public Boolean shouldRetainTables() {
+        return retainTables != null ? retainTables : false;
     }
 
-    public Builder setCmekKey(@Nullable String cmekKey) {
-      this.cmekKey = cmekKey;
-      return this;
+    public Integer getTempTableTTLHours() {
+        return tempTableTTLHours != null && tempTableTTLHours > 0 ? tempTableTTLHours : 72;
     }
 
-    public Builder setLocation(@Nullable String location) {
-      this.location = location;
-      return this;
+    public Boolean shouldUseStorageReadAPI() {
+        return useStorageReadAPI != null ? useStorageReadAPI : false;
     }
 
-    public Builder setBucket(@Nullable String bucket) {
-      this.bucket = bucket;
-      return this;
+    public QueryJobConfiguration.Priority getJobPriority() {
+        String priority = jobPriority != null ? jobPriority : "batch";
+        return QueryJobConfiguration.Priority.valueOf(priority.toUpperCase());
     }
 
-    public BigQuerySQLEngineConfig build() {
-      return new BigQuerySQLEngineConfig(
-        connection,
-        project,
-        dataset,
-        location,
-        cmekKey,
-        bucket
-      );
+    /**
+     * Validates configuration properties
+     */
+    public void validate() {
+        // Ensure value for the job priority configuration property is valid
+        if (jobPriority != null && !containsMacro(NAME_JOB_PRIORITY)
+                && !PRIORITY_BATCH.equalsIgnoreCase(jobPriority)
+                && !PRIORITY_INTERACTIVE.equalsIgnoreCase(jobPriority)) {
+            throw new SQLEngineException("Property 'jobPriority' must be 'batch' or 'interactive'");
+        }
     }
-  }
+
+    public void validate(FailureCollector failureCollector) {
+        validate(failureCollector, Collections.emptyMap());
+    }
+
+    public void validate(FailureCollector failureCollector, Map<String, String> arguments) {
+        validate();
+        ConfigUtil.validateConnection(this, useConnection, connection, failureCollector);
+        String bucket = getBucket();
+        if (!containsMacro(NAME_BUCKET)) {
+            BigQueryUtil.validateBucket(bucket, NAME_BUCKET, failureCollector);
+        }
+        if (!containsMacro(NAME_DATASET)) {
+            BigQueryUtil.validateDataset(dataset, NAME_DATASET, failureCollector);
+        }
+        if (!containsMacro(NAME_CMEK_KEY)) {
+            validateCmekKey(failureCollector, arguments);
+        }
+    }
+
+    void validateCmekKey(FailureCollector failureCollector, Map<String, String> arguments) {
+        CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(cmekKey, arguments, failureCollector);
+        if (containsMacro(NAME_LOCATION)) {
+            return;
+        }
+        validateCmekKeyLocation(cmekKeyName, null, location, failureCollector);
+    }
+
+
+    @Nullable
+    public String getLocation() {
+        return location;
+    }
+
+    public String getDatasetProject() {
+        return connection == null ? null : connection.getDatasetProject();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * BigQuery SQlEngine configuration builder.
+     */
+    public static class Builder {
+        private String project;
+        private String dataset;
+        private String cmekKey;
+        private String location;
+        private String bucket;
+        private BigQueryConnectorConfig connection;
+
+        public Builder setConnection(@Nullable BigQueryConnectorConfig connection) {
+            this.connection = connection;
+            return this;
+        }
+
+        public Builder setProject(@Nullable String project) {
+            this.project = project;
+            return this;
+        }
+
+        public Builder setDataset(@Nullable String dataset) {
+            this.dataset = dataset;
+            return this;
+        }
+
+        public Builder setCmekKey(@Nullable String cmekKey) {
+            this.cmekKey = cmekKey;
+            return this;
+        }
+
+        public Builder setLocation(@Nullable String location) {
+            this.location = location;
+            return this;
+        }
+
+        public Builder setBucket(@Nullable String bucket) {
+            this.bucket = bucket;
+            return this;
+        }
+
+        public BigQuerySQLEngineConfig build() {
+            return new BigQuerySQLEngineConfig(
+                    connection,
+                    project,
+                    dataset,
+                    location,
+                    cmekKey,
+                    bucket
+            );
+        }
+    }
 }


### PR DESCRIPTION
 **Issue** 
https://cdap.atlassian.net/browse/PLUGIN-977

 **Description** 

1. Change BigQueryBaseConfig to not inherit from GCPConfig (but instead PluginConfig). We want decouple GCPConfig, since it has connection properties (dataset, project, serviceAccount etc). 
2. BigQuerySourceConfig, BigQuerySinkConfig, BigQuerySqlEngineConfig must inherit from BigQueryBaseConfig : we need to refactor the common methods in these classes into BigQueryBaseConfig.


 **Testing** 

Tested locally on my sandbox 

