### PR TITLE
[PLUGIN-698] Wildcard feature for GCS Move/Copy

### DIFF
--- a/docs/GCSCopy-action.md
+++ b/docs/GCSCopy-action.md
@@ -28,6 +28,8 @@ It can be found on the Dashboard in the Google Cloud Platform Console.
 
 **Destination Path**: Path to the destination. The bucket will be created if it does not exist. 
 
+**Use Wildcard**: Whether to use Wildcard regular expression to filter the files in the source directory that will be copied.
+
 **Copy All Subdirectories**: If the source is a directory, copy all subdirectories.
 
 **Overwrite Existing Files**: Whether to overwrite existing files during the copy. If this is set to

--- a/docs/GCSMove-action.md
+++ b/docs/GCSMove-action.md
@@ -29,6 +29,8 @@ It can be found on the Dashboard in the Google Cloud Platform Console.
 
 **Destination Path**: Path to the destination. The bucket will be created if it does not exist.
 
+**Use Wildcard**: Whether to use Wildcard regular expression to filter the files in the source directory that will be moved.
+
 **Copy All Subdirectories**: If the source is a directory, move all subdirectories.
 
 **Overwrite Existing Files**: Whether to overwrite existing files during the move. If this is set to

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
     <avro.version>1.8.2</avro.version>
     <bigquery.connector.hadoop2.version>hadoop2-1.0.0</bigquery.connector.hadoop2.version>
     <commons.codec.version>1.4</commons.codec.version>
+    <commons.io.version>2.11.0</commons.io.version>
     <cdap.version>6.8.0-SNAPSHOT</cdap.version>
     <cdap.plugin.version>2.10.0-SNAPSHOT</cdap.plugin.version>
     <dropwizard.metrics-core.version>3.2.6</dropwizard.metrics-core.version>
