### PR TITLE
CDAP-19078 update service account loading to use newer libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <avro.version>1.8.2</avro.version>
     <bigquery.connector.hadoop2.version>hadoop2-1.0.0</bigquery.connector.hadoop2.version>
     <commons.codec.version>1.4</commons.codec.version>
-    <cdap.version>6.8.0-SNAPSHOT</cdap.version>
+    <cdap.version>6.7.0</cdap.version>
     <cdap.plugin.version>2.10.0-SNAPSHOT</cdap.plugin.version>
     <dropwizard.metrics-core.version>3.2.6</dropwizard.metrics-core.version>
     <flogger.system.backend.version>0.3.1</flogger.system.backend.version>
@@ -532,6 +532,11 @@
     </dependency>
     <dependency>
       <groupId>com.google.cloud.bigdataoss</groupId>
+      <artifactId>util-hadoop</artifactId>
+      <version>${gcs.connector.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud.bigdataoss</groupId>
       <artifactId>gcs-connector</artifactId>
       <version>${gcs.connector.version}</version>
     </dependency>
@@ -844,8 +849,8 @@
         <version>1.1.0</version>
         <configuration>
           <cdapArtifacts>
-            <parent>system:cdap-data-pipeline[6.7.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
-            <parent>system:cdap-data-streams[6.7.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-pipeline[6.7.1-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-streams[6.7.1-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
           </cdapArtifacts>
         </configuration>
         <executions>

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
@@ -47,7 +47,6 @@ import com.google.cloud.bigquery.FieldList;
 import com.google.cloud.bigquery.JobId;
 import com.google.cloud.bigquery.JobInfo;
 import com.google.cloud.bigquery.QueryJobConfiguration;
-import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.hadoop.io.bigquery.BigQueryConfiguration;
 import com.google.cloud.hadoop.io.bigquery.BigQueryFactory;
@@ -745,17 +744,7 @@ public class BigQueryOutputFormat extends ForwardingBigQueryFileOutputFormat<Str
 
   private static BigQuery getBigQuery(Configuration config) throws IOException {
     String projectId = ConfigurationUtil.getMandatoryConfig(config, BigQueryConfiguration.PROJECT_ID_KEY);
-    String serviceAccount;
-    boolean isServiceAccountFile = GCPUtils.SERVICE_ACCOUNT_TYPE_FILE_PATH
-      .equals(config.get(GCPUtils.SERVICE_ACCOUNT_TYPE));
-    if (isServiceAccountFile) {
-      serviceAccount = config.get(GCPUtils.CLOUD_JSON_KEYFILE, null);
-    } else {
-      serviceAccount = config.get(String.format("%s.%s", GCPUtils.CLOUD_JSON_KEYFILE_PREFIX,
-                                                GCPUtils.CLOUD_ACCOUNT_JSON_SUFFIX));
-    }
-    Credentials credentials = serviceAccount == null ? null :
-      GCPUtils.loadServiceAccountCredentials(serviceAccount, isServiceAccountFile);
+    Credentials credentials = GCPUtils.loadCredentialsFromConf(config);
     return GCPUtils.getBigQuery(projectId, credentials);
   }
 }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQueryFactoryWithScopes.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQueryFactoryWithScopes.java
@@ -21,7 +21,6 @@ import com.google.cloud.hadoop.io.bigquery.BigQueryFactory;
 import com.google.cloud.hadoop.util.AccessTokenProviderClassFromConfigFactory;
 import com.google.cloud.hadoop.util.CredentialFromAccessTokenProviderClassFactory;
 import com.google.cloud.hadoop.util.HadoopCredentialConfiguration;
-import io.cdap.plugin.gcp.common.GCPUtils;
 import org.apache.hadoop.conf.Configuration;
 
 import java.io.IOException;

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
@@ -72,7 +72,6 @@ public final class BigQueryUtil {
   public static final String BUCKET_PATTERN = "[a-z0-9._-]+";
   public static final String DATASET_PATTERN = "[A-Za-z0-9_]+";
   public static final String TABLE_PATTERN = "[A-Za-z0-9_]+";
-  public static final String MAP_REDUCE_JSON_KEY_PREFIX = "mapred.bq";
 
   // array of arrays and map of arrays are not supported by big query
   public static final Set<Schema.Type> UNSUPPORTED_ARRAY_TYPES = ImmutableSet.of(Schema.Type.ARRAY, Schema.Type.MAP);
@@ -150,13 +149,9 @@ public final class BigQueryUtil {
 
     Configuration configuration = job.getConfiguration();
     configuration.clear();
-    if (serviceAccountInfo != null) {
-      final Map<String, String> authProperties = GCPUtils.generateAuthProperties(serviceAccountInfo,
-                                                                                 serviceAccountType,
-                                                                                 MAP_REDUCE_JSON_KEY_PREFIX,
-                                                                                 GCPUtils.CLOUD_JSON_KEYFILE_PREFIX);
-      authProperties.forEach(configuration::set);
-    }
+    Map<String, String> authProperties =
+      GCPUtils.generateBigQueryAuthProperties(serviceAccountInfo, serviceAccountType);
+    authProperties.forEach(configuration::set);
     configuration.set("fs.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem");
     configuration.set("fs.AbstractFileSystem.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS");
     configuration.set("fs.gs.project.id", projectId);

--- a/src/main/java/io/cdap/plugin/gcp/dataplex/common/util/DataplexUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/dataplex/common/util/DataplexUtil.java
@@ -344,7 +344,7 @@ public final class DataplexUtil {
     if (isServiceAccountJson || (filePath != null && !filePath.equalsIgnoreCase(DataplexConstants.NONE))) {
       return GCPUtils.loadServiceAccountCredentials(serviceAccount, !isServiceAccountJson);
     } else {
-      return ServiceAccountCredentials.getApplicationDefault();
+      return GoogleCredentials.getApplicationDefault();
     }
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/gcs/ServiceAccountAccessTokenProvider.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/ServiceAccountAccessTokenProvider.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+package io.cdap.plugin.gcp.gcs;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.hadoop.util.AccessTokenProvider;
+import io.cdap.plugin.gcp.common.GCPUtils;
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Date;
+
+/**
+ * An AccessTokenProvider that uses the newer GoogleCredentials library to get the credentials. This is used instead
+ * of the default GCS implementation that uses the older GoogleCredential library, which does not work with external
+ * service accounts.
+ */
+public class ServiceAccountAccessTokenProvider implements AccessTokenProvider {
+  private Configuration conf;
+  private GoogleCredentials credentials;
+
+  @Override
+  public AccessToken getAccessToken() {
+    try {
+      com.google.auth.oauth2.AccessToken token = getCredentials().getAccessToken();
+      if (token == null || token.getExpirationTime().before(Date.from(Instant.now()))) {
+        refresh();
+        token = getCredentials().getAccessToken();
+      }
+      return new AccessToken(token.getTokenValue(), token.getExpirationTime().getTime());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void refresh() throws IOException {
+    getCredentials().refresh();
+  }
+
+  private GoogleCredentials getCredentials() throws IOException {
+    if (credentials == null) {
+      credentials = GCPUtils.loadCredentialsFromConf(conf);
+    }
+    return credentials;
+  }
+
+  @Override
+  public void setConf(Configuration configuration) {
+    this.conf = configuration;
+  }
+
+  @Override
+  public Configuration getConf() {
+    return conf;
+  }
+}

--- a/src/main/java/io/cdap/plugin/gcp/gcs/StorageClient.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/StorageClient.java
@@ -47,7 +47,7 @@ public class StorageClient {
   private static final Logger LOG = LoggerFactory.getLogger(StorageClient.class);
   private final Storage storage;
 
-  private StorageClient(Storage storage) {
+  public StorageClient(Storage storage) {
     this.storage = storage;
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketCreate.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketCreate.java
@@ -89,10 +89,8 @@ public final class GCSBucketCreate extends Action {
     Credentials credentials = serviceAccount == null ?
       null : GCPUtils.loadServiceAccountCredentials(serviceAccount, isServiceAccountFilePath);
 
-    if (serviceAccount != null) {
-      Map<String, String> map = GCPUtils.generateGCSAuthProperties(serviceAccount, config.getServiceAccountType());
-      map.forEach(configuration::set);
-    }
+    Map<String, String> map = GCPUtils.generateGCSAuthProperties(serviceAccount, config.getServiceAccountType());
+    map.forEach(configuration::set);
 
     configuration.set("fs.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem");
     configuration.set("fs.AbstractFileSystem.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS");

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketCreate.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketCreate.java
@@ -86,12 +86,11 @@ public final class GCSBucketCreate extends Action {
       return;
     }
     String serviceAccount = config.getServiceAccount();
-    ServiceAccountCredentials credentials = serviceAccount == null ?
-                                null : GCPUtils.loadServiceAccountCredentials(serviceAccount, isServiceAccountFilePath);
+    Credentials credentials = serviceAccount == null ?
+      null : GCPUtils.loadServiceAccountCredentials(serviceAccount, isServiceAccountFilePath);
 
     if (serviceAccount != null) {
-      Map<String, String> map = GCPUtils.generateAuthProperties(serviceAccount, config.getServiceAccountType(),
-                                                                GCPUtils.CLOUD_JSON_KEYFILE_PREFIX);
+      Map<String, String> map = GCPUtils.generateGCSAuthProperties(serviceAccount, config.getServiceAccountType());
       map.forEach(configuration::set);
     }
 

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketDelete.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketDelete.java
@@ -17,7 +17,7 @@
 package io.cdap.plugin.gcp.gcs.actions;
 
 import com.google.api.gax.paging.Page;
-import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.auth.Credentials;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
@@ -34,9 +34,7 @@ import io.cdap.plugin.gcp.common.GCPUtils;
 import io.cdap.plugin.gcp.gcs.GCSPath;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.RemoteIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,11 +76,10 @@ public final class GCSBucketDelete extends Action {
       return;
     }
     String serviceAccount = config.getServiceAccount();
-    ServiceAccountCredentials credentials = serviceAccount == null ?
+    Credentials credentials = serviceAccount == null ?
       null : GCPUtils.loadServiceAccountCredentials(serviceAccount, isServiceAccountFilePath);
     if (serviceAccount != null) {
-      Map<String, String> map = GCPUtils.generateAuthProperties(serviceAccount, config.getServiceAccountType(),
-                                                                GCPUtils.CLOUD_JSON_KEYFILE_PREFIX);
+      Map<String, String> map = GCPUtils.generateGCSAuthProperties(serviceAccount, config.getServiceAccountType());
       map.forEach(configuration::set);
     }
     configuration.set("fs.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem");

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketDelete.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketDelete.java
@@ -78,10 +78,8 @@ public final class GCSBucketDelete extends Action {
     String serviceAccount = config.getServiceAccount();
     Credentials credentials = serviceAccount == null ?
       null : GCPUtils.loadServiceAccountCredentials(serviceAccount, isServiceAccountFilePath);
-    if (serviceAccount != null) {
-      Map<String, String> map = GCPUtils.generateGCSAuthProperties(serviceAccount, config.getServiceAccountType());
-      map.forEach(configuration::set);
-    }
+    Map<String, String> map = GCPUtils.generateGCSAuthProperties(serviceAccount, config.getServiceAccountType());
+    map.forEach(configuration::set);
     configuration.set("fs.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem");
     configuration.set("fs.AbstractFileSystem.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS");
     // validate project id availability

--- a/src/test/java/io/cdap/plugin/gcp/gcs/connector/GCSConnectorTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/gcs/connector/GCSConnectorTest.java
@@ -57,7 +57,6 @@ import java.util.Map;
 /**
  * GCS connector test
  * project.id -- the name of the project
- * gcs.bucket -- bucket name, the bucket will get created and deleted after test
  * service.account.file -- path to service account
  */
 public class GCSConnectorTest {
@@ -83,8 +82,7 @@ public class GCSConnectorTest {
     Assume.assumeFalse(String.format(messageTemplate, "project id"), project == null);
     System.setProperty("GCLOUD_PROJECT", project);
 
-    bucket = System.getProperty("gcs.bucket");
-    Assume.assumeFalse(String.format(messageTemplate, "bucket"), bucket == null);
+    bucket = "gcs-connector-test-" + System.currentTimeMillis();
 
     serviceAccountFilePath = System.getProperty("service.account.file");
     Assume.assumeFalse(String.format(messageTemplate, "service account key file"), serviceAccountFilePath == null);
@@ -92,7 +90,7 @@ public class GCSConnectorTest {
     serviceAccountKey = new String(Files.readAllBytes(Paths.get(new File(serviceAccountFilePath).getAbsolutePath())),
                                    StandardCharsets.UTF_8);
     storage = GCPUtils.getStorage(project, GCPUtils.loadServiceAccountCredentials(serviceAccountFilePath));
-    Assume.assumeFalse("The bucket already exists.", storage.get(bucket) != null);
+    Assume.assumeFalse("The test bucket already exists.", storage.get(bucket) != null);
   }
 
   @Before

--- a/src/test/java/io/cdap/plugin/gcp/gcs/connector/GCSConnectorTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/gcs/connector/GCSConnectorTest.java
@@ -89,7 +89,7 @@ public class GCSConnectorTest {
 
     serviceAccountKey = new String(Files.readAllBytes(Paths.get(new File(serviceAccountFilePath).getAbsolutePath())),
                                    StandardCharsets.UTF_8);
-    storage = GCPUtils.getStorage(project, GCPUtils.loadServiceAccountCredentials(serviceAccountFilePath));
+    storage = GCPUtils.getStorage(project, GCPUtils.loadServiceAccountFileCredentials(serviceAccountFilePath));
     Assume.assumeFalse("The test bucket already exists.", storage.get(bucket) != null);
   }
 

--- a/src/test/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSinkTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSinkTest.java
@@ -29,14 +29,14 @@ import javax.annotation.Nullable;
 public class GCSBatchSinkTest {
 
   @Test
-  public void testValidFSProperties() throws NoSuchFieldException {
+  public void testValidFSProperties() {
     GCSBatchSinkConfig config = getBuilder(null).build();
     MockFailureCollector collector = new MockFailureCollector("gcssink");
     config.validate(collector);
     Assert.assertEquals(0, collector.getValidationFailures().size());
   }
 
-  private GCSBatchSinkConfig.Builder getBuilder(@Nullable String fileSystemProperties) throws NoSuchFieldException {
+  private GCSBatchSinkConfig.Builder getBuilder(@Nullable String fileSystemProperties) {
     return GCSBatchSinkConfig.builder()
       .setReferenceName("testref")
       .setGcsPath("gs://test")
@@ -45,7 +45,7 @@ public class GCSBatchSinkTest {
   }
 
   @Test
-  public void testValidFSProperties1() throws NoSuchFieldException {
+  public void testValidFSProperties1() {
     GCSBatchSink.GCSBatchSinkConfig config = getBuilder("{\"key\":\"val\"}").build();
     MockFailureCollector collector = new MockFailureCollector("gcssink");
     config.validate(collector);
@@ -53,7 +53,7 @@ public class GCSBatchSinkTest {
   }
 
   @Test
-  public void testInvalidFSProperties() throws NoSuchFieldException {
+  public void testInvalidFSProperties() {
     GCSBatchSink.GCSBatchSinkConfig config = getBuilder("{\"key\":}").build();
     MockFailureCollector collector = new MockFailureCollector("gcssink");
     config.validate(collector);
@@ -61,7 +61,7 @@ public class GCSBatchSinkTest {
   }
 
   @Test
-  public void testValidContentType() throws Exception {
+  public void testValidContentType() {
     GCSBatchSinkConfig.Builder builder = getBuilder(null);
     GCSBatchSinkConfig config = builder.build();
     MockFailureCollector collector = new MockFailureCollector("gcssink");
@@ -82,7 +82,7 @@ public class GCSBatchSinkTest {
   }
 
   @Test
-  public void testInvalidContentType() throws Exception {
+  public void testInvalidContentType() {
     GCSBatchSinkConfig.Builder builder = getBuilder(null);
     MockFailureCollector collector = new MockFailureCollector("gcssink");
 

--- a/src/test/java/io/cdap/plugin/gcp/gcs/sink/GCSOutputformatProviderTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/gcs/sink/GCSOutputformatProviderTest.java
@@ -92,7 +92,7 @@ public class GCSOutputformatProviderTest {
     Mockito.when(fileOutputCommitter.getCommittedTaskPath(mockContext)).thenReturn(committedTaskPathMock);
     Mockito.when(committedTaskPathMock.toString()).thenReturn("gs://test");
     StorageClient mockStorage = Mockito.mock(StorageClient.class);
-    Mockito.when(committerToTest.getStorageClient(configuration)).thenReturn(mockStorage);
+    Mockito.doReturn(mockStorage).when(committerToTest).getStorageClient(configuration);
 
     committerToTest.commitTask(mockContext);
     Mockito.verify(fileOutputCommitter, Mockito.times(1)).commitTask(mockContext);


### PR DESCRIPTION
Configure the GCS connector to use a custom AccessTokenProvider
that uses the newer Credentials library instead of the default
behavior, which uses the Credential library. This allows the
connector to work with newer service account types, such as the
external_account type.

As part of this, refactoring the util class to clean up the code
and also remove bad assumptions, like the service account will
always be of type 'service_account' and instead let the
GoogleCredentials class look at the type and determine the correct
underlying implementation.

Also removing a bunch of useless constants and property prefixing.