### PR TITLE
[PLUGIN-1291] Support GCS Delete Action in multiple Buckets

### DIFF
--- a/src/e2e-test/features/gcsdelete/GCSDelete.feature
+++ b/src/e2e-test/features/gcsdelete/GCSDelete.feature
@@ -112,6 +112,44 @@ Feature: GCS Delete - Verification of GCS Delete plugin
     Then Verify multiple objects "gcsDeleteObjectsList3" deleted successfully by GCS Delete action plugin
     Then Verify objects "gcsKeepObjectsList2" still exist after GCS Delete action plugin
 
+  @GCS_DELETE_MULTIPLE_BUCKETS_TEST
+  Scenario: Verify the GCS Delete successfully deletes file from multiple buckets
+    Given Open Datafusion Project to configure pipeline
+    When Expand Plugin group in the LHS plugins list: "Conditions and Actions"
+    When Select plugin: "GCS Delete" from the plugins list as: "Conditions and Actions"
+    When Navigate to the properties page of plugin: "GCS Delete"
+    Then Enter the GCS Delete property projectId "projectId"
+    Then Enter the GCS Delete property objects from multiple Buckets to delete as list of objects "gcsMultiBucketsPath1"
+    Then Override Service account details if set in environment variables
+    Then Validate "GCS Delete" plugin properties
+    Then Close the GCS Delete properties
+    Then Save and Deploy Pipeline
+    Then Run the Pipeline in Runtime
+    Then Wait till pipeline is in running state
+    Then Open and capture logs
+    Then Verify the pipeline status is "Succeeded"
+    Then Verify multiple objects "gcsMultiBucketsPath1" from multiple Buckets deleted successfully by GCS Delete action plugin
+    Then Verify objects "gcsKeepMultiBucketsPath1" from multiple Buckets still exist after GCS Delete action plugin
+
+  @GCS_DELETE_MULTIPLE_BUCKETS_TEST
+  Scenario: Verify the GCS Delete successfully deletes file from multiple buckets use wildcard
+    Given Open Datafusion Project to configure pipeline
+    When Expand Plugin group in the LHS plugins list: "Conditions and Actions"
+    When Select plugin: "GCS Delete" from the plugins list as: "Conditions and Actions"
+    When Navigate to the properties page of plugin: "GCS Delete"
+    Then Enter the GCS Delete property projectId "projectId"
+    Then Enter the GCS Delete property objects from multiple Buckets to delete as list of objects "gcsWildcardMultiBucketsPath1"
+    Then Override Service account details if set in environment variables
+    Then Validate "GCS Delete" plugin properties
+    Then Close the GCS Delete properties
+    Then Save and Deploy Pipeline
+    Then Run the Pipeline in Runtime
+    Then Wait till pipeline is in running state
+    Then Open and capture logs
+    Then Verify the pipeline status is "Succeeded"
+    Then Verify multiple objects "gcsDeleteWildcardMultiBucketsPath1" from multiple Buckets deleted successfully by GCS Delete action plugin
+    Then Verify objects "gcsKeepWildcardMultiBucketsPath1" from multiple Buckets still exist after GCS Delete action plugin
+
   Scenario:Verify GCS Delete properties validation error for mandatory field Objects to Delete
     Given Open Datafusion Project to configure pipeline
     When Expand Plugin group in the LHS plugins list: "Conditions and Actions"

