### PR TITLE
[PLUGIN-664] Literally match special regex characters

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketDelete.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketDelete.java
@@ -104,7 +104,7 @@ public final class GCSBucketDelete extends Action {
           String.format("Unable to access or create bucket %s. ", gcsPath.getBucket())
             + "Ensure you entered the correct bucket path and have permissions for it.", e);
       }
-      String regx = (gcsPath.getName()).replace("*", "[^/]*");
+      String regx = ("\\Q" + gcsPath.getName() + "\\E").replace("*", "\\E[^/]*\\Q");
       Page<Blob> blobs = storage.list(gcsPath.getBucket());
       for (Blob blob : blobs.iterateAll()) {
         String currentName = blob.getName();


### PR DESCRIPTION
Jira: https://cdap.atlassian.net/browse/PLUGIN-664
Previous PR: https://github.com/data-integrations/google-cloud/pull/1058

When we have search path: "gs://MY_BUCKET/*.csv", we should delete file such as "gs://MY_BUCKET/file1.csv", but keep the file "gs://MY_BUCKET/file2csv". The updated code will match the special regex character literally. 