### PR TITLE
add user managed schema option to dataplex sink plugin

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/dataplex/common/util/DataplexConstants.java
+++ b/src/main/java/io/cdap/plugin/gcp/dataplex/common/util/DataplexConstants.java
@@ -30,4 +30,6 @@ public final class DataplexConstants {
   public static final String NONE = "none";
   public static final String BIGQUERY_DATASET_ASSET_TYPE = "BIGQUERY_DATASET";
   public static final String STORAGE_BUCKET_ASSET_TYPE = "STORAGE_BUCKET";
+  public static final String STORAGE_BUCKET_PARTITION_KEY = "ts";
+  public static final String STORAGE_BUCKET_PATH_PREFIX = "gs://";
 }

--- a/src/main/java/io/cdap/plugin/gcp/dataplex/common/util/DataplexUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/dataplex/common/util/DataplexUtil.java
@@ -17,22 +17,31 @@
 package io.cdap.plugin.gcp.dataplex.common.util;
 
 import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.paging.Page;
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.dataplex.v1.DataplexServiceClient;
 import com.google.cloud.dataplex.v1.DataplexServiceSettings;
+import com.google.cloud.dataplex.v1.Entity;
 import com.google.cloud.dataplex.v1.Job;
 import com.google.cloud.dataplex.v1.JobName;
 import com.google.cloud.dataplex.v1.MetadataServiceClient;
 import com.google.cloud.dataplex.v1.MetadataServiceSettings;
+import com.google.cloud.dataplex.v1.Partition;
+import com.google.cloud.dataplex.v1.Schema.Mode;
+import com.google.cloud.dataplex.v1.Schema.PartitionField;
+import com.google.cloud.dataplex.v1.Schema.PartitionStyle;
+import com.google.cloud.dataplex.v1.Schema.SchemaField;
+import com.google.cloud.dataplex.v1.Schema.Type;
 import com.google.cloud.dataplex.v1.TaskName;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Storage;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.data.schema.Schema.LogicalType;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryTypeSize;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;
 import io.cdap.plugin.gcp.common.GCPConnectorConfig;
 import io.cdap.plugin.gcp.common.GCPUtils;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.awaitility.Awaitility;
