### PR TITLE
Add BigQuery implementations of relational classes for BQ Aggregation pushdown

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/relational/BigQueryRelation.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/relational/BigQueryRelation.java
@@ -1,0 +1,117 @@
+package io.cdap.plugin.gcp.bigquery.relational;
+
+import io.cdap.cdap.etl.api.aggregation.DeduplicateAggregationDefinition;
+import io.cdap.cdap.etl.api.aggregation.GroupByAggregationDefinition;
+import io.cdap.cdap.etl.api.relational.Expression;
+import io.cdap.cdap.etl.api.relational.Relation;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * An implementation of {@link Relation} designed to operate on BigQuery.
+ */
+public class BigQueryRelation implements Relation {
+  private final boolean isValid;
+  private final String validationError;
+
+  private final Map<String, Expression> columns;
+  private final Expression filter;
+  private final Relation baseRelation;
+  private final String datasetName;
+
+  /**
+   * Initializes a new {@link BigQueryRelation} using the set of columns specified.
+   * @param columnSet set of strings indicating column names in the relation.
+   */
+  public BigQueryRelation(String datasetName, Set<String> columnSet) {
+    SQLExpressionFactory factory = new SQLExpressionFactory();
+
+    Map<String, Expression> columns = new HashMap<>();
+    for (String column: columnSet) {
+      columns.put(column, factory.compile(column));
+    }
+    this.datasetName = datasetName;
+    this.columns = columns;
+    this.isValid = true;
+    this.validationError = null;
+    this.filter = null;
+    this.baseRelation = null;
+  }
+
+  private BigQueryRelation(String datasetName,
+                           Map<String, Expression> columns,
+                           Expression filter,
+                           Relation baseRelation) {
+    this(datasetName, columns, filter, baseRelation, true, null);
+  }
+
+  private BigQueryRelation(String datasetName,
+                           Map<String, Expression> columns,
+                           Expression filter,
+                           Relation baseRelation,
+                           boolean isValid,
+                           String validationError) {
+    this.datasetName = datasetName;
+    this.columns = columns;
+    this.filter = filter;
+    this.baseRelation = baseRelation;
+    this.isValid = isValid;
+    this.validationError = validationError;
+  }
+
+  private Relation getInvalidRelation(String validationError) {
+    return new BigQueryRelation(null, null, null, null, false, validationError);
+  }
+
+  @Override
+  public boolean isValid() {
+    return isValid;
+  }
+
+  @Override
+  public String getValidationError() {
+    return isValid() ? null : validationError;
+  }
+
+  public Relation getBaseRelation() {
+    return baseRelation;
+  }
+
+  @Override
+  public Relation setColumn(String column, Expression value) {
+    Map<String, Expression> newColumns = new HashMap<>(columns);
+    newColumns.put(column, value);
+
+    return new BigQueryRelation(datasetName, newColumns, filter, this);
+  }
+
+  @Override
+  public Relation dropColumn(String column) {
+    Map<String, Expression> newColumns = new HashMap<>(columns);
+    newColumns.remove(column);
+
+    return new BigQueryRelation(datasetName, newColumns, filter, this);
+  }
+
+  @Override
+  public Relation select(Map<String, Expression> columns) {
+    return new BigQueryRelation(datasetName, columns, filter, this);
+  }
+
+  @Override
+  public Relation filter(Expression filter) {
+    return new BigQueryRelation(datasetName, columns, filter, this);
+  }
+
+  @Override
+  public Relation groupBy(GroupByAggregationDefinition aggregationDefinition) {
+    return getInvalidRelation("Group by operation not supported currently.");
+  }
+
+  @Override
+  public Relation deduplicate(DeduplicateAggregationDefinition aggregationDefinition) {
+    return getInvalidRelation("Deduplicate operation not supported currently.");
+  }
+}

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/relational/SQLExpression.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/relational/SQLExpression.java
@@ -1,0 +1,73 @@
+package io.cdap.plugin.gcp.bigquery.relational;
+
+import io.cdap.cdap.etl.api.relational.Expression;
+
+import java.util.Objects;
+
+/**
+ * A default implementation of Expression that simply stores the expression as a string.
+ * The string is assumed to be ANSI SQL compliant.
+ * It is the responsibility of the factory creating {@link SQLExpression} objects to enforce correctness of
+ * the expression.
+ */
+public class SQLExpression implements Expression {
+  private final String expression;
+
+  /**
+   * Creates a {@link SQLExpression} from the specified SQL string.
+   * @param expression a String containing the SQL expression.
+   */
+  public SQLExpression(String expression) {
+    this.expression = expression;
+  }
+
+  /**
+   *
+   * @return the SQL string contained in the {@link SQLExpression} object.
+   */
+  public String getExpression() {
+    return expression;
+  }
+
+  /**
+   * A {@link SQLExpression} is always assumed to contain valid SQL. It is the responsibility of the creator of the
+   * object to ensure correctness of the SQL string.
+   * @return This method always returns true.
+   */
+  @Override
+  public boolean isValid() {
+    return true;
+  }
+
+  /**
+   * A {@link SQLExpression} is always assumed to contain valid SQL. It is the responsibility of the creator of the
+   * object to ensure correctness of the SQL string.
+   * @return This method always returns a null string.
+   */
+  @Override
+  public String getValidationError() {
+    return null;
+  }
+
+  /**
+   * Two {@link SQLExpression} objects are considered equal if they contain equal SQL expressions.
+   * @param o other object to be compared for equality.
+   * @return true iff both objects are {@link SQLExpression}s with equal SQL strings.
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SQLExpression that = (SQLExpression) o;
+    return Objects.equals(getExpression(), that.getExpression());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getExpression());
+  }
+}

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/relational/SQLExpressionFactory.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/relational/SQLExpressionFactory.java
@@ -1,0 +1,46 @@
+package io.cdap.plugin.gcp.bigquery.relational;
+
+import io.cdap.cdap.etl.api.relational.Capability;
+import io.cdap.cdap.etl.api.relational.Expression;
+import io.cdap.cdap.etl.api.relational.ExpressionFactory;
+import io.cdap.cdap.etl.api.relational.ExpressionFactoryType;
+import io.cdap.cdap.etl.api.relational.StringExpressionFactoryType;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * An {@link ExpressionFactory} that compiles SQL strings into expressions.
+ * The resultant expressions are of type {@link SQLExpression}.
+ */
+public class SQLExpressionFactory implements ExpressionFactory<String> {
+
+  /**
+   * Gets the expression factory type, which in this case is SQL.
+   * @return {@link StringExpressionFactoryType}.SQL.
+   */
+  @Override
+  public ExpressionFactoryType<String> getType() {
+    return StringExpressionFactoryType.SQL;
+  }
+
+  /**
+   * Saves the SQL expression specified in a {@link SQLExpression} and returns it.
+   * @param expression A valid SQL string with which an Expression can be created.
+   * @return The compiled {@link SQLExpression}.
+   */
+  @Override
+  public Expression compile(String expression) {
+    return new SQLExpression(expression);
+  }
+
+  /**
+   * Get the set of Capabilities supported, which in this case is SQL.
+   * @return A single capability, {@link StringExpressionFactoryType}.SQL.
+   */
+  @Override
+  public Set<Capability> getCapabilities() {
+    return new HashSet<>(Collections.singleton(StringExpressionFactoryType.SQL));
+  }
+}


### PR DESCRIPTION
This PR adds BigQuery-specific implementations of `Relation`, `Expression` and `ExpressionFactory`. The BQ implementation of `Relation` currently does not support the `groupBy()` and `deduplicate()` operations, which will be added in a future PR.