### PR TITLE
e2e tests fix for CDAP-19213 - skip header changes

### DIFF
--- a/src/e2e-test/features/bigquery/sink/GCSToBigQuery.feature
+++ b/src/e2e-test/features/bigquery/sink/GCSToBigQuery.feature
@@ -45,8 +45,8 @@ Feature: BigQuery sink - Verification of GCS to BigQuery successful data transfe
     Then Enter GCS property projectId and reference name
     Then Override Service account details if set in environment variables
     Then Enter GCS source property path "gcsCsvRangeFile"
-    Then Toggle GCS source property skip header to true
     Then Select GCS property format "csv"
+    Then Toggle GCS source property skip header to true
     Then Validate output schema with expectedSchema "gcsCsvRangeFileSchema"
     Then Validate "GCS" plugin properties
     Then Close the GCS properties
@@ -88,8 +88,8 @@ Feature: BigQuery sink - Verification of GCS to BigQuery successful data transfe
     Then Enter GCS property projectId and reference name
     Then Override Service account details if set in environment variables
     Then Enter GCS source property path "gcsCsvRangeFile"
-    Then Toggle GCS source property skip header to true
     Then Select GCS property format "csv"
+    Then Toggle GCS source property skip header to true
     Then Validate output schema with expectedSchema "gcsCsvRangeFileSchema"
     Then Validate "GCS" plugin properties
     Then Close the GCS properties
@@ -126,8 +126,8 @@ Feature: BigQuery sink - Verification of GCS to BigQuery successful data transfe
     Then Enter GCS property projectId and reference name
     Then Override Service account details if set in environment variables
     Then Enter GCS source property path "gcsCsvRangeFile"
-    Then Toggle GCS source property skip header to true
     Then Select GCS property format "csv"
+    Then Toggle GCS source property skip header to true
     Then Validate output schema with expectedSchema "gcsCsvRangeFileSchema"
     Then Validate "GCS" plugin properties
     Then Close the GCS properties

--- a/src/e2e-test/features/bigquery/sink/GCSToBigQuery_WithMacro.feature
+++ b/src/e2e-test/features/bigquery/sink/GCSToBigQuery_WithMacro.feature
@@ -13,8 +13,8 @@ Feature: BigQuery sink - Verification of GCS to BigQuery successful data transfe
     Then Enter GCS property "serviceAccountFilePath" as macro argument "serviceAccount"
     Then Enter GCS property "serviceAccountJSON" as macro argument "serviceAccount"
     Then Enter GCS property "path" as macro argument "gcsSourcePath"
-    Then Enter GCS source property "skipHeader" as macro argument "gcsSkipHeader"
     Then Enter GCS property "format" as macro argument "gcsFormat"
+    Then Enter GCS source property "skipHeader" as macro argument "gcsSkipHeader"
     Then Enter GCS source property output schema "outputSchema" as macro argument "gcsOutputSchema"
     Then Validate "GCS" plugin properties
     Then Close the GCS properties

--- a/src/e2e-test/features/gcs/source/GCSSourceToBigQuery.feature
+++ b/src/e2e-test/features/gcs/source/GCSSourceToBigQuery.feature
@@ -11,8 +11,8 @@ Feature: GCS source - Verification of GCS to BQ successful data transfer
     Then Enter GCS property projectId and reference name
     Then Override Service account details if set in environment variables
     Then Enter GCS source property path "gcsCsvFile"
-    Then Toggle GCS source property skip header to true
     Then Select GCS property format "csv"
+    Then Toggle GCS source property skip header to true
     Then Validate output schema with expectedSchema "gcsCsvFileSchema"
     Then Validate "GCS" plugin properties
     Then Close the GCS properties
@@ -132,7 +132,6 @@ Feature: GCS source - Verification of GCS to BQ successful data transfer
     Then Enter GCS source property path "gcsBlobFile"
     Then Select GCS property format "blob"
     Then Enter GCS source property minimum split size "gcsMinSplitSize" and maximum split size "gcsMaxSplitSize"
-    Then Toggle GCS source property skip header to true
     Then Validate output schema with expectedSchema "gcsBlobFileSchema"
     Then Validate "GCS" plugin properties
     Then Close the GCS properties

--- a/src/e2e-test/features/gcs/source/GCSourceSchema.feature
+++ b/src/e2e-test/features/gcs/source/GCSourceSchema.feature
@@ -1,7 +1,7 @@
 @GCS_Source
 Feature: GCS source - Validate GCS plugin output schema for different formats
 
-  Scenario Outline:GCS Source output schema validation
+  Scenario Outline:GCS Source output schema validation for csv and tsv format
     Given Open Datafusion Project to configure pipeline
     When Source is GCS
     Then Open GCS source properties
@@ -19,6 +19,16 @@ Feature: GCS source - Validate GCS plugin output schema for different formats
     Examples:
       | GcsPath      | FileFormat  | ExpectedSchema     |
       | gcsTsvFile   | tsv         | gcsTsvFileSchema   |
