### PR TITLE
e2e tests separate build job per plugin

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,7 +25,6 @@ on:
 jobs:
   build:
     runs-on: k8s-runner-e2e
-
     # We allow builds:
     # 1) When triggered manually
     # 2) When it's a merge into a branch
@@ -37,14 +36,25 @@ jobs:
       github.event_name == 'workflow_dispatch'
       || github.event_name == 'push'
       || (contains(github.event.pull_request.labels.*.name, 'build')
-         && (github.event.action != 'labeled' || github.event.label.name == 'build')
-         )
-
+          && (github.event.action != 'labeled' || github.event.label.name == 'build')
+          )
+    strategy:
+      matrix:
+        tests: [bigquery, common, gcs, pubsub, spanner, gcsdelete, gcsmove]
+      fail-fast: false
     steps:
       # Pinned 1.0.0 version
       - uses: actions/checkout@v2.3.4
         with:
           path: plugin
+      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
+        if: github.event_name != 'workflow_dispatch' && github.event_name != 'push'
+        id: filter
+        with:
+          working-directory: plugin
+          filters: |
+            e2e-test:
+              - '**/e2e-test/**'
       - name: Checkout e2e test repo
         uses: actions/checkout@v2.3.4
         with:
@@ -58,22 +68,22 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-${{ github.workflow }}
       - name: Run required e2e tests
-        if: github.event_name != 'workflow_dispatch' && github.event_name != 'push'
-        run: python3 e2e/src/main/scripts/run_e2e_test.py --testRunner TestRunnerRequired.java
+        if: github.event_name != 'workflow_dispatch' && github.event_name != 'push' && steps.filter.outputs.e2e-test == 'false'
+        run: python3 e2e/src/main/scripts/run_e2e_test.py --testRunner **/${{ matrix.tests }}/**/TestRunnerRequired.java
       - name: Run all e2e tests
-        if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
-        run: python3 e2e/src/main/scripts/run_e2e_test.py
+        if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || steps.filter.outputs.e2e-test == 'true'
+        run: python3 e2e/src/main/scripts/run_e2e_test.py --testRunner **/${{ matrix.tests }}/**/TestRunner.java
       - name: Upload report 
         uses: actions/upload-artifact@v2.2.4
         if: always()
         with:
-          name: Cucumber report
+          name: Cucumber report - ${{ matrix.tests }}
           path: ./plugin/target/cucumber-reports
       - name: Upload debug files 
         uses: actions/upload-artifact@v2.2.4
         if: always()
         with:
-          name: Debug files
+          name: Debug files - ${{ matrix.tests }}
           path: ./**/target/e2e-debug
       - name: Upload files to GCS
         uses: google-github-actions/upload-cloud-storage@v0
@@ -81,12 +91,3 @@ jobs:
         with:
           path: ./plugin/target/cucumber-reports
           destination: e2e-tests-cucumber-reports/${{ github.event.repository.name }}/${{ github.ref }}
-      - name: github-status-action
-        uses: Sibz/github-status-action@67af1f4042a5a790681aad83c44008ca6cfab83d
-        if: always()
-        with:
-          authToken: ${{ secrets.GITHUB_TOKEN }}
-          state: success
-          context: Cucumber report
-          sha: ${{github.event.pull_request.head.sha || github.sha}}
-          

--- a/src/e2e-test/features/gcs/source/GCSSourceError.feature
+++ b/src/e2e-test/features/gcs/source/GCSSourceError.feature
@@ -49,7 +49,7 @@ Feature: GCS source - Verify GCS Source plugin error scenarios
     Then Verify get schema fails with error
 
   @GCS_CSV_TEST @BQ_SINK_TEST
-  Scenario: To verify Pipeline preview gets failed for incorrect Regex-Path
+  Scenario: To verify schema detection fails for incorrect Regex-Path as input path is not found
     Given Open Datafusion Project to configure pipeline
     When Source is GCS
     When Sink is BigQuery
@@ -61,14 +61,5 @@ Feature: GCS source - Verify GCS Source plugin error scenarios
     Then Select GCS property format "csv"
     Then Enter GCS source property regex path filter "gcsIncorrectRegexPath"
     Then Toggle GCS source property skip header to true
