### PR TITLE
CDAP-19370 fix gcs and bigquery connector tests

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/connector/BigQueryConnector.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/connector/BigQueryConnector.java
@@ -159,7 +159,8 @@ public final class BigQueryConnector implements DirectConnector {
   private BrowseDetail getTableDetail(BigQuery bigQuery, String datasetProject, String datasetName, String tableName) {
     Table table = getTable(bigQuery, datasetProject, datasetName, tableName);
     return BrowseDetail.builder().addEntity(
-      BrowseEntity.builder(tableName, "/" + datasetName + "/" + tableName, table.getDefinition().getType().name())
+      BrowseEntity.builder(tableName, "/" + datasetName + "/" + tableName,
+                           table.getDefinition().getType().name().toLowerCase())
         .canSample(true).build()).setTotalCount(1).build();
   }
 


### PR DESCRIPTION
Fix the failing gcs connector test. It started to fail due to
changes in the abstract class that it extends. Changed the test
to only check properties set by the GCS connector and not its
base test

Also fixed the BigQuery connector test, which was failing due
to case differences in the entity type (table vs TABLE), and
failing due to sinks and SQL engine being added to the related
plugins.