--- a/src/e2e-test/resources/pluginParameters.properties
+++ b/src/e2e-test/resources/pluginParameters.properties
@@ -41,6 +41,9 @@ gcsCsvRangeFileSchema=[{"key":"Emp_ID","value":"int"},{"key":"First_Name","value
 gcsWildcardPath1=testdata/GCS_WILDCARD_TEST/*.csv
 gcsWildcardPath2=testdata/GCS_WILDCARD_TEST/wildcard*
 gcsWildcardPath3=testdata/GCS_WILDCARD_TEST/test*
+gcsWildcardMultiBucketsPath1=testdata/GCS_RECURSIVE_TEST/*.csv;\
+  testdata/GCS_RECURSIVE_TEST/recursiveFile2*
+
 gcsOverrideField=id
 gcsInvalidOverrideField=invalid
 gcsOverrideDataType=float
@@ -114,8 +117,18 @@ pubsubDelimiter=@
 gcsDeleteObjectsList=testdata/GCS_RECURSIVE_TEST/recursiveFile1.csv,testdata/GCS_RECURSIVE_TEST/recursiveFile2.csv
 gcsDeleteObjectsList2=testdata/GCS_WILDCARD_TEST/wildcardFile2.csv,testdata/GCS_WILDCARD_TEST/wildcardFile3.csv
 gcsDeleteObjectsList3=testdata/GCS_WILDCARD_TEST/test
+gcsMultiBucketsPath1=testdata/GCS_RECURSIVE_TEST/recursiveFile1.csv;\
+  testdata/GCS_RECURSIVE_TEST/recursiveFile2.csv,testdata/GCS_RECURSIVE_TEST/recursiveFile3.csv
+gcsDeleteWildcardMultiBucketsPath1=testdata/GCS_RECURSIVE_TEST/recursiveFile1.csv,\
+  testdata/GCS_RECURSIVE_TEST/recursiveFile2.csv,testdata/GCS_RECURSIVE_TEST/recursiveFile3.csv;\
+  testdata/GCS_RECURSIVE_TEST/recursiveFile2.csv
 gcsKeepObjectsList=testdata/GCS_WILDCARD_TEST/test/wildcardFile1.csv
 gcsKeepObjectsList2=testdata/GCS_WILDCARD_TEST/wildcardFile2.csv,testdata/GCS_WILDCARD_TEST/wildcardFile3.csv
+gcsKeepMultiBucketsPath1=testdata/GCS_RECURSIVE_TEST/recursiveFile2.csv,testdata/GCS_RECURSIVE_TEST/recursiveFile3.csv;\
+  testdata/GCS_RECURSIVE_TEST/recursiveFile1.csv
+gcsKeepWildcardMultiBucketsPath1=testdata/GCS_RECURSIVE_TEST/;\
+  testdata/GCS_RECURSIVE_TEST/recursiveFile1.csv,testdata/GCS_RECURSIVE_TEST/recursiveFile3.csv
+bucketNumber = 2
 ## GCSDELETE-PLUGIN-PROPERTIES-END
 
 ## SPANNER-PLUGIN-PROPERTIES-START

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketDelete.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSBucketDelete.java
@@ -114,7 +114,7 @@ public final class GCSBucketDelete extends Action {
     int deleteCount = 0;
     for (Path gcsPath : gcsPaths) {
       try {
-        fs = gcsPaths.get(0).getFileSystem(configuration);
+        fs = gcsPath.getFileSystem(configuration);
       } catch (IOException e) {
         LOG.info("Failed deleting file " + gcsPath.toUri().getPath() + ", " + e.getMessage());
         // no-op.
@@ -135,7 +135,7 @@ public final class GCSBucketDelete extends Action {
     for (GCSPath gcsPath : gcsPathsWild) {
       String regex = ("\\Q" + gcsPath.getUri().toString() + "\\E").replace("*", "\\E[^/]*\\Q") + "(/.*)?";
       try {
-        fs = new Path(gcsPathsWild.get(0).getUri()).getFileSystem(configuration);
+        fs = new Path(gcsPath.getUri()).getFileSystem(configuration);
       } catch (IOException e) {
         LOG.info("Failed deleting file " + gcsPath.getUri().getPath() + ", " + e.getMessage());
         // no-op.


### PR DESCRIPTION
Jira: https://cdap.atlassian.net/browse/PLUGIN-1291

Update GCS Delete Action, support delete file from different buckets.
Support wildcard delete (*) for file/directory
Not support wildcard character in Bucket name.
Add e2e test.