### PR TITLE
[PLUGIN-954 & PLUGIN-1256] set cmek key in BQ job in BQExecute only when storing results in a table

### DIFF
--- a/docs/BigQueryExecute-action.md
+++ b/docs/BigQueryExecute-action.md
@@ -48,9 +48,11 @@ cache that will be flushed whenever tables in the query are modified.
 
 **Job Location**: Location of the job. It must match the location of the dataset specified in the query.
 
-**Encryption Key Name**: Used to encrypt data written to any dataset or table created by the plugin.
-If the dataset or table already exists, this is ignored. More information can be found
-[here](https://cloud.google.com/data-fusion/docs/how-to/customer-managed-encryption-keys)
+**Store results in a BigQuery Table**: Whether to store results in a BigQuery Table.
+
+**Encryption Key Name**: Used to encrypt data written to the dataset or table created by the plugin to store the query results.
+It is only applicable when users choose to store the query results in a BigQuery table.
+More information can be found [here](https://cloud.google.com/data-fusion/docs/how-to/customer-managed-encryption-keys)
 
 **Row As Arguments**: Row as arguments. For example, if the query is 'select min(id) as min_id, max(id) as max_id from my_dataset.my_table',
 an arguments for 'min_id' and 'max_id' will be set based on the query results. Plugins further down the pipeline can then

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/action/BigQueryExecute.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/action/BigQueryExecute.java
@@ -42,6 +42,7 @@ import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.action.Action;
 import io.cdap.cdap.etl.api.action.ActionContext;
+import io.cdap.plugin.common.ConfigUtil;
 import io.cdap.plugin.gcp.bigquery.sink.BigQuerySinkUtils;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;
 import io.cdap.plugin.gcp.common.CmekUtils;
@@ -86,14 +87,13 @@ public final class BigQueryExecute extends AbstractBigQueryAction {
 
     CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(config.cmekKey, context.getArguments().asMap(), collector);
     collector.getOrThrowException();
-    if (cmekKeyName != null) {
-      builder.setDestinationEncryptionConfiguration(
-        EncryptionConfiguration.newBuilder().setKmsKeyName(cmekKeyName.toString()).build());
-    }
 
     // Save the results of the query to a permanent table.
-    if (config.getDataset() != null && config.getTable() != null) {
-      builder.setDestinationTable(TableId.of(config.getDataset(), config.getTable()));
+    String datasetName = config.getDataset();
+    String tableName = config.getTable();
+    String datasetProjectId = config.getDatasetProject();
+    if (config.getStoreResults() && datasetProjectId != null && datasetName != null && tableName != null) {
+      builder.setDestinationTable(TableId.of(datasetProjectId, datasetName, tableName));
     }
 
     // Enable or Disable the query cache to force live query evaluation.
@@ -115,14 +115,16 @@ public final class BigQueryExecute extends AbstractBigQueryAction {
                                                     config.isServiceAccountFilePath());
     BigQuery bigQuery = GCPUtils.getBigQuery(config.getProject(), credentials);
     //create dataset to store the results if not exists
-    String datasetName = config.getDataset();
-    String tableName = config.getTable();
-    String datasetProjectId = config.getDatasetProject();
-    if (!Strings.isNullOrEmpty(datasetName) && !Strings.isNullOrEmpty(tableName)) {
+    if (config.getStoreResults() && !Strings.isNullOrEmpty(datasetName) &&
+      !Strings.isNullOrEmpty(tableName)) {
       BigQuerySinkUtils.createDatasetIfNotExists(bigQuery, DatasetId.of(datasetProjectId, datasetName),
                                                  config.getLocation(), cmekKeyName,
                                                  () -> String.format("Unable to create BigQuery dataset '%s.%s'",
                                                                      datasetProjectId, datasetName));
+      if (cmekKeyName != null) {
+        builder.setDestinationEncryptionConfiguration(
+          EncryptionConfiguration.newBuilder().setKmsKeyName(cmekKeyName.toString()).build());
+      }
     }
 
     Job queryJob = bigQuery.create(JobInfo.newBuilder(queryConfig).setJobId(jobId).build());
@@ -183,6 +185,7 @@ public final class BigQueryExecute extends AbstractBigQueryAction {
     private static final String TABLE = "table";
     private static final String NAME_LOCATION = "location";
     private static final int ERROR_CODE_NOT_FOUND = 404;
+    private static final String STORE_RESULTS = "storeResults";
 
     @Description("Dialect of the SQL command. The value must be 'legacy' or 'standard'. " +
       "If set to 'standard', the query will use BigQuery's standard SQL: " +
@@ -229,9 +232,10 @@ public final class BigQueryExecute extends AbstractBigQueryAction {
     @Name(NAME_CMEK_KEY)
     @Macro
     @Nullable
-    @Description("The GCP customer managed encryption key (CMEK) name used to encrypt data written to " +
-      "any dataset or table created by the plugin. If the dataset or table already exists, this is ignored. More " +
-      "information can be found at https://cloud.google.com/data-fusion/docs/how-to/customer-managed-encryption-keys")
+    @Description("The GCP customer managed encryption key (CMEK) name used to encrypt data written to the " +
+      "dataset or table created by the plugin to store the query results. It is only applicable when users choose to " +
+      "store the query results in a BigQuery table. More information can be found at " +
+      "https://cloud.google.com/data-fusion/docs/how-to/customer-managed-encryption-keys")
     private String cmekKey;
 
     @Description("Row as arguments. For example, if the query is " +
@@ -242,10 +246,15 @@ public final class BigQueryExecute extends AbstractBigQueryAction {
     @Macro
     private String rowAsArguments;
 
+    @Name(STORE_RESULTS)
+    @Nullable
+    @Description("Whether to store results in a BigQuery Table.")
+    private Boolean storeResults;
+
     private Config(@Nullable String project, @Nullable String serviceAccountType, @Nullable String serviceFilePath,
                    @Nullable String serviceAccountJson, @Nullable String dataset, @Nullable String table,
                    @Nullable String location, @Nullable String cmekKey, @Nullable String dialect, @Nullable String sql,
-                   @Nullable String mode) {
+                   @Nullable String mode, @Nullable Boolean storeResults) {
       this.project = project;
       this.serviceAccountType = serviceAccountType;
       this.serviceFilePath = serviceFilePath;
@@ -257,6 +266,7 @@ public final class BigQueryExecute extends AbstractBigQueryAction {
       this.dialect = dialect;
       this.sql = sql;
       this.mode = mode;
+      this.storeResults = storeResults;
     }
 
     public boolean isLegacySQL() {
@@ -277,6 +287,10 @@ public final class BigQueryExecute extends AbstractBigQueryAction {
 
     public String getSql() {
       return sql;
+    }
+
+    public Boolean getStoreResults() {
+      return storeResults == null || storeResults;
     }
 
     public QueryJobConfiguration.Priority getMode() {
@@ -413,6 +427,7 @@ public final class BigQueryExecute extends AbstractBigQueryAction {
       private String dialect;
       private String sql;
       private String mode;
+      private Boolean storeResults;
 
       public Builder setProject(@Nullable String project) {
         this.project = project;
@@ -481,7 +496,8 @@ public final class BigQueryExecute extends AbstractBigQueryAction {
           cmekKey,
           dialect,
           sql,
-          mode
+          mode,
+          storeResults
         );
       }
 

--- a/widgets/BigQueryExecute-action.json
+++ b/widgets/BigQueryExecute-action.json
@@ -67,30 +67,6 @@
           }
         },
         {
-          "widget-type": "textbox",
-          "label": "Dataset Project ID",
-          "name": "datasetProject",
-          "widget-attributes": {
-            "placeholder": "The project in which the dataset specified in the `Dataset Name` is located or should be created. Defaults to the project specified in the Project Id property."
-          }
-        },
-        {
-          "widget-type": "textbox",
-          "label": "Dataset Name",
-          "name": "dataset",
-          "widget-attributes": {
-            "placeholder": "Name of dataset to store the results."
-          }
-        },
-        {
-          "widget-type": "textbox",
-          "label": "Table Name",
-          "name": "table",
-          "widget-attributes": {
-            "placeholder": "Name of table to store the results."
-          }
-        },
-        {
           "name": "useCache",
           "label": "Use Cache",
           "widget-type": "toggle",
@@ -113,6 +89,46 @@
           "widget-attributes": {
             "placeholder": "Location of the job.",
             "default": "US"
+          }
+        },
+        {
+          "widget-type": "toggle",
+          "label": "Store results in a BigQuery Table",
+          "name": "storeResults",
+          "widget-attributes": {
+            "on": {
+              "value": "true",
+              "label": "YES"
+            },
+            "off": {
+              "value": "false",
+              "label": "NO"
+            },
+            "default": "false"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Dataset Project ID",
+          "name": "datasetProject",
+          "widget-attributes": {
+            "placeholder": "The project in which the dataset specified in the `Dataset Name` is located or should be created. Defaults to the project specified in the Project Id property."
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Dataset Name",
+          "name": "dataset",
+          "widget-attributes": {
+            "placeholder": "Name of dataset to store the results."
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Table Name",
+          "name": "table",
+          "widget-attributes": {
+            "placeholder": "Name of table to store the results."
           }
         },
         {
@@ -201,6 +217,30 @@
         {
           "type": "property",
           "name": "serviceAccountJSON"
+        }
+      ]
+    },
+    {
+      "name": "showDestinationTableProperties",
+      "condition": {
+        "expression": "storeResults == true"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "datasetProject"
+        },
+        {
+          "type": "property",
+          "name": "dataset"
+        },
+        {
+          "type": "property",
+          "name": "table"
+        },
+        {
+          "type": "property",
+          "name": "cmekKey"
         }
       ]
     }


### PR DESCRIPTION
[PLUGIN-954](https://cdap.atlassian.net/browse/PLUGIN-954) - Plugin Config Improvement suggested by @bdmogal.
[PLUGIN-1256](https://cdap.atlassian.net/browse/PLUGIN-1256) - Do not set cmek key by default in BQ job in BQ execute plugin because it causes job with ddl statements to fail.