### PR TITLE
[CDAP-19045] tied get schema button with format instead of delimiter

### DIFF
--- a/widgets/GCSFile-batchsource.json
+++ b/widgets/GCSFile-batchsource.json
@@ -106,6 +106,16 @@
           "name": "format",
           "widget-attributes": {
             "plugin-type": "validatingInputFormat"
+          },
+          "plugin-function": {
+            "method": "POST",
+            "widget": "outputSchema",
+            "label": "Get Schema Value",
+            "required-fields": [
+              "path"
+            ],
+            "missing-required-fields-message": "Please provide path field",
+            "plugin-method": "getSchema"
           }
         },
         {
@@ -144,16 +154,6 @@
           "name": "delimiter",
           "widget-attributes": {
             "placeholder": "Delimiter if the format is 'delimited'"
-          },
-          "plugin-function": {
-            "method": "POST",
-            "widget": "outputSchema",
-            "label": "Get Schema Value",
-            "required-fields": [
-              "path"
-            ],
-            "missing-required-fields-message": "Please provide path field",
-            "plugin-method": "getSchema"
           }
         },
         {


### PR DESCRIPTION
[CDAP-19045](https://cdap.atlassian.net/browse/CDAP-19045)

Why- when `Get Schema` is tied to delimiter, it is only visible when delimited format is selected. Ideally `Get Schema` should be allowed for every format.