-    Then Validate output schema with expectedSchema "gcsCsvFileSchema"
-    Then Validate "GCS" plugin properties
-    Then Close the GCS properties
-    Then Open BigQuery sink properties
-    Then Override Service account details if set in environment variables
-    Then Enter the BigQuery sink mandatory properties
-    Then Validate "BigQuery" plugin properties
-    Then Close the BigQuery properties
-    Then Save the pipeline
-    Then Preview and run the pipeline
-    Then Verify the preview of pipeline is "failed"
+    Then Click on the Get Schema button
+    Then Verify that the Plugin is displaying an error message: "errorMessageInvalidPath" on the header

--- a/src/e2e-test/features/gcs/source/GCSSourceToBigQuery.feature
+++ b/src/e2e-test/features/gcs/source/GCSSourceToBigQuery.feature
@@ -66,7 +66,7 @@ Feature: GCS source - Verification of GCS to BQ successful data transfer
     Then Get count of no of records transferred to target BigQuery Table
     Then Verify output field "gcsPathField" in target BigQuery table contains path of the source GcsBucket "gcsOutputFieldTestFile"
 
-  @GCS_OUTPUT_FIELD_TEST @BQ_SINK_TEST
+  @GCS_OUTPUT_FIELD_TEST @BQ_SINK_TEST @GCS_Source_Required
   Scenario: To verify Successful GCS to BigQuery data transfer with Datatype override
     Given Open Datafusion Project to configure pipeline
     When Source is GCS

--- a/src/e2e-test/features/gcsdelete/GCSDelete.feature
+++ b/src/e2e-test/features/gcsdelete/GCSDelete.feature
@@ -37,7 +37,7 @@ Feature: GCS Delete - Verification of GCS Delete plugin
     Then Verify the pipeline status is "Succeeded"
     Then Verify objects in the GCS path "gcsCsvFile" deleted successfully by GCS Delete action plugin
 
-  @GCS_READ_RECURSIVE_TEST
+  @GCS_READ_RECURSIVE_TEST @GCSDelete_Required
   Scenario: Verify the GCS Delete successfully deletes multiple objects
     Given Open Datafusion Project to configure pipeline
     When Expand Plugin group in the LHS plugins list: "Conditions and Actions"
@@ -55,7 +55,7 @@ Feature: GCS Delete - Verification of GCS Delete plugin
     Then Verify the pipeline status is "Succeeded"
     Then Verify multiple objects "gcsDeleteObjectsList" deleted successfully by GCS Delete action plugin
 
-  @GCS_DELETE_WILDCARD_TEST
+  @GCS_DELETE_WILDCARD_TEST @GCSDelete_Required
   Scenario: Verify the GCS Delete successfully deletes multiple csv file under current directory
     Given Open Datafusion Project to configure pipeline
     When Expand Plugin group in the LHS plugins list: "Conditions and Actions"
@@ -74,7 +74,7 @@ Feature: GCS Delete - Verification of GCS Delete plugin
     Then Verify multiple objects "gcsDeleteObjectsList2" deleted successfully by GCS Delete action plugin
     Then Verify objects "gcsKeepObjectsList" still exist after GCS Delete action plugin
 
-  @GCS_DELETE_WILDCARD_TEST
+  @GCS_DELETE_WILDCARD_TEST @GCSDelete_Required
   Scenario: Verify the GCS Delete successfully deletes multiple objects with prefix wildcard under current directory
     Given Open Datafusion Project to configure pipeline
     When Expand Plugin group in the LHS plugins list: "Conditions and Actions"

--- a/src/e2e-test/features/gcsmove/GCSMove.feature
+++ b/src/e2e-test/features/gcsmove/GCSMove.feature
@@ -22,7 +22,7 @@ Feature:GCSMove - Verification of successful objects move from one bucket to ano
     Then Validate GCSMove successfully moved object "gcsCsvFile" to destination bucket
     Then Validate the cmek key "cmekGCS" of target GCS bucket if cmek is enabled
 
-  @GCS_READ_RECURSIVE_TEST @GCS_SINK_TEST
+  @GCS_READ_RECURSIVE_TEST @GCS_SINK_TEST @GCSMove_Required
   Scenario:Validate successful move objects from one bucket to another with Move All Subdirectories set to true
     Given Open Datafusion Project to configure pipeline
     When Expand Plugin group in the LHS plugins list: "Conditions and Actions"
