### PR TITLE
Reused code in Dataplex plugin moved to common util classes.

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
@@ -17,17 +17,11 @@ package io.cdap.plugin.gcp.bigquery.sink;
 
 import com.google.auth.Credentials;
 import com.google.cloud.bigquery.BigQuery;
-import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.DatasetId;
-import com.google.cloud.bigquery.Field;
-import com.google.cloud.bigquery.FieldList;
-import com.google.cloud.bigquery.Table;
-import com.google.cloud.bigquery.TableId;
 import com.google.cloud.hadoop.io.bigquery.BigQueryConfiguration;
 import com.google.cloud.hadoop.io.bigquery.output.BigQueryTableFieldSchema;
 import com.google.cloud.kms.v1.CryptoKeyName;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
 import io.cdap.cdap.api.data.batch.Output;
 import io.cdap.cdap.api.data.batch.OutputFormatProvider;
 import io.cdap.cdap.api.data.format.StructuredRecord;
@@ -37,26 +31,22 @@ import io.cdap.cdap.etl.api.Emitter;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
-import io.cdap.cdap.etl.api.engine.sql.SQLEngineOutput;
-import io.cdap.cdap.etl.api.validation.ValidationFailure;
-import io.cdap.plugin.common.LineageRecorder;
-import io.cdap.plugin.gcp.bigquery.sqlengine.BigQuerySQLEngine;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryConstants;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryTypeSize;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;
 import io.cdap.plugin.gcp.common.CmekUtils;
 import io.cdap.plugin.gcp.common.GCPUtils;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
 import javax.annotation.Nullable;
 
 /**
@@ -142,8 +132,9 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, S
                                   FailureCollector collector) throws IOException {
     LOG.debug("Init output for table '{}' with schema: {}", tableName, tableSchema);
 
-    List<BigQueryTableFieldSchema> fields = getBigQueryTableFields(bigQuery, tableName, tableSchema,
-                                                                   getConfig().isAllowSchemaRelaxation(), collector);
+    List<BigQueryTableFieldSchema> fields = BigQuerySinkUtils.getBigQueryTableFields(bigQuery, tableName, tableSchema,
+      getConfig().isAllowSchemaRelaxation(), getConfig().getDatasetProject(),
+      getConfig().getDataset(), getConfig().isTruncateTableSet(), collector);
 
     Configuration configuration = new Configuration(baseConfiguration);
 
@@ -159,7 +150,7 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, S
     List<String> fieldNames = fields.stream()
       .map(BigQueryTableFieldSchema::getName)
       .collect(Collectors.toList());
-    recordLineage(context, outputName, tableSchema, fieldNames);
+    BigQuerySinkUtils.recordLineage(context, outputName, tableSchema, fieldNames);
     context.addOutput(Output.of(outputName, getOutputFormatProvider(configuration, tableName, tableSchema)));
   }
 
@@ -226,51 +217,6 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, S
     return baseConfiguration;
   }
 
-  protected void validateInsertSchema(Table table, @Nullable Schema tableSchema, FailureCollector collector) {
-    com.google.cloud.bigquery.Schema bqSchema = table.getDefinition().getSchema();
-    if (bqSchema == null || bqSchema.getFields().isEmpty()) {
-      // Table is created without schema, so no further validation is required.
-      return;
-    }
-
-    if (getConfig().isTruncateTableSet() || tableSchema == null) {
-      //no validation required for schema if truncate table is set.
-      // BQ will overwrite the schema for normal tables when write disposition is WRITE_TRUNCATE
-      //note - If write to single partition is supported in future, schema validation will be necessary
-      return;
-    }
-    FieldList bqFields = bqSchema.getFields();
-    List<Schema.Field> outputSchemaFields = Objects.requireNonNull(tableSchema.getFields());
-
-    List<String> remainingBQFields = BigQueryUtil.getBqFieldsMinusSchema(bqFields, outputSchemaFields);
-    for (String field : remainingBQFields) {
-      if (bqFields.get(field).getMode() != Field.Mode.NULLABLE) {
-        collector.addFailure(String.format("Required Column '%s' is not present in the schema.", field),
-                             String.format("Add '%s' to the schema.", field));
-      }
-    }
-
-    String tableName = table.getTableId().getTable();
-    List<String> missingBQFields = BigQueryUtil.getSchemaMinusBqFields(outputSchemaFields, bqFields);
-    // Match output schema field type with BigQuery column type
-    for (Schema.Field field : tableSchema.getFields()) {
-      String fieldName = field.getName();
-      // skip checking schema if field is missing in BigQuery
-      if (!missingBQFields.contains(fieldName)) {
-        ValidationFailure failure = BigQueryUtil.validateFieldSchemaMatches(
-          bqFields.get(field.getName()), field, getConfig().getDataset(), tableName,
-          AbstractBigQuerySinkConfig.SUPPORTED_TYPES, collector);
-        if (failure != null) {
-          failure.withInputSchemaField(fieldName).withOutputSchemaField(fieldName);
-        }
-        BigQueryUtil.validateFieldModeMatches(bqFields.get(fieldName), field,
-                                              getConfig().isAllowSchemaRelaxation(),
-                                              collector);
-      }
-    }
-    collector.getOrThrowException();
-  }
-
   /**
    * Check that there are not more than BigQueryTypeSize.Struct.MAX_DEPTH levels in any nested record
    *
@@ -332,131 +278,6 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, S
       }
     }
   }
-
-  /**
-   * Validates output schema against Big Query table schema. It throws {@link IllegalArgumentException}
-   * if the output schema has more fields than Big Query table or output schema field types does not match
-   * Big Query column types unless schema relaxation policy is allowed.
-   *
-   * @param tableName big query table
-   * @param bqSchema BigQuery table schema
-   * @param tableSchema Configured table schema
-   * @param allowSchemaRelaxation allows schema relaxation policy
-   * @param collector failure collector
-   */
-  protected void validateSchema(
-    String tableName,
-    com.google.cloud.bigquery.Schema bqSchema,
-    @Nullable Schema tableSchema,
-    boolean allowSchemaRelaxation,
-    FailureCollector collector) {
-    if (bqSchema == null || bqSchema.getFields().isEmpty() || tableSchema == null) {
-      // Table is created without schema, so no further validation is required.
-      return;
-    }
-
-    FieldList bqFields = bqSchema.getFields();
-    List<Schema.Field> outputSchemaFields = Objects.requireNonNull(tableSchema.getFields());
-
-    List<String> missingBQFields = BigQueryUtil.getSchemaMinusBqFields(outputSchemaFields, bqFields);
-
-    if (allowSchemaRelaxation && !getConfig().isTruncateTableSet()) {
-      // Required fields can be added only if truncate table option is set.
-      List<String> nonNullableFields = missingBQFields.stream()
-        .map(tableSchema::getField)
-        .filter(Objects::nonNull)
-        .filter(field -> !field.getSchema().isNullable())
-        .map(Schema.Field::getName)
-        .collect(Collectors.toList());
-
-      for (String nonNullableField : nonNullableFields) {
-        collector.addFailure(
-          String.format("Required field '%s' does not exist in BigQuery table '%s.%s'.",
-                        nonNullableField, getConfig().getDataset(), tableName),
-          "Change the field to be nullable.")
-          .withInputSchemaField(nonNullableField).withOutputSchemaField(nonNullableField);
-      }
-    }
-
-    if (!allowSchemaRelaxation) {
-      // schema should not have fields that are not present in BigQuery table,
-      for (String missingField : missingBQFields) {
-        collector.addFailure(
-          String.format("Field '%s' does not exist in BigQuery table '%s.%s'.",
-                        missingField, getConfig().getDataset(), tableName),
-          String.format("Remove '%s' from the input, or add a column to the BigQuery table.", missingField))
-          .withInputSchemaField(missingField).withOutputSchemaField(missingField);
-      }
-
-      // validate the missing columns in output schema are nullable fields in BigQuery
-      List<String> remainingBQFields = BigQueryUtil.getBqFieldsMinusSchema(bqFields, outputSchemaFields);
-      for (String field : remainingBQFields) {
-        Field.Mode mode = bqFields.get(field).getMode();
-        // Mode is optional. If the mode is unspecified, the column defaults to NULLABLE.
-        if (mode != null && mode != Field.Mode.NULLABLE) {
-          collector.addFailure(String.format("Required Column '%s' is not present in the schema.", field),
-                               String.format("Add '%s' to the schema.", field));
-        }
-      }
-    }
-
-    // column type changes should be disallowed if either allowSchemaRelaxation or truncate table are not set.
-    if (!allowSchemaRelaxation || !getConfig().isTruncateTableSet()) {
-      // Match output schema field type with BigQuery column type
-      for (Schema.Field field : tableSchema.getFields()) {
-        String fieldName = field.getName();
-        // skip checking schema if field is missing in BigQuery
-        if (!missingBQFields.contains(fieldName)) {
-          ValidationFailure failure = BigQueryUtil.validateFieldSchemaMatches(
-            bqFields.get(field.getName()), field, getConfig().getDataset(), tableName,
-            AbstractBigQuerySinkConfig.SUPPORTED_TYPES, collector);
-          if (failure != null) {
-            failure.withInputSchemaField(fieldName).withOutputSchemaField(fieldName);
-          }
-          BigQueryUtil.validateFieldModeMatches(bqFields.get(fieldName), field,
-                                                allowSchemaRelaxation,
-                                                collector);
-        }
-      }
-    }
-    collector.getOrThrowException();
-  }
-
-  /**
-   * Generates Big Query field instances based on given CDAP table schema after schema validation.
-   *
-   * @param bigQuery big query object
-   * @param tableName table name
-   * @param tableSchema table schema
-   * @param allowSchemaRelaxation if schema relaxation policy is allowed
-   * @param collector failure collector
-   * @return list of Big Query fields
-   */
-  protected List<BigQueryTableFieldSchema> getBigQueryTableFields(BigQuery bigQuery, String tableName,
-                                                                  @Nullable Schema tableSchema,
-                                                                  boolean allowSchemaRelaxation,
-                                                                  FailureCollector collector) {
-    if (tableSchema == null) {
-      return Collections.emptyList();
-    }
-
-    TableId tableId = TableId.of(getConfig().getDatasetProject(), getConfig().getDataset(), tableName);
-    try {
-      Table table = bigQuery.getTable(tableId);
-      // if table is null that mean it does not exist. So there is no need to perform validation
-      if (table != null) {
-        com.google.cloud.bigquery.Schema bqSchema = table.getDefinition().getSchema();
-        validateSchema(tableName, bqSchema, tableSchema, allowSchemaRelaxation, collector);
-      }
-    } catch (BigQueryException e) {
-      collector.addFailure("Unable to get details about the BigQuery table: " + e.getMessage(), null)
-        .withConfigProperty("table");
-      throw collector.getOrThrowException();
-    }
-
-    return BigQuerySinkUtils.getBigQueryTableFieldsFromSchema(tableSchema);
-  }
-
   /**
    * Creates Hadoop configuration instance
    *
@@ -465,17 +286,6 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, S
   protected Configuration getOutputConfiguration() throws IOException {
     Configuration configuration = new Configuration(baseConfiguration);
     return configuration;
-  }
-
-  private void recordLineage(BatchSinkContext context,
-                             String outputName,
-                             Schema tableSchema,
-                             List<String> fieldNames) {
-    LineageRecorder lineageRecorder = new LineageRecorder(context, outputName);
-    lineageRecorder.createExternalDataset(tableSchema);
-    if (!fieldNames.isEmpty()) {
-      lineageRecorder.recordWrite("Write", "Wrote to BigQuery table.", fieldNames);
-    }
   }
 
 }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSink.java
@@ -127,7 +127,8 @@ public class BigQueryMultiSink extends AbstractBigQuerySink {
           // override against configured schema as necessary.
           com.google.cloud.bigquery.Schema bqSchema = table.getDefinition().getSchema();
 
-          validateSchema(tableName, bqSchema, configuredSchema, config.allowSchemaRelaxation, collector);
+          BigQuerySinkUtils.validateSchema(tableName, bqSchema, configuredSchema, config.allowSchemaRelaxation,
+            config.isTruncateTableSet(), config.getDataset(), collector);
 
         }
 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
@@ -38,10 +38,15 @@ import com.google.cloud.storage.StorageException;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.FailureCollector;
+import io.cdap.cdap.etl.api.batch.BatchSinkContext;
+import io.cdap.cdap.etl.api.validation.ValidationFailure;
+import io.cdap.plugin.common.LineageRecorder;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryConstants;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryTypeSize.Numeric;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;
 import io.cdap.plugin.gcp.common.GCPUtils;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
@@ -50,11 +55,15 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+
 import javax.annotation.Nullable;
 
 /**
@@ -553,4 +562,257 @@ public final class BigQuerySinkUtils {
     }
     return String.join(" ", queryWords);
   }
+
+  /**
+   * Generates Big Query field instances based on given CDAP table schema after schema validation.
+   *
+   * @param bigQuery              big query object
+   * @param tableName             table name
+   * @param tableSchema           table schema
+   * @param allowSchemaRelaxation if schema relaxation policy is allowed
+   * @param datasetProject        project name of dataset
+   * @param dataset               dataset name
+   * @param isTruncateTableSet    to truncate the table before writing or not while inserting
+   * @param collector             failure collector
+   * @return list of Big Query fields
+   */
+  public static List<BigQueryTableFieldSchema> getBigQueryTableFields(BigQuery bigQuery, String tableName,
+                                                                      @Nullable Schema tableSchema,
+                                                                      boolean allowSchemaRelaxation,
+                                                                      String datasetProject,
+                                                                      String dataset, boolean isTruncateTableSet,
+                                                                      FailureCollector collector) {
+    if (tableSchema == null) {
+      return Collections.emptyList();
+    }
+
+    TableId tableId = TableId.of(datasetProject, dataset, tableName);
+    try {
+      Table table = bigQuery.getTable(tableId);
+      // if table is null that mean it does not exist. So there is no need to perform validation
+      if (table != null) {
+        com.google.cloud.bigquery.Schema bqSchema = table.getDefinition().getSchema();
+        validateSchema(tableName, bqSchema, tableSchema, allowSchemaRelaxation, isTruncateTableSet, dataset,
+          collector);
+      }
+    } catch (BigQueryException e) {
+      collector.addFailure("Unable to get details about the BigQuery table: " + e.getMessage(), null)
+        .withConfigProperty("table");
+      throw collector.getOrThrowException();
+    }
+
+    return BigQuerySinkUtils.getBigQueryTableFieldsFromSchema(tableSchema);
+  }
+
+  /**
+   * Validates output schema against Big Query table schema. It throws {@link IllegalArgumentException}
+   * if the output schema has more fields than Big Query table or output schema field types does not match
+   * Big Query column types unless schema relaxation policy is allowed.
+   *
+   * @param tableName             big query table
+   * @param bqSchema              BigQuery table schema
+   * @param tableSchema           Configured table schema
+   * @param allowSchemaRelaxation allows schema relaxation policy
+   * @param isTruncateTableSet    to truncate the table before writing or not while inserting
+   * @param dataset               dataset name
+   * @param collector             failure collector
+   */
+  public static void validateSchema(
+    String tableName,
+    com.google.cloud.bigquery.Schema bqSchema,
+    @Nullable Schema tableSchema,
+    boolean allowSchemaRelaxation,
+    boolean isTruncateTableSet,
+    String dataset,
+    FailureCollector collector) {
+    if (bqSchema == null || bqSchema.getFields().isEmpty() || tableSchema == null) {
+      // Table is created without schema, so no further validation is required.
+      return;
+    }
+
+    FieldList bqFields = bqSchema.getFields();
+    List<Schema.Field> outputSchemaFields = Objects.requireNonNull(tableSchema.getFields());
+
+    List<String> missingBQFields = BigQueryUtil.getSchemaMinusBqFields(outputSchemaFields, bqFields);
+
+    if (allowSchemaRelaxation && !isTruncateTableSet) {
+      // Required fields can be added only if truncate table option is set.
+      List<String> nonNullableFields = missingBQFields.stream()
+        .map(tableSchema::getField)
+        .filter(Objects::nonNull)
+        .filter(field -> !field.getSchema().isNullable())
+        .map(Schema.Field::getName)
+        .collect(Collectors.toList());
+
+      for (String nonNullableField : nonNullableFields) {
+        collector.addFailure(
+            String.format("Required field '%s' does not exist in BigQuery table '%s.%s'.",
+              nonNullableField, dataset, tableName),
+            "Change the field to be nullable.")
+          .withInputSchemaField(nonNullableField).withOutputSchemaField(nonNullableField);
+      }
+    }
+
+    if (!allowSchemaRelaxation) {
+      // schema should not have fields that are not present in BigQuery table,
+      for (String missingField : missingBQFields) {
+        collector.addFailure(
+            String.format("Field '%s' does not exist in BigQuery table '%s.%s'.",
+              missingField, dataset, tableName),
+            String.format("Remove '%s' from the input, or add a column to the BigQuery table.", missingField))
+          .withInputSchemaField(missingField).withOutputSchemaField(missingField);
+      }
+
+      // validate the missing columns in output schema are nullable fields in BigQuery
+      List<String> remainingBQFields = BigQueryUtil.getBqFieldsMinusSchema(bqFields, outputSchemaFields);
+      for (String field : remainingBQFields) {
+        Field.Mode mode = bqFields.get(field).getMode();
+        // Mode is optional. If the mode is unspecified, the column defaults to NULLABLE.
+        if (mode != null && mode != Field.Mode.NULLABLE) {
+          collector.addFailure(String.format("Required Column '%s' is not present in the schema.", field),
+            String.format("Add '%s' to the schema.", field));
+        }
+      }
+    }
+
+    // column type changes should be disallowed if either allowSchemaRelaxation or truncate table are not set.
+    if (!allowSchemaRelaxation || !isTruncateTableSet) {
+      // Match output schema field type with BigQuery column type
+      for (Schema.Field field : tableSchema.getFields()) {
+        String fieldName = field.getName();
+        // skip checking schema if field is missing in BigQuery
+        if (!missingBQFields.contains(fieldName)) {
+          ValidationFailure failure = BigQueryUtil.validateFieldSchemaMatches(
+            bqFields.get(field.getName()), field, dataset, tableName,
+            AbstractBigQuerySinkConfig.SUPPORTED_TYPES, collector);
+          if (failure != null) {
+            failure.withInputSchemaField(fieldName).withOutputSchemaField(fieldName);
+          }
+          BigQueryUtil.validateFieldModeMatches(bqFields.get(fieldName), field,
+            allowSchemaRelaxation,
+            collector);
+        }
+      }
+    }
+    collector.getOrThrowException();
+  }
+
+  /**
+   * Validates output schema against Big Query table schema for Insert operation. It throws
+   * {@link IllegalArgumentException}
+   * if the output schema has more fields than Big Query table or output schema field types does not match
+   * Big Query column types unless schema relaxation policy is allowed.
+   * @param table                   table name
+   * @param tableSchema             configured table schema
+   * @param allowSchemaRelaxation   allows schema relaxation policy
+   * @param isTruncateTableSet      to truncate the table before writing or not while inserting
+   * @param dataset                 dataset name
+   * @param collector               failure collector
+   */
+  public static void validateInsertSchema(Table table, @Nullable Schema tableSchema,
+                                          boolean allowSchemaRelaxation,
+                                          boolean isTruncateTableSet,
+                                          String dataset, FailureCollector collector) {
+    com.google.cloud.bigquery.Schema bqSchema = table.getDefinition().getSchema();
+    if (bqSchema == null || bqSchema.getFields().isEmpty()) {
+      // Table is created without schema, so no further validation is required.
+      return;
+    }
+
+    if (isTruncateTableSet || tableSchema == null) {
+      //no validation required for schema if truncate table is set.
+      // BQ will overwrite the schema for normal tables when write disposition is WRITE_TRUNCATE
+      //note - If write to single partition is supported in future, schema validation will be necessary
+      return;
+    }
+    FieldList bqFields = bqSchema.getFields();
+    List<Schema.Field> outputSchemaFields = Objects.requireNonNull(tableSchema.getFields());
+
+    List<String> remainingBQFields = BigQueryUtil.getBqFieldsMinusSchema(bqFields, outputSchemaFields);
+    for (String field : remainingBQFields) {
+      if (bqFields.get(field).getMode() != Field.Mode.NULLABLE) {
+        collector.addFailure(String.format("Required Column '%s' is not present in the schema.", field),
+          String.format("Add '%s' to the schema.", field));
+      }
+    }
+
+    String tableName = table.getTableId().getTable();
+    List<String> missingBQFields = BigQueryUtil.getSchemaMinusBqFields(outputSchemaFields, bqFields);
+    // Match output schema field type with BigQuery column type
+    for (Schema.Field field : tableSchema.getFields()) {
+      String fieldName = field.getName();
+      // skip checking schema if field is missing in BigQuery
+      if (!missingBQFields.contains(fieldName)) {
+        ValidationFailure failure = BigQueryUtil.validateFieldSchemaMatches(
+          bqFields.get(field.getName()), field, dataset, tableName,
+          AbstractBigQuerySinkConfig.SUPPORTED_TYPES, collector);
+        if (failure != null) {
+          failure.withInputSchemaField(fieldName).withOutputSchemaField(fieldName);
+        }
+        BigQueryUtil.validateFieldModeMatches(bqFields.get(fieldName), field,
+          allowSchemaRelaxation,
+          collector);
+      }
+    }
+    collector.getOrThrowException();
+  }
+
+  /**
+   * Returns list of duplicated fields (case insensitive)
+   * @param schemaFields List of schema fields
+   * @return             return set of duplicate fields
+   */
+  public static Set<String> getDuplicatedFields(List<String> schemaFields) {
+    final Set<String> duplicatedFields = new HashSet<>();
+    final Set<String> set = new HashSet<>();
+    for (String field : schemaFields) {
+      if (!set.add(field)) {
+        duplicatedFields.add(field);
+      }
+    }
+    return duplicatedFields;
+  }
+
+  /**
+   * returns whether any logical type is supported or not in BigQuery.
+   * @param logicalType logical type of schema field
+   * @return boolean value
+   */
+  public static boolean isSupportedLogicalType(Schema.LogicalType logicalType) {
+    if (logicalType != null) {
+      return logicalType == Schema.LogicalType.DATE || logicalType == Schema.LogicalType.TIMESTAMP_MICROS ||
+        logicalType == Schema.LogicalType.TIMESTAMP_MILLIS || logicalType == Schema.LogicalType.DECIMAL;
+    }
+    return false;
+  }
+
+  /**
+   * returns a Map, if fields are coming multiple times in fieldList.
+   * @param values
+   * @return Map containing Field as key and occurrence as value
+   */
+  public static Map<String, Integer> calculateDuplicates(List<String> values) {
+    return values.stream()
+      .map(v -> v.split(" ")[0])
+      .collect(Collectors.toMap(p -> p, p -> 1, (x, y) -> x + y));
+  }
+
+  /**
+   * Record the lineage for the plugin
+   * @param context       Batch sink context
+   * @param outputName    output name
+   * @param tableSchema   schema of table
+   * @param fieldNames    field list
+   */
+  public static void recordLineage(BatchSinkContext context,
+                                   String outputName,
+                                   Schema tableSchema,
+                                   List<String> fieldNames) {
+    LineageRecorder lineageRecorder = new LineageRecorder(context, outputName);
+    lineageRecorder.createExternalDataset(tableSchema);
+    if (!fieldNames.isEmpty()) {
+      lineageRecorder.recordWrite("Write", "Wrote to BigQuery table.", fieldNames);
+    }
+  }
+
 }

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkTest.java
@@ -203,11 +203,13 @@ public class BigQuerySinkTest {
     BigQuerySink sink = getValidationTestSink(false);
     MockFailureCollector collector = new MockFailureCollector("bqsink");
     Table table = getTestSchema();
-    sink.validateSchema(
+    BigQuerySinkUtils.validateSchema(
       table.getTableId().getTable(),
       table.getDefinition().getSchema(),
       sink.getConfig().getSchema(collector),
       false,
+      false,
+      "ds",
       collector);
   }
 
@@ -216,11 +218,13 @@ public class BigQuerySinkTest {
     BigQuerySink sink = getValidationTestSink(true);
     MockFailureCollector collector = new MockFailureCollector("bqsink");
     Table table = getTestSchema();
-    sink.validateSchema(
+    BigQuerySinkUtils.validateSchema(
       table.getTableId().getTable(),
       table.getDefinition().getSchema(),
       sink.getConfig().getSchema(collector),
       false,
+      true,
+      "ds",
       collector);
     Assert.assertEquals(0, collector.getValidationFailures().size());
   }
@@ -230,11 +234,13 @@ public class BigQuerySinkTest {
     BigQuerySink sink = getValidationTestSink(true);
     MockFailureCollector collector = new MockFailureCollector("bqsink");
     Table table = getTestSchema();
-    sink.validateSchema(
+    BigQuerySinkUtils.validateSchema(
       table.getTableId().getTable(),
       table.getDefinition().getSchema(),
       sink.getConfig().getSchema(collector),
       true,
+      true,
+      "ds",
       collector);
     Assert.assertEquals(0, collector.getValidationFailures().size());
   }
@@ -244,11 +250,13 @@ public class BigQuerySinkTest {
     BigQuerySink sink = getValidationTestSink(false);
     MockFailureCollector collector = new MockFailureCollector("bqsink");
     Table table = getTestSchema();
-    sink.validateSchema(
+    BigQuerySinkUtils.validateSchema(
       table.getTableId().getTable(),
       table.getDefinition().getSchema(),
       sink.getConfig().getSchema(collector),
       true,
+      false,
+      "ds",
       collector);
     Assert.assertEquals(0, collector.getValidationFailures().size());
   }
@@ -258,15 +266,20 @@ public class BigQuerySinkTest {
     BigQuerySink sink = getValidationTestSink(false);
     MockFailureCollector collector = new MockFailureCollector("bqsink");
     Table table = getTestSchema();
-    sink.validateSchema(
+    BigQuerySinkUtils.validateSchema(
       table.getTableId().getTable(),
       table.getDefinition().getSchema(),
       null,
       true,
+      false,
+      "ds",
       collector);
-    sink.validateInsertSchema(
+    BigQuerySinkUtils.validateInsertSchema(
       table,
       null,
+      true,
+      false,
+      "ds",
       collector);
     Assert.assertEquals(0, collector.getValidationFailures().size());
   }


### PR DESCRIPTION
Dataplex plugins are reusing Bigquery plugins code. So, common code has been moved to util classes for reuse.