### PR TITLE
Rearranging transformation pushdown widget

### DIFF
--- a/widgets/BigQueryPushdownEngine-sqlengine.json
+++ b/widgets/BigQueryPushdownEngine-sqlengine.json
@@ -5,7 +5,29 @@
   "display-name": "BigQuery Pushdown",
   "configuration-groups": [
     {
-      "label": "Connection",
+      "label": "Basic",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "BigQuery Dataset",
+          "name": "dataset",
+          "widget-attributes": {
+            "placeholder": "Dataset to use to store temporary tables when pipeline is run."
+          }
+        },
+        {
+          "label": "browse",
+          "widget-type": "connection-browser",
+          "widget-category": "plugin",
+          "widget-attributes": {
+            "connectionType": "BIGQUERY",
+            "label": "Browse"
+          }
+        }
+      ]
+    },
+    {
+      "label": "Advanced",
       "properties": [
         {
           "widget-type": "toggle",
@@ -78,34 +100,7 @@
           "widget-type": "textbox",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
-        }
-      ]
-    },
-    {
-      "label": "Basic",
-      "properties": [
-        {
-          "widget-type": "textbox",
-          "label": "BigQuery Dataset",
-          "name": "dataset",
-          "widget-attributes": {
-            "placeholder": "Dataset to use to store temporary tables when pipeline is run."
-          }
         },
-        {
-          "label": "browse",
-          "widget-type": "connection-browser",
-          "widget-category": "plugin",
-          "widget-attributes": {
-            "connectionType": "BIGQUERY",
-            "label": "Browse"
-          }
-        }
-      ]
-    },
-    {
-      "label": "Advanced",
-      "properties": [
         {
           "widget-type": "textbox",
           "label": "Temporary Bucket Name",


### PR DESCRIPTION
**Issue** 

https://cdap.atlassian.net/browse/PLUGIN-1246

**Description**

We must have 2 configuration groups : "basic" and "advanced" and connection properties are rearranged under "advanced" and basic has "Big query dataset" which is required

<img width="981" alt="Screen Shot 2022-05-05 at 6 37 34 PM" src="https://user-images.githubusercontent.com/93731383/167053905-33a9e67a-dcd8-45b4-918d-972246eb91ee.png">
<img width="973" alt="Screen Shot 2022-05-05 at 6 37 50 PM" src="https://user-images.githubusercontent.com/93731383/167053899-64acde5f-69e4-4018-a51d-967fcc677a91.png">
<img width="970" alt="Screen Shot 2022-05-05 at 6 37 59 PM" src="https://user-images.githubusercontent.com/93731383/167053892-b3cefee0-5abb-445d-bec4-a44cd6c9436d.png">



