### PR TITLE
Updated BigQuery table name validation to work with all valid characters

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/spanner/connector/SpannerPath.java
+++ b/src/main/java/io/cdap/plugin/gcp/spanner/connector/SpannerPath.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.gcp.spanner.connector;
 
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 /**
@@ -26,7 +27,7 @@ public class SpannerPath {
   private String database;
   private String table;
   private static final int NAME_MAX_LENGTH = 1024;
-  private static final String VALID_NAME_REGEX = "[\\w-]+";
+  private static final Pattern VALID_NAME_REGEX = Pattern.compile("[\\w-]+");
 
   public SpannerPath(String path) {
     parsePath(path);
@@ -88,7 +89,7 @@ public class SpannerPath {
       throw new IllegalArgumentException(
         String.format("%s is invalid, it should contain at most %d characters.", property, NAME_MAX_LENGTH));
     }
-    if (!name.matches(VALID_NAME_REGEX)) {
+    if (!VALID_NAME_REGEX.matcher(name).matches()) {
       throw new IllegalArgumentException(
         String.format("%s is invalid, it should contain only letters, numbers, and underscores.", property));
     }

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/connector/BigQueryPathTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/connector/BigQueryPathTest.java
@@ -53,6 +53,26 @@ public class BigQueryPathTest {
     path = new BigQueryPath("/dataset/table/");
     Assert.assertEquals("dataset", path.getDataset());
     Assert.assertEquals("table", path.getTable());
+
+    //table path with space
+    path = new BigQueryPath("/dataset/table 01");
+    Assert.assertEquals("dataset", path.getDataset());
+    Assert.assertEquals("table 01", path.getTable());
+
+    //table path with foreign characters
+    path = new BigQueryPath("/dataset/ग्राहक");
+    Assert.assertEquals("dataset", path.getDataset());
+    Assert.assertEquals("ग्राहक", path.getTable());
+
+    //table path with foreign characters
+    path = new BigQueryPath("/dataset/00_お客様");
+    Assert.assertEquals("dataset", path.getDataset());
+    Assert.assertEquals("00_お客様", path.getTable());
+
+    //table path with an accent and a dash
+    path = new BigQueryPath("/dataset/étudiant-01");
+    Assert.assertEquals("dataset", path.getDataset());
+    Assert.assertEquals("étudiant-01", path.getTable());
   }
 
 
@@ -87,7 +107,8 @@ public class BigQueryPathTest {
       () -> new BigQueryPath("/b/" + Strings.repeat('a', 1025)));
 
     //table contains invalid character
-    Assert.assertThrows("Dataset is invalid, it should contain only letters, numbers, and underscores.",
+    Assert.assertThrows("Dataset is invalid, it should only contain Unicode characters in category " +
+                    "L (letter), M (mark), N (number), Pc (connector, including underscore), Pd (dash), Zs (space).",
       IllegalArgumentException.class, () -> new BigQueryPath("/a/%"));
   }
 }


### PR DESCRIPTION
Previously, BigQuery table names could only contain letters, numbers, and underscores. The valid character set has since been expanded ([reference](https://cloud.google.com/bigquery/docs/tables#table_naming)), so certain valid BigQuery tables currently cannot be imported into CDAP (such as if their name contains a hyphen).

This PR fixes this issue by updating the regex used to validate table names. I also added relevant unit tests.

Fixes Jira issue [PLUGIN-1325](https://cdap.atlassian.net/browse/PLUGIN-1325).

[PR #172](https://github.com/data-integrations/bigquery-delta-plugins/pull/172) in `bigquery-delta-plugins` is related.