@@ -43,9 +52,9 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-
 import javax.annotation.Nullable;
 
 /**
@@ -230,8 +239,8 @@ public final class DataplexUtil {
         String error =
           String.format("Entity column '%s' is of unsupported type '%s'.", fieldName, standardType.name());
         String action = String.format("Supported column types are: %s.",
-          BigQueryUtil.BQ_TYPE_MAP.keySet().stream().map(t -> t.getStandardType().name())
-            .collect(Collectors.joining(", ")));
+                                      BigQueryUtil.BQ_TYPE_MAP.keySet().stream().map(t -> t.getStandardType().name())
+                                        .collect(Collectors.joining(", ")));
         if (collector != null) {
           collector.addFailure(error, action);
         } else {
@@ -292,7 +301,7 @@ public final class DataplexUtil {
     try (DataplexServiceClient dataplexServiceClient = DataplexUtil.getDataplexServiceClient(googleCredentials)) {
       DataplexServiceClient.ListJobsPagedResponse
         jobList = dataplexServiceClient.listJobs(TaskName.newBuilder().setProject(projectID).setLake(lake).
-        setLocation(location).setTask(taskId).build());
+                                                   setLocation(location).setTask(taskId).build());
       Job dataplexJob = jobList.iterateAll().iterator().next();
       try {
         Awaitility.await()
@@ -302,7 +311,7 @@ public final class DataplexUtil {
           .until(() -> {
             Job currentJob =
               dataplexServiceClient.getJob(JobName.newBuilder().setProject(projectID).setLocation(location)
-                .setLake(lake).setTask(taskId).setJob(dataplexJob.getUid()).build());
+                                             .setLake(lake).setTask(taskId).setJob(dataplexJob.getUid()).build());
             LOG.debug("State of the Job is still " + currentJob.getState());
             return currentJob.getState() != null && !Job.State.RUNNING.equals(currentJob.getState()) &&
               !Job.State.STATE_UNSPECIFIED.equals(currentJob.getState());
@@ -311,7 +320,8 @@ public final class DataplexUtil {
         throw new IOException("Job timed out.", e);
       }
       Job completedJob = dataplexServiceClient.getJob(JobName.newBuilder().setProject(projectID).setLocation(location)
-        .setLake(lake).setTask(taskId).setJob(dataplexJob.getUid()).build());
+                                                        .setLake(lake).setTask(taskId).setJob(dataplexJob.getUid())
+                                                        .build());
       if (!Job.State.SUCCEEDED.equals(completedJob.getState())) {
         throw new IOException("Job failed with message: " + completedJob.getMessage());
       }
@@ -392,4 +402,243 @@ public final class DataplexUtil {
     return metadataServiceClient;
   }
 
+  /**
+   * Get storage format for entity data.
+   *
+   * @param format
+   */
+  public static String getStorageFormatForEntity(String format) {
+    switch (format) {
+      case "avro":
+        return "application/x-avro";
+      case "csv":
+        return "text/csv";
+      case "json":
+        return "application/json";
+      case "orc":
+        return "application/x-orc";
+      case "parquet":
+        return "application/x-parquet";
+      default:
+        return "undefined";
+    }
+
+  }
+
+  /**
+   * Return Dataplex Schema from CDAP Schema.
+   *
+   * @param schema input schema from cdap
+   * @return MetadataServiceClient
+   */
+  public static com.google.cloud.dataplex.v1.Schema getDataplexSchema(Schema schema) throws IOException {
+    com.google.cloud.dataplex.v1.Schema.Builder dataplexSchemaBuilder =
+      com.google.cloud.dataplex.v1.Schema.newBuilder();
+    dataplexSchemaBuilder.setUserManaged(true);
+    if (schema == null) {
+      return dataplexSchemaBuilder.build();
+    }
+    // Since "ts" is used by dataplex sink to create time partitioned layout on GCS, we should remove any
+    // existing columns named "ts" to avoid conflict.
+    dataplexSchemaBuilder.addAllFields(Objects.requireNonNull(schema.getFields()).stream()
+      .filter(avroField -> !avroField.getName().equals(DataplexConstants.STORAGE_BUCKET_PARTITION_KEY))
+      .map(DataplexUtil::toDataplexSchemaField).collect(Collectors.toList()));
+    // Add partitioning scheme to the schema
+    Schema.Field partitionField = Schema.Field.of(DataplexConstants.STORAGE_BUCKET_PARTITION_KEY, schema);
+    dataplexSchemaBuilder.setPartitionStyle(PartitionStyle.HIVE_COMPATIBLE);
+    dataplexSchemaBuilder.addPartitionFields(toDataplexPartitionField(partitionField));
+    return dataplexSchemaBuilder.build();
+  }
+
+  private static SchemaField toDataplexSchemaField(
+    Schema.Field avroField) {
+    SchemaField.Builder fieldBuilder = SchemaField.newBuilder();
+    fieldBuilder.setName(avroField.getName());
+    fieldBuilder.setType(dataplexFieldType(avroField));
+    fieldBuilder.setMode(dataplexFieldMode(avroField));
+    if (avroField.getSchema().getType() == Schema.Type.RECORD) {
+      // Handle nested records. Filtering "ts" column for the same reason in getDataplexSchema
+      fieldBuilder.addAllFields(avroField.getSchema().getFields().stream()
+        .filter(schemaField -> !schemaField.getName().equals(DataplexConstants.STORAGE_BUCKET_PARTITION_KEY))
+        .map(DataplexUtil::toDataplexSchemaField).collect(Collectors.toList()));
+    }
+    return fieldBuilder.build();
+  }
+
+  private static PartitionField toDataplexPartitionField(
+    Schema.Field avroField) {
+    PartitionField.Builder partitionFieldBuilder = PartitionField.newBuilder();
+    partitionFieldBuilder.setName(avroField.getName());
+    // Dataplex supports only partition field type of String for files on GCS.
+    partitionFieldBuilder.setType(Type.STRING);
+    return partitionFieldBuilder.build();
+}
+
+  private static Mode dataplexFieldMode(Schema.Field field) {
+    /*
+     Field modes supported by Dataplex:
+
+     MODE_UNSPECIFIED: Mode unspecified.
+     REQUIRED: The field has required semantics.
+     NULLABLE: The field has optional semantics, and may be null.
+     REPEATED: The field has repeated (0 or more) semantics, and is a list of values.
+    */
+
+    Schema.Type type = field.getSchema().getType();
+    if (type == Schema.Type.ARRAY) {
+      return Mode.REPEATED;
+    } else if (type == Schema.Type.UNION) {
+      for (Schema innerSchema : field.getSchema().getUnionSchemas()) {
+        if (innerSchema.getType() == Schema.Type.NULL) {
+          return Mode.NULLABLE;
+        }
+      }
+    }
+    return Mode.REQUIRED;
+  }
+
+  private static Type dataplexFieldType(Schema.Field field) {
+    /*
+    Field types supported by Dataplex:
+
+    TYPE_UNSPECIFIED SchemaType unspecified.
+    BOOLEAN: Boolean field.
+    BYTE: Single byte numeric field.
+    INT16: 16-bit numeric field.
+    INT32: 32-bit numeric field.
+    INT64: 64-bit numeric field.
+    FLOAT: Floating point numeric field.
+    DOUBLE: Double precision numeric field.
+    DECIMAL: Real value numeric field.
+    STRING: Sequence of characters field.
+    BINARY: Sequence of bytes field.
+    TIMESTAMP: Date and time field.
+    DATE: Date field.
+    TIME: Time field.
+    RECORD: Structured field. Nested fields that define the structure of the map. 
+                      If all nested fields are nullable, this field represents a union.
+    NULL: Null field that does not have values.
+    */
+
+    Schema schema = field.getSchema();
+
+    if (schema.getType() == Schema.Type.UNION) {
+      // Special case for UNION: a union of ["null", "non-null type"] means this is a
+      // nullable field. In Dataplex this will be a field with Mode = NULLABLE and Type = <non-null
+      // type>. So here we have to return the type of the other, non-NULL, element.
+      // A union of 3+ elements is not supported (can't be represented as a Dataplex type).
+      if (schema.isNullable()) {
+        return dataplexPrimitiveFieldType(schema.getNonNullable());
+      }
+      return Type.TYPE_UNSPECIFIED;
+    }
+
+    if (schema.getType() == Schema.Type.ARRAY) {
+      // Special case for ARRAY: check the type of the underlying elements.
+      // In Dataplex this will be a field with Mode = REPEATED and Type = <array element type>.
+      return dataplexPrimitiveFieldType(schema.getComponentSchema());
+    }
+
+    return dataplexPrimitiveFieldType(schema);
+  }
+
+  private static Type dataplexPrimitiveFieldType(Schema schema) {
+    if (schema.getLogicalType() != null) {
+      Type type = dataplexLogicalFieldType(schema);
+      if (type != null) {
+        return type;
+      }
+    }
+
+    Schema.Type avroType = schema.getType();
+    switch (avroType) {
+      case RECORD:
+        return Type.RECORD;
+      case STRING:
+        return Type.STRING;
+      case FLOAT:
+        return Type.FLOAT;
+      case DOUBLE:
+        return Type.DOUBLE;
+      case BOOLEAN:
+        return Type.BOOLEAN;
+      case NULL:
+        return Type.NULL;
+      case BYTES: // BYTES is binary data with variable size.
+        return Type.BINARY;
+      case INT:
+        return Type.INT32;
+      case LONG:
+        return Type.INT64;
+      case UNION: // Shouldn't happen. Unions can not contain other unions as per Avro spec.
+      case ARRAY: // Not supported as a primitive type (e.g. if this is an ARRAY of ARRAYs).
+      case MAP:
+      case ENUM:
+      default:
+        return Type.TYPE_UNSPECIFIED;
+    }
+  }
+
+  private static Type dataplexLogicalFieldType(Schema schema) {
+    LogicalType logicalType = schema.getLogicalType();
+
+    if (logicalType == LogicalType.DECIMAL) {
+      return Type.DECIMAL;
+    } else if (logicalType == LogicalType.DATE) {
+      return Type.DATE;
+    } else if (logicalType == LogicalType.TIME_MICROS
+      || logicalType == LogicalType.TIME_MILLIS) {
+      return Type.TIME;
+    } else if (logicalType == LogicalType.TIMESTAMP_MICROS
+      || logicalType == LogicalType.TIMESTAMP_MILLIS) {
+      return Type.TIMESTAMP;
+    }
+
+    return null;
+  }
+
+  /**
+   * Add partition info to dataplex entity.
+   *
+   * @param entity dataplex entity
+   * @param credentials Google Credentials
+   * @param bucketName
+   * @param tableName
+   * @param project
+   * @throws IOException
+   */
+  public static void addPartitionInfo(Entity entity,
+                                      GoogleCredentials credentials,
+                                      String bucketName, String tableName, String project) throws IOException {
+    Storage storage = GCPUtils.getStorage(project, credentials);
+    String delimiter = "/";
+    String partitionPrefix = DataplexConstants.STORAGE_BUCKET_PARTITION_KEY + "=";
+    Page<Blob> blobs =
+      storage.list(
+        bucketName,
+        Storage.BlobListOption.prefix(tableName + delimiter + partitionPrefix),
+        Storage.BlobListOption.currentDirectory());
+    String lastPartition = null;
+    // blob name example: bq_source_2/ts=2022-08-22-21-52/
+    // Get the last blob's name in the iterator as it is the one that corresponds to the entity that was just
+    // created/updated.
+    for (Blob blob : blobs.iterateAll()) {
+      lastPartition = blob.getName();
+    }
+    // Remove the delimiter from the end of the blob name for creating location string
+    String location = DataplexConstants.STORAGE_BUCKET_PATH_PREFIX + bucketName +
+      delimiter + lastPartition.substring(0, lastPartition.length() - 1);
+    String[] lastPartitionParts = lastPartition.split(delimiter);
+    Partition.Builder dataplexPartitionBuilder =
+      Partition.newBuilder();
+    try (MetadataServiceClient metadataServiceClient =
+           getMetadataServiceClient(credentials)) {
+      Partition partition = dataplexPartitionBuilder
+        .setLocation(location)
+        //extract the date value from blob name (e.g., 2022-08-22-21-52) to pass as partition value
+        .addValues(lastPartitionParts[lastPartitionParts.length - 1].substring(partitionPrefix.length()))
+        .build();
+        metadataServiceClient.createPartition(entity.getName(), partition);
+    }
+  }
 }

