### PR TITLE
Prevent pipeline from deploying for unsupported gcs multi file sink combination

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSMultiBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSMultiBatchSink.java
@@ -97,17 +97,21 @@ public class GCSMultiBatchSink extends BatchSink<StructuredRecord, NullWritable,
 
     PluginProperties formatProperties = formatPropertiesBuilder.build();
 
-    if (!this.config.containsMacro("format")) {
-      String format = config.getFormatName();
-      OutputFormatProvider outputFormatProvider =
-              pipelineConfigurer.usePlugin(ValidatingOutputFormat.PLUGIN_TYPE, format, FORMAT_PLUGIN_ID,
-                      formatProperties);
-      if (outputFormatProvider == null) {
-        collector.addFailure(
-                String.format("Could not find the '%s' output format plugin.", format), null)
-                .withPluginNotFound(FORMAT_PLUGIN_ID, format, ValidatingOutputFormat.PLUGIN_TYPE);
+    try {
+      if (!this.config.containsMacro("format")) {
+        String format = config.getFormatName();
+        OutputFormatProvider outputFormatProvider =
+                pipelineConfigurer.usePlugin(ValidatingOutputFormat.PLUGIN_TYPE, format, FORMAT_PLUGIN_ID,
+                        formatProperties);
+        if (outputFormatProvider == null) {
+          collector.addFailure(
+                          String.format("Could not find the '%s' output format plugin.", format), null)
+                  .withPluginNotFound(FORMAT_PLUGIN_ID, format, ValidatingOutputFormat.PLUGIN_TYPE);
+        }
+        return;
       }
-      return;
+    } catch (Throwable t) {
+      collector.addFailure(t.getMessage(), null);
     }
     //deploying all format plugins if its macro, so that required format plugin is available when macro is resolved
     for (FileFormat f: FileFormat.values()) {


### PR DESCRIPTION
** Issue **
https://cdap.atlassian.net/browse/PLUGIN-1139

** Description **

Capturing the validation error in the failure collector and preventing the pipeline from deploying when an invalid input is specified in gcs multi sink (in this case we allow flexible schema to be enabled 

<img width="1781" alt="Screen Shot 2022-05-04 at 2 48 41 PM" src="https://user-images.githubusercontent.com/93731383/166831804-d0226c34-8150-4a33-acf4-36947f181c75.png">

<img width="1788" alt="Screen Shot 2022-05-04 at 2 55 51 PM" src="https://user-images.githubusercontent.com/93731383/166832200-8eb559fc-0bf7-49a2-829c-fa868f1f14aa.png">

