### PR TITLE
Fix BigQuerySink test cases

### DIFF
--- a/src/e2e-test/features/bigquery/sink/GCSToBigQuery.feature
+++ b/src/e2e-test/features/bigquery/sink/GCSToBigQuery.feature
@@ -7,8 +7,8 @@ Feature: BigQuery sink - Verification of GCS to BigQuery successful data transfe
     When Source is GCS
     When Sink is BigQuery
     Then Open GCS source properties
-    Then Override Service account details if set in environment variables
     Then Enter the GCS source mandatory properties
+    Then Override Service account details if set in environment variables
     Then Validate "GCS" plugin properties
     Then Close the GCS properties
     Then Open BigQuery sink properties

--- a/src/e2e-test/java/io/cdap/plugin/common/stepsdesign/TestSetupHooks.java
+++ b/src/e2e-test/java/io/cdap/plugin/common/stepsdesign/TestSetupHooks.java
@@ -79,7 +79,7 @@ public class TestSetupHooks {
           }
         if (serviceAccountType.equalsIgnoreCase("JSON")) {
           PluginPropertyUtils.addPluginProp("serviceAccountType", "JSON");
-          String serviceAccountJSON = System.getenv("SERVICE_ACCOUNT_JSON");
+          String serviceAccountJSON = System.getenv("SERVICE_ACCOUNT_JSON").replaceAll("[\r\n]+", " ");
           if (!(serviceAccountJSON == null) && !serviceAccountJSON.equalsIgnoreCase("auto-detect")) {
             PluginPropertyUtils.addPluginProp("serviceAccount", serviceAccountJSON);
           }


### PR DESCRIPTION
**Scenario:Validate successful records transfer from GCS to BigQuery**
The preview failure was caused by format parsing exception:
And exception was related to these [two steps](https://github.com/data-integrations/google-cloud/blob/release/0.20/src/e2e-test/features/bigquery/sink/GCSToBigQuery.feature#L10-L11):
```
Then Enter the GCS source mandatory properties 
Then Override Service account details if set in environment variables
```
Entering the GCS source mandatory properties will trigger the [get schema](https://github.com/data-integrations/google-cloud/blob/b55a3c5dd88f35d7f2d94a4b4c6635293e7031a1/src/e2e-test/java/io/cdap/plugin/gcs/stepsdesign/GCSSource.java#L90). Due to the service account missing, which was setup after this step, the GCS source failed to get the schema and caused the BigQuery table input format to be {offset: int, body: str}, which was inconsistent with the [source of truth](https://github.com/data-integrations/google-cloud/blob/release/0.20/src/e2e-test/resources/testdata/GCS_CSV_TEST.csv).

Fix: Switch the order can fix the issue

**BigQuery source - Verification of BigQuery to GCS successful data transfer with macro arguments**
The service account key is a multiple line json and can mess the runtime arguments if it's not handled correclty.
![image](https://user-images.githubusercontent.com/25891353/173907995-15e02181-163a-4b9d-aae0-96b4a4957bd6.png)
Fix: Parse the service account json into one line.