@@ -418,6 +419,11 @@
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-datastore</artifactId>
       <version>${google.cloud.datastore.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>${commons.io.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
@@ -35,6 +35,7 @@ import io.cdap.plugin.gcp.gcs.GCSPath;
 import io.cdap.plugin.gcp.gcs.StorageClient;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import javax.annotation.Nullable;
 
@@ -76,7 +77,19 @@ public class GCSMove extends Action {
     storageClient.createBucketIfNotExists(destPath, config.location, cmekKeyName);
 
     //noinspection ConstantConditions
-    storageClient.move(config.getSourcePath(), config.getDestPath(), config.recursive, config.shouldOverwrite());
+    if (config.wildcard) {
+      ArrayList<GCSPath> matchedPaths = storageClient.getAllMatchingWildcardPaths(config.getSourcePath());
+      if (matchedPaths.size() == 0) {
+        collector.addFailure("Found no matching paths given the source path regex.",
+                             "Please check the source path input.");
+        collector.getOrThrowException();
+      }
+      for (GCSPath sourcePath: matchedPaths) {
+        storageClient.move(sourcePath, config.getDestPath(), config.recursive, config.shouldOverwrite());
+      }
+    } else {
+      storageClient.move(config.getSourcePath(), config.getDestPath(), config.recursive, config.shouldOverwrite());
+    }
   }
 
   /**
@@ -89,9 +102,16 @@ public class GCSMove extends Action {
     @Description("Whether to move objects in all subdirectories.")
     private Boolean recursive;
 
+    @Macro
+    @Nullable
+    @Description("Whether to Wildcard regular expression " +
+      "to filter the files in the source directory that will be moved.")
+    private Boolean wildcard;
+
     public Config() {
       super();
       recursive = false;
+      wildcard = false;
     }
   }
 }

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
@@ -78,7 +78,8 @@ public class GCSMove extends Action {
 
     //noinspection ConstantConditions
     if (config.wildcard) {
-      ArrayList<GCSPath> matchedPaths = storageClient.getAllMatchingWildcardPaths(config.getSourcePath());
+      ArrayList<GCSPath> matchedPaths = storageClient.getAllMatchingWildcardPaths(config.getSourcePath()
+        , config.recursive);
       if (matchedPaths.size() == 0) {
         collector.addFailure("Found no matching paths given the source path regex.",
                              "Please check the source path input.");
@@ -104,7 +105,7 @@ public class GCSMove extends Action {
 
     @Macro
     @Nullable
-    @Description("Whether to Wildcard regular expression " +
+    @Description("Whether to use Wildcard regular expression " +
       "to filter the files in the source directory that will be moved.")
     private Boolean wildcard;
 

--- a/src/test/java/io/cdap/plugin/gcp/gcs/StorageClientTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/gcs/StorageClientTest.java
@@ -17,8 +17,11 @@
 package io.cdap.plugin.gcp.gcs;
 
 import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.Storage;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.ArrayList;
 
 /**
  * Tests for storage client
@@ -66,5 +69,23 @@ public class StorageClientTest {
                         StorageClient.resolve("dir1/dir2", "dir1/dir2/a/b/c", GCSPath.from("b0/subdir"), false));
     Assert.assertEquals(BlobId.of("b0", "subdir/dir2/a/b/c"),
                         StorageClient.resolve("dir1/dir2", "dir1/dir2/a/b/c", GCSPath.from("b0/subdir/"), false));
+  }
+
+  @Test
+  public void testGetMatchingWildcardPath() {
+    Assert.assertEquals(GCSPath.from("b0/test_1/sub_1")
+      , StorageClient.getMatchingWildcardPath("test_1/sub_1/", "test_*/*", 1, true, "b0"));
+    Assert.assertEquals(GCSPath.from("b0/test_1/sub_1")
+      , StorageClient.getMatchingWildcardPath("test_1/sub_1/", "test_*/", 1, true, "b0"));
+    Assert.assertEquals(null
+      , StorageClient.getMatchingWildcardPath("test_1/sub_1/sub_2/", "test_*/*", 1, true, "b0"));
+    Assert.assertEquals(GCSPath.from("b0/test_1/file.json")
+      , StorageClient.getMatchingWildcardPath("test_1/file.json", "test_*/*.json", 1, true, "b0"));
+    Assert.assertEquals(GCSPath.from("b0/test_1/file.json")
+      , StorageClient.getMatchingWildcardPath("test_1/file.json", "test_*/*.json", 1, false, "b0"));
+    Assert.assertEquals(GCSPath.from("b0/test_1/")
+      , StorageClient.getMatchingWildcardPath("test_1/", "test_*/", 1, true, "b0"));
+    Assert.assertEquals(GCSPath.from("b0/test_1/")
+      , StorageClient.getMatchingWildcardPath("test_1/", "test_*/", 1, false, "b0"));
   }
 }

--- a/widgets/GCSCopy-action.json
+++ b/widgets/GCSCopy-action.json
@@ -33,6 +33,25 @@
         },
         {
           "widget-type": "radio-group",
+          "name" : "wildcard",
+          "label" : "Use Wildcard",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "false",
+            "options": [
+              {
+                "id": "true",
+                "label": "True"
+              },
+              {
+                "id": "false",
+                "label": "False"
+              }
+            ]
+          }
+        },
+        {
+          "widget-type": "radio-group",
           "name" : "recursive",
           "label" : "Copy All Subdirectories",
           "widget-attributes": {

--- a/widgets/GCSMove-action.json
+++ b/widgets/GCSMove-action.json
@@ -33,6 +33,25 @@
         },
         {
           "widget-type": "radio-group",
+          "name" : "wildcard",
+          "label" : "Use Wildcard",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "false",
+            "options": [
+              {
+                "id": "true",
+                "label": "True"
+              },
+              {
+                "id": "false",
+                "label": "False"
+              }
+            ]
+          }
+        },
+        {
+          "widget-type": "radio-group",
           "name" : "recursive",
           "label" : "Move All Subdirectories",
           "widget-attributes": {


### PR DESCRIPTION
# [PLUGIN-698] Wildcard feature for GCS Move/Copy

## Description
Add a new wildcard toggle option to allow user input '*' in source path to match 0 or any number of characters. Tested a number of different expressions and worked as expected. May need to test some more edge cases

## Jira 
[PLUGIN-698](https://cdap.atlassian.net/browse/PLUGIN-698)

![image](https://user-images.githubusercontent.com/98125204/166082498-a3acca07-23c8-499f-bb01-daad56a7d684.png)
