### PR TITLE
[PLUGIN-869] Added execution metrics for BQ Pushdown jobs

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQueryJoinDataset.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQueryJoinDataset.java
@@ -150,12 +150,14 @@ public class BigQueryJoinDataset implements SQLDataset, BigQuerySQLDataset {
     if (queryJob == null) {
       throw new SQLEngineException("BigQuery job not found: " + jobId);
     } else if (queryJob.getStatus().getError() != null) {
+      BigQuerySQLEngineUtils.logJobMetrics(queryJob);
       throw new SQLEngineException(String.format(
         "Error executing BigQuery Job: '%s' in Project '%s', Dataset '%s', Location'%s' : %s",
         jobId, project, bqDataset, location, queryJob.getStatus().getError().toString()));
     }
 
     LOG.info("Created BigQuery table `{}` using Job: {}", bqTable, jobId);
+    BigQuerySQLEngineUtils.logJobMetrics(queryJob);
   }
 
   @Override

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQuerySelectDataset.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQuerySelectDataset.java
@@ -124,12 +124,14 @@ public class BigQuerySelectDataset implements SQLDataset, BigQuerySQLDataset {
     if (queryJob == null) {
       throw new SQLEngineException("BigQuery job not found: " + jobId);
     } else if (queryJob.getStatus().getError() != null) {
+      BigQuerySQLEngineUtils.logJobMetrics(queryJob);
       throw new SQLEngineException(String.format(
         "Error executing BigQuery Job: '%s' in Project '%s', Dataset '%s', Location'%s' : %s",
         jobId, project, bqDataset, location, queryJob.getStatus().getError().toString()));
     }
 
     LOG.info("Created BigQuery table `{}` using Job: {}", bqTable, jobId);
+    BigQuerySQLEngineUtils.logJobMetrics(queryJob);
     return this;
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQueryWrite.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQueryWrite.java
@@ -228,6 +228,7 @@ public class BigQueryWrite {
 
     // Check for errors
     if (queryJob.getStatus().getError() != null) {
+      BigQuerySQLEngineUtils.logJobMetrics(queryJob);
       LOG.error("Error executing BigQuery Job: '{}' in Project '{}', Dataset '{}': {}",
                 jobId, sqlEngineConfig.getProject(), sqlEngineConfig.getDatasetProject(),
                 queryJob.getStatus().getError().toString());
@@ -241,6 +242,7 @@ public class BigQueryWrite {
     LOG.info("Executed copy operation for {} records from {}.{}.{} to {}.{}.{}", numRows,
              sourceTableId.getProject(), sourceTableId.getDataset(), sourceTableId.getTable(),
              destinationTableId.getProject(), destinationTableId.getDataset(), destinationTableId.getTable());
+    BigQuerySQLEngineUtils.logJobMetrics(queryJob);
 
     return SQLWriteResult.success(datasetName, numRows);
   }


### PR DESCRIPTION
Trace logging for additional metrics can be enabled by configuring `io.cdap.plugin.gcp.bigquery.sqlengine.util.BigQuerySQLEngineUtils` to `TRACE` log level