### PR TITLE
Initial commit for GCS Batch Source plugin metadata feature.

### DIFF
--- a/docs/GCSFile-batchsource.md
+++ b/docs/GCSFile-batchsource.md
@@ -84,6 +84,14 @@ the regular expression syntax
 If not specified, the file path will not be included in output records.
 If specified, the field must exist in the output schema as a string.
 
+**Length Field:** Output field to place the length of the file that the record was read from.
+If not specified, the file length will not be included in output records.
+If specified, the field must exist in the output schema as a long.
+
+**Modification Time Field:** Output field to place the modification time of the file that the record was read from.
+If not specified, the file modification time will not be included in output records.
+If specified, the field must exist in the output schema as a long.
+
 **Path Filename Only:** Whether to only use the filename instead of the URI of the file path when a path field is given.
 The default value is false.
 

--- a/widgets/GCSFile-batchsource.json
+++ b/widgets/GCSFile-batchsource.json
@@ -226,6 +226,22 @@
           }
         },
         {
+          "widget-type": "textbox",
+          "label": "Length Field",
+          "name": "lengthField",
+          "widget-attributes": {
+            "placeholder": "Output field to place the length of the file that was read from"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Modification Time Field",
+          "name": "modificationTimeField",
+          "widget-attributes": {
+            "placeholder": "Output field to place the modification time of the file that was read from"
+          }
+        },
+        {
           "widget-type": "radio-group",
           "name": "filenameOnly",
           "label": "Path Filename Only",


### PR DESCRIPTION
This change extends functionality of GCS Batch Source plugin. There were added two new plugin parameters here:
- Length Field
- Modification Time Field

If a customer set values for these parameters, the plugin output schema will be extended with additional fields with appropriate names. In general the plugin works with these parameters in the same way as with "Path Field" parameter. Additionally was fixed "GET SCHEMA" functionality when "Path Field"/"Length Field"/"Modification Time Field" are set.

This change is supplied in two PRs, the second is .


There are open questions regarding the proposed change:

1. There are 4 tests in google-cloud module which are failing even before my changes:

```
Failed tests: 
  BigtableSourceConfigTest.testValidateMissingProjectId:95->validateConfigValidationFail:207->validateConfigValidationFail:191 expected:<1> but was:<0>
  BigtableSinkConfigTest.testValidateMissingProjectId:86->validateConfigValidationFail:116 expected:<1> but was:<0>
  DataplexBatchSourceTest.validateServiceAccountWhenIsServiceAccountJsonFalse:107 expected:<0> but was:<2>
  DataplexBatchSourceTest.validateServiceAccountWhenServiceAccountFilePathIsNull:121 expected:<0> but was:<2>

Tests run: 394, Failures: 4, Errors: 0, Skipped: 9
```
Should they be fixed before PR or there is no difference?

2. File Batch Source plugin had "GET SCHEMA" button for all formats in 2.7.1 version. But now this button is available for "delimited" format only. Does this functionality regress make any sense? (just faced this behavior during testing)

3. Noticed that in fact "length" and "modification time" fields functionality was implemented for all "AbstractFileSource" batch source plugins. Does it make sense to add these fields to File Batch Source plugin?

4. Initially all these changes were intended to create a customized GCS Source plugin which can be added to the current 6.5.1 CDAP cluster. As there were some changes of interfaces, it was required to support back-compatibility with unchanged version of File Batch Source and other possible plugins based on AbstractFileSource. Do we need this functionality now in future 6.7.0? (for example if we want use 6.7.0 CDAP with some old plugin based on AbstractFileSource and which uses old PathTrackingInputFormat.createRecordReader() without length and modification time support)