### PR TITLE
CDAP-18806 fix incorrect encoding gcspath

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/gcs/connector/GCSConnector.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/connector/GCSConnector.java
@@ -136,7 +136,8 @@ public class GCSConnector extends AbstractFileConnector<GCPConnectorConfig> {
     if (isRoot(path)) {
       return GCSPath.SCHEME;
     }
-    return GCSPath.from(path).getUri().toString();
+    GCSPath gcsPath = GCSPath.from(path);
+    return GCSPath.SCHEME + gcsPath.getBucket() + gcsPath.getUri().getPath();
   }
 
   @Override


### PR DESCRIPTION
uri.tostring(), will give an encoded path, with space replaced with %20, so gcs connector will throw input path not exist.

Should use the original path to construct the gcs path.