+
+  Scenario Outline:GCS Source output schema validation for blob and text format
+    Given Open Datafusion Project to configure pipeline
+    When Source is GCS
+    Then Open GCS source properties
+    Then Enter GCS property projectId and reference name
+    Then Override Service account details if set in environment variables
+    Then Enter GCS source property path "<GcsPath>"
+    Then Select GCS property format "<FileFormat>"
+    Then Validate output schema with expectedSchema "<ExpectedSchema>"
     @GCS_BLOB_TEST
     Examples:
       | GcsPath      | FileFormat  | ExpectedSchema     |

--- a/src/e2e-test/features/pubsub/sink/GCSToPubSub.feature
+++ b/src/e2e-test/features/pubsub/sink/GCSToPubSub.feature
@@ -97,8 +97,8 @@ Feature: PubSub-Sink - Verification of GCS to PubSub successful data transfer
     Then Enter GCS property projectId and reference name
     Then Override Service account details if set in environment variables
     Then Enter GCS source property path "gcsDataTypeTest1File"
-    Then Toggle GCS source property skip header to true
     Then Select GCS property format "csv"
+    Then Toggle GCS source property skip header to true
     Then Click on the Get Schema button
     Then Validate "GCS" plugin properties
     Then Close the GCS properties
@@ -134,8 +134,8 @@ Feature: PubSub-Sink - Verification of GCS to PubSub successful data transfer
     Then Enter GCS property projectId and reference name
     Then Override Service account details if set in environment variables
     Then Enter GCS source property path "gcsDataTypeTest2File"
-    Then Toggle GCS source property skip header to true
     Then Select GCS property format "csv"
+    Then Toggle GCS source property skip header to true
     Then Click on the Get Schema button
     Then Validate "GCS" plugin properties
     Then Close the GCS properties
@@ -170,8 +170,8 @@ Feature: PubSub-Sink - Verification of GCS to PubSub successful data transfer
     Then Enter GCS property projectId and reference name
     Then Override Service account details if set in environment variables
     Then Enter GCS source property path "<GcsPath>"
-    Then Toggle GCS source property skip header to true
     Then Select GCS property format "<SourceFormat>"
+    Then Toggle GCS source property skip header to true
     Then Click on the Get Schema button
     Then Validate "GCS" plugin properties
     Then Close the GCS properties
@@ -196,10 +196,6 @@ Feature: PubSub-Sink - Verification of GCS to PubSub successful data transfer
     Then Verify the pipeline status is "Succeeded"
     Then Validate OUT record count is equal to IN record count
     Then Open and capture logs
-    @GCS_TEXT_TEST
-    Examples:
-      | GcsPath     | SourceFormat | SinkFormat |
-      | gcsTextFile | text         | csv        |
     @GCS_CSV_TEST
     Examples:
       | GcsPath    | SourceFormat | SinkFormat |
@@ -230,7 +226,6 @@ Feature: PubSub-Sink - Verification of GCS to PubSub successful data transfer
     Then Enter GCS property projectId and reference name
     Then Override Service account details if set in environment variables
     Then Enter GCS source property path "<GcsPath>"
-    Then Toggle GCS source property skip header to true
     Then Select GCS property format "<SourceFormat>"
     Then Click on the Get Schema button
     Then Validate "GCS" plugin properties

--- a/src/e2e-test/features/pubsub/sink/GCSToPubSub_WithMacro.feature
+++ b/src/e2e-test/features/pubsub/sink/GCSToPubSub_WithMacro.feature
@@ -13,8 +13,8 @@ Feature: PubSub-Sink - Verification of GCS to PubSub successful data transfer wi
     Then Enter GCS property "serviceAccountFilePath" as macro argument "serviceAccount"
     Then Enter GCS property "serviceAccountJSON" as macro argument "serviceAccount"
     Then Enter GCS property "path" as macro argument "gcsSourcePath"
-    Then Enter GCS source property "skipHeader" as macro argument "gcsSkipHeader"
     Then Enter GCS property "format" as macro argument "gcsFormat"
+    Then Enter GCS source property "skipHeader" as macro argument "gcsSkipHeader"
     Then Enter GCS source property output schema "outputSchema" as macro argument "gcsOutputSchema"
     Then Validate "GCS" plugin properties
     Then Close the GCS properties
@@ -79,8 +79,8 @@ Feature: PubSub-Sink - Verification of GCS to PubSub successful data transfer wi
     Then Enter GCS property "serviceAccountFilePath" as macro argument "serviceAccount"
     Then Enter GCS property "serviceAccountJSON" as macro argument "serviceAccount"
     Then Enter GCS property "path" as macro argument "gcsSourcePath"
-    Then Enter GCS source property "skipHeader" as macro argument "gcsSkipHeader"
     Then Enter GCS property "format" as macro argument "gcsFormat"
+    Then Enter GCS source property "skipHeader" as macro argument "gcsSkipHeader"
     Then Enter GCS source property output schema "outputSchema" as macro argument "gcsOutputSchema"
     Then Validate "GCS" plugin properties
     Then Close the GCS properties


### PR DESCRIPTION
In recent build tests are failing due to [CDAP-19213](https://github.com/data-integrations/google-cloud/pull/1032) -skip header condition change.

Updated e2e tests as per new condition.

@itsankit-google @rmstar Please review.