### PR TITLE
Exclusions removed from pom for PLUGIN-1198 fix.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,10 +227,6 @@
           <groupId>com.google.code.findbugs</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>grpc-alts</artifactId>
-          <groupId>io.grpc</groupId>
-        </exclusion>
-        <exclusion>
           <artifactId>grpc-auth</artifactId>
           <groupId>io.grpc</groupId>
         </exclusion>


### PR DESCRIPTION
Exclusions removed from pom for PLUGIN-1198 fix.