@@ -42,7 +42,7 @@ Feature:GCSMove - Verification of successful objects move from one bucket to ano
     Then Verify the pipeline status is "Succeeded"
     Then Validate GCSMove successfully moved object "gcsMoveReadRecursivePath" to destination bucket
 
-  @GCS_READ_RECURSIVE_TEST @GCS_SINK_TEST
+  @GCS_READ_RECURSIVE_TEST @GCS_SINK_TEST @GCSMove_Required
   Scenario:Validate successful move objects from one bucket to another with Move All Subdirectories set to false
     Given Open Datafusion Project to configure pipeline
     When Expand Plugin group in the LHS plugins list: "Conditions and Actions"
@@ -62,7 +62,7 @@ Feature:GCSMove - Verification of successful objects move from one bucket to ano
     Then Verify the pipeline status is "Succeeded"
     Then Validate GCSMove did not move subdirectory "gcsMoveReadRecursiveSubDirectory" to destination bucket
 
-  @GCS_CSV_TEST @GCS_SINK_EXISTING_BUCKET_TEST
+  @GCS_CSV_TEST @GCS_SINK_EXISTING_BUCKET_TEST @GCSMove_Required
   Scenario:Validate successful move objects from one bucket to another existing bucket with Overwrite Existing Files set to true
     Given Open Datafusion Project to configure pipeline
     When Expand Plugin group in the LHS plugins list: "Conditions and Actions"

--- a/src/e2e-test/features/pubsub/sink/GCSToPubSub.feature
+++ b/src/e2e-test/features/pubsub/sink/GCSToPubSub.feature
@@ -161,7 +161,6 @@ Feature: PubSub-Sink - Verification of GCS to PubSub successful data transfer
     Then Validate OUT record count is equal to IN record count
     Then Open and capture logs
 
-  @PubSub_Sink_Required
   Scenario Outline: To verify data is getting transferred from GCS to PubSub with different file format combination in source and sink
     Given Open Datafusion Project to configure pipeline
     When Source is GCS
@@ -205,7 +204,7 @@ Feature: PubSub-Sink - Verification of GCS to PubSub successful data transfer
     Examples:
       | GcsPath    | SourceFormat | SinkFormat |
       | gcsTsvFile | tsv          | parquet    |
-    @GCS_CSV_TEST
+    @GCS_CSV_TEST @PubSub_Sink_Required
     Examples:
       | GcsPath    | SourceFormat | SinkFormat |
       | gcsCsvFile | csv          | json       |

--- a/src/e2e-test/features/spanner/source/SpannerToSpanner_withConnections.feature
+++ b/src/e2e-test/features/spanner/source/SpannerToSpanner_withConnections.feature
@@ -1,7 +1,7 @@
-@Spanner_Source @SPANNER_TEST @Spanner_Source_Required
+@Spanner_Source @SPANNER_TEST
 Feature: Spanner source - Verification of Spanner to Spanner successful data transfer using connections
 
-  @SPANNER_SOURCE_BASIC_TEST @SPANNER_SINK_TEST @SPANNER_CONNECTION
+  @SPANNER_SOURCE_BASIC_TEST @SPANNER_SINK_TEST @SPANNER_CONNECTION @Spanner_Source_Required
   Scenario: To verify data transfer from Spanner to Spanner with pipeline connection created from wrangler
     Given Open Wrangler connections page
     Then Click plugin property: "addConnection" button
@@ -66,7 +66,7 @@ Feature: Spanner source - Verification of Spanner to Spanner successful data tra
     Then Click plugin property: "Delete" button
     Then Verify connection: "spannerConnectionName" of type: "Spanner" is deleted successfully
 
-  @SPANNER_SINK_TEST @EXISTING_SPANNER_CONNECTION
+  @SPANNER_SINK_TEST @EXISTING_SPANNER_CONNECTION @Spanner_Source_Required
   Scenario: To verify data is getting transferred from Spanner to Spanner with use connection functionality
     Given Open Datafusion Project to configure pipeline
     When Select plugin: "Spanner" from the plugins list as: "Source"