--- a/src/main/java/io/cdap/plugin/gcp/dataplex/sink/config/DataplexBatchSinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/dataplex/sink/config/DataplexBatchSinkConfig.java
@@ -87,6 +87,7 @@ public class DataplexBatchSinkConfig extends DataplexBaseConfig {
   private static final String NAME_PARTITION_FILTER = "partitionFilter";
   private static final String NAME_PARTITIONING_TYPE = "partitioningType";
   private static final String NAME_TRUNCATE_TABLE = "truncateTable";
+  private static final String NAME_UPDATE_DATAPLEX_METADATA = "updateDataplexMetadata";
   private static final String NAME_UPDATE_SCHEMA = "allowSchemaRelaxation";
   private static final String NAME_PARTITION_BY_FIELD = "partitionField";
   private static final String NAME_REQUIRE_PARTITION_FIELD = "requirePartitionField";
@@ -205,6 +206,14 @@ public class DataplexBatchSinkConfig extends DataplexBaseConfig {
     "operation.")
   protected Boolean truncateTable;
 
+  @Name(NAME_UPDATE_DATAPLEX_METADATA)
+  @Nullable
+  @Macro
+  @Description("Whether to update Dataplex metadata for the newly created entities." + 
+    "If enabled, the pipeline will automatically copy the output schema to the destination " + 
+    "Dataplex entities, and the automated Dataplex Discovery won't run for them.")
+  protected Boolean updateDataplexMetadata;
+
   @Name(NAME_UPDATE_SCHEMA)
   @Nullable
   @Macro
@@ -257,6 +266,11 @@ public class DataplexBatchSinkConfig extends DataplexBaseConfig {
   @Nullable
   public FileFormat getFormat() {
     return FileFormat.from(format, FileFormat::canWrite);
+  }
+
+  @Nullable
+  public String getFormatStr() {
+    return format;
   }
 
   @Nullable
@@ -321,6 +335,11 @@ public class DataplexBatchSinkConfig extends DataplexBaseConfig {
   public JobInfo.WriteDisposition getWriteDisposition() {
     return isTruncateTable() ? JobInfo.WriteDisposition.WRITE_TRUNCATE
       : JobInfo.WriteDisposition.WRITE_APPEND;
+  }
+
+  @Nullable
+  public Boolean isUpdateDataplexMetadata() {
+    return updateDataplexMetadata != null && updateDataplexMetadata;
   }
 
   @Nullable
@@ -944,7 +963,6 @@ public class DataplexBatchSinkConfig extends DataplexBaseConfig {
     }
   }
 
-
   /*  This method gets the value of content type. Valid content types for each format are:
    *
    *  avro -> application/avro, application/octet-stream
@@ -966,10 +984,10 @@ public class DataplexBatchSinkConfig extends DataplexBaseConfig {
                                   @Nullable String operation, @Nullable String partitionFilter,
                                   @Nullable String partitioningType, @Nullable Long rangeStart,
                                   @Nullable Long rangeEnd, @Nullable Long rangeInterval,
-                                  @Nullable Boolean truncateTable, @Nullable Boolean allowSchemaRelaxation,
-                                  @Nullable String partitionByField, @Nullable Boolean requirePartitionField,
-                                  @Nullable String clusteringOrder, @Nullable String suffix,
-                                  @Nullable String schema) {
+                                  @Nullable Boolean truncateTable, @Nullable Boolean updateDataplexMetadata, 
+                                  @Nullable Boolean allowSchemaRelaxation, @Nullable String partitionByField,
+                                  @Nullable Boolean requirePartitionField, @Nullable String clusteringOrder, 
+                                  @Nullable String suffix, @Nullable String schema) {
     this.referenceName = referenceName;
     this.connection = connection;
     this.location = location;
@@ -988,6 +1006,7 @@ public class DataplexBatchSinkConfig extends DataplexBaseConfig {
     this.rangeEnd = rangeEnd;
     this.rangeInterval = rangeInterval;
     this.truncateTable = truncateTable;
+    this.updateDataplexMetadata = updateDataplexMetadata;
     this.allowSchemaRelaxation = allowSchemaRelaxation;
     this.partitionByField = partitionByField;
     this.requirePartitionField = requirePartitionField;
@@ -1018,6 +1037,7 @@ public class DataplexBatchSinkConfig extends DataplexBaseConfig {
     private Long rangeEnd;
     private Long rangeInterval;
     private Boolean truncateTable;
+    private Boolean updateDataplexMetadata;
     private Boolean allowSchemaRelaxation;
     private String partitionByField;
     private Boolean requirePartitionField;
@@ -1095,6 +1115,11 @@ public class DataplexBatchSinkConfig extends DataplexBaseConfig {
       return this;
     }
 
+    public Builder setUpdateDataplexMetadata(Boolean updateDataplexMetadata) {
+      this.updateDataplexMetadata = updateDataplexMetadata;
+      return this;
+    }
+
     public Builder setAllowSchemaRelaxation(Boolean allowSchemaRelaxation) {
       this.allowSchemaRelaxation = allowSchemaRelaxation;
       return this;
@@ -1153,7 +1178,8 @@ public class DataplexBatchSinkConfig extends DataplexBaseConfig {
     public DataplexBatchSinkConfig build() {
       return new DataplexBatchSinkConfig(referenceName, asset, assetType, location, lake, zone, format, connection,
         table, tableKey, dedupeBy, operation, partitionFilter,
-        partitioningType, rangeStart, rangeEnd, rangeInterval, truncateTable, allowSchemaRelaxation, partitionByField,
+        partitioningType, rangeStart, rangeEnd, rangeInterval, truncateTable,
+        updateDataplexMetadata, allowSchemaRelaxation, partitionByField,
         requirePartitionField, clusteringOrder, suffix, schema);
     }
 

--- a/widgets/Dataplex-batchsink.json
+++ b/widgets/Dataplex-batchsink.json
@@ -2,7 +2,7 @@
   "metadata": {
     "spec-version": "1.5"
   },
-  "display-name": "Dataplex (Preview)",
+  "display-name": "Dataplex",
   "configuration-groups": [
     {
       "label": "Basic",
@@ -179,6 +179,22 @@
           }
         },
         {
+          "widget-type": "toggle",
+          "label": "Update Dataplex Metadata",
+          "name": "updateDataplexMetadata",
+          "widget-attributes": {
+            "default": "false",
+            "on": {
+              "value": "true",
+              "label": "True"
+            },
+            "off": {
+              "value": "false",
+              "label": "False"
+            }
+          }
+        },
+        {
           "widget-type": "radio-group",
           "name": "operation",
           "label": "Operation",
@@ -352,6 +368,10 @@
         {
           "type": "property",
           "name": "contentType"
+        },
+        {
+          "type": "property",
+          "name": "updateDataplexMetadata"
         }
       ]
     },

--- a/widgets/Dataplex-batchsource.json
+++ b/widgets/Dataplex-batchsource.json
@@ -2,7 +2,7 @@
   "metadata": {
     "spec-version": "1.5"
   },
-  "display-name": "Dataplex (Preview)",
+  "display-name": "Dataplex",
   "configuration-groups": [
     {
       "label": "Basic",


### PR DESCRIPTION
This PR adds a new config parameter (i.e., `Update Dataplex Metadata`) to dataplex sink plugin which adds support for updating metadata in dataplex for newly generated data.

JIRA: [PLUGIN-1379](https://cdap.atlassian.net/browse/PLUGIN-1379)