--- a/src/e2e-test/java/io/cdap/plugin/gcs/runners/sourcerunner/TestRunnerRequired.java
+++ b/src/e2e-test/java/io/cdap/plugin/gcs/runners/sourcerunner/TestRunnerRequired.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.gcs.runners.sourcerunner;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+
+/**
+ * Test Runner to execute only required GCS source cases.
+ */
+@RunWith(Cucumber.class)
+@CucumberOptions(
+  features = {"src/e2e-test/features"},
+  glue = {"io.cdap.plugin.gcs.stepsdesign", "io.cdap.plugin.bigquery.stepsdesign",
+    "stepsdesign", "io.cdap.plugin.common.stepsdesign"},
+  tags = {"@GCS_Source_Required"},
+  monochrome = true,
+  plugin = {"pretty", "html:target/cucumber-html-report/gcs-source-required",
+    "json:target/cucumber-reports/cucumber-gcs-source-required.json",
+    "junit:target/cucumber-reports/cucumber-gcs-source-required.xml"}
+)
+public class TestRunnerRequired {
+}

--- a/src/e2e-test/java/io/cdap/plugin/gcsdelete/runners/TestRunnerRequired.java
+++ b/src/e2e-test/java/io/cdap/plugin/gcsdelete/runners/TestRunnerRequired.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.gcsdelete.runners;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+/**
+ * Test Runner to execute only required GCSDelete action cases.
+ */
+@RunWith(Cucumber.class)
+@CucumberOptions(
+  features = {"src/e2e-test/features"},
+  glue = {"io.cdap.plugin.gcsdelete.stepsdesign", "io.cdap.plugin.gcs.stepsdesign", "stepsdesign",
+    "io.cdap.plugin.common.stepsdesign"},
+  tags = {"@GCSDelete_Required"},
+  monochrome = true,
+  plugin = {"pretty", "html:target/cucumber-html-report/gcsdelete-required",
+    "json:target/cucumber-reports/cucumber-gcsdelete-required.json",
+    "junit:target/cucumber-reports/cucumber-gcsdelete-required.xml"}
+)
+public class TestRunnerRequired {
+}

--- a/src/e2e-test/java/io/cdap/plugin/gcsmove/runners/TestRunnerRequired.java
+++ b/src/e2e-test/java/io/cdap/plugin/gcsmove/runners/TestRunnerRequired.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.gcsmove.runners;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+/**
+ * Test Runner to execute only required GCSMove test cases.
+ */
+@RunWith(Cucumber.class)
+@CucumberOptions(
+  features = {"src/e2e-test/features"},
+  glue = {"io.cdap.plugin.gcsmove.stepsdesign", "io.cdap.plugin.gcs.stepsdesign",
+    "stepsdesign", "io.cdap.plugin.common.stepsdesign"},
+  tags = {"@GCSMove_Required"},
+  //TODO: Enable test once issue is fixed https://cdap.atlassian.net/browse/PLUGIN-1134
+  monochrome = true,
+  plugin = {"pretty", "html:target/cucumber-html-report/gcsmove-action-required",
+    "json:target/cucumber-reports/cucumber-gcsmove-action-required.json",
+    "junit:target/cucumber-reports/cucumber-gcsmove-action-required.xml"}
+)
+public class TestRunnerRequired {
+}

--- a/src/e2e-test/resources/errorMessage.properties
+++ b/src/e2e-test/resources/errorMessage.properties
@@ -16,3 +16,4 @@ errorMessagePubSubErrorThreshold=Invalid error threshold for publishing. Ensure 
 errorMessageIncorrectBQChunkSize=Value must be a multiple of 262144.
 errorMessageIncorrectBQBucketName=Bucket name can only contain lowercase letters, numbers, '.', '_', and '-'.
 errorMessageIncorrectBQProperty=PROPERTY name can only contain letters (lower or uppercase), numbers and '_'.
+errorMessageInvalidPath=Error when trying to detect schema: Input path not found


### PR DESCRIPTION
@itsankit-google @rmstar Please review.

This PR contains :

1. Updated e2e tests run condition.
We should run all e2e tests on PR raise, for addition of new test scenarios or updates in existing scenario.

2. When all e2e tests are executed (on PR merge / manual trigger / any change in existing tests) - create separate parallel build jobs to execute all tests per plugin.