### PR TITLE
add fqn to bq plugin

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
@@ -31,6 +31,8 @@ import io.cdap.cdap.etl.api.Emitter;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
+import io.cdap.plugin.common.Asset;
+import io.cdap.plugin.common.ReferenceNames;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryConstants;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryTypeSize;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;
@@ -127,8 +129,8 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, S
    * @param tableSchema table schema
    * @param bucket bucket name
    */
-  protected final void initOutput(BatchSinkContext context, BigQuery bigQuery, String outputName, String tableName,
-                                  @Nullable Schema tableSchema, String bucket,
+  protected final void initOutput(BatchSinkContext context, BigQuery bigQuery, String outputName, String fqn,
+                                  String tableName, @Nullable Schema tableSchema, String bucket,
                                   FailureCollector collector) throws IOException {
     LOG.debug("Init output for table '{}' with schema: {}", tableName, tableSchema);
 
@@ -150,7 +152,8 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, S
     List<String> fieldNames = fields.stream()
       .map(BigQueryTableFieldSchema::getName)
       .collect(Collectors.toList());
-    BigQuerySinkUtils.recordLineage(context, outputName, tableSchema, fieldNames);
+    Asset asset = Asset.builder(outputName).setFqn(fqn).setLocation(getConfig().getLocation()).build();
+    BigQuerySinkUtils.recordLineage(context, asset, tableSchema, fieldNames);
     context.addOutput(Output.of(outputName, getOutputFormatProvider(configuration, tableName, tableSchema)));
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
@@ -15,6 +15,7 @@
  */
 package io.cdap.plugin.gcp.bigquery.sink;
 
+import com.google.api.client.util.Strings;
 import com.google.cloud.bigquery.JobInfo;
 import com.google.cloud.kms.v1.CryptoKeyName;
 import com.google.common.collect.ImmutableSet;
@@ -26,6 +27,7 @@ import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.plugin.common.ConfigUtil;
 import io.cdap.plugin.common.Constants;
 import io.cdap.plugin.common.IdUtils;
+import io.cdap.plugin.common.ReferenceNames;
 import io.cdap.plugin.gcp.bigquery.common.BigQueryBaseConfig;
 import io.cdap.plugin.gcp.bigquery.connector.BigQueryConnectorConfig;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;
@@ -51,6 +53,7 @@ public abstract class AbstractBigQuerySinkConfig extends BigQueryBaseConfig {
   private static final String SCHEME = "gs://";
 
   @Name(Constants.Reference.REFERENCE_NAME)
+  @Nullable
   @Description(Constants.Reference.REFERENCE_NAME_DESCRIPTION)
   protected String referenceName;
 
@@ -85,8 +88,11 @@ public abstract class AbstractBigQuerySinkConfig extends BigQueryBaseConfig {
     super(connection, dataset, cmekKey, bucket);
   }
 
+  @Nullable
   public String getReferenceName() {
-    return referenceName;
+    return Strings.isNullOrEmpty(referenceName)
+      ? ReferenceNames.normalizeFqn(BigQueryUtil.getFQN(getDatasetProject(), dataset, getTable()))
+      : referenceName;
   }
 
   @Nullable

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -25,6 +25,7 @@ import com.google.cloud.bigquery.JobId;
 import com.google.cloud.bigquery.JobStatistics;
 import com.google.cloud.bigquery.Table;
 import com.google.cloud.hadoop.io.bigquery.output.BigQueryTableFieldSchema;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import io.cdap.cdap.api.annotation.Description;
@@ -41,6 +42,7 @@ import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.cdap.etl.api.connector.Connector;
 import io.cdap.cdap.etl.api.engine.sql.SQLEngineOutput;
+import io.cdap.plugin.common.ReferenceNames;
 import io.cdap.plugin.gcp.bigquery.connector.BigQueryConnector;
 import io.cdap.plugin.gcp.bigquery.sqlengine.BigQuerySQLEngine;
 import io.cdap.plugin.gcp.bigquery.sqlengine.BigQueryWrite;
@@ -129,7 +131,9 @@ public final class BigQuerySink extends AbstractBigQuerySink {
 
     configureTable(outputSchema);
     configureBigQuerySink();
-    initOutput(context, bigQuery, config.getReferenceName(), config.getTable(), outputSchema, bucket, collector);
+    initOutput(context, bigQuery, config.getReferenceName(),
+               BigQueryUtil.getFQN(config.getDatasetProject(), config.getDataset(), config.getTable()),
+               config.getTable(), outputSchema, bucket, collector);
     initSQLEngineOutput(context, bigQuery, config.getReferenceName(), context.getStageName(), config.getTable(),
                         outputSchema, collector);
   }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
@@ -171,10 +171,9 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
   protected String partitionFilter;
 
   @VisibleForTesting
-  public BigQuerySinkConfig(String referenceName, String dataset, String table,
-                            @Nullable String bucket, @Nullable String schema, @Nullable String partitioningType,
-                            @Nullable Long rangeStart, @Nullable Long rangeEnd, @Nullable Long rangeInterval,
-                            @Nullable String gcsChunkSize) {
+  public BigQuerySinkConfig(@Nullable String referenceName, String dataset, String table, @Nullable String bucket,
+                            @Nullable String schema, @Nullable String partitioningType, @Nullable Long rangeStart,
+                            @Nullable Long rangeEnd, @Nullable Long rangeInterval, @Nullable String gcsChunkSize) {
     super(null, dataset, null, bucket);
     this.referenceName = referenceName;
     this.table = table;
@@ -187,9 +186,10 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
   }
 
   private BigQuerySinkConfig(@Nullable String referenceName, @Nullable String project,
-                            @Nullable String serviceAccountType, @Nullable String serviceFilePath,
-                            @Nullable String serviceAccountJson, @Nullable String dataset, @Nullable String table,
-                            @Nullable String location, @Nullable String cmekKey, @Nullable String bucket) {
+                             @Nullable String serviceAccountType, @Nullable String serviceFilePath,
+                             @Nullable String serviceAccountJson,
+                             @Nullable String dataset, @Nullable String table, @Nullable String location,
+                             @Nullable String cmekKey, @Nullable String bucket) {
     super(new BigQueryConnectorConfig(project, project, serviceAccountType,
             serviceFilePath, serviceAccountJson), dataset, cmekKey, bucket);
     this.referenceName = referenceName;

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
@@ -41,6 +41,7 @@ import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.cdap.etl.api.validation.ValidationFailure;
+import io.cdap.plugin.common.Asset;
 import io.cdap.plugin.common.LineageRecorder;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryConstants;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryTypeSize.Numeric;
@@ -855,15 +856,15 @@ public final class BigQuerySinkUtils {
   /**
    * Record the lineage for the plugin
    * @param context       Batch sink context
-   * @param outputName    output name
+   * @param asset         asset object of table
    * @param tableSchema   schema of table
    * @param fieldNames    field list
    */
   public static void recordLineage(BatchSinkContext context,
-                                   String outputName,
+                                   Asset asset,
                                    Schema tableSchema,
                                    List<String> fieldNames) {
-    LineageRecorder lineageRecorder = new LineageRecorder(context, outputName);
+    LineageRecorder lineageRecorder = new LineageRecorder(context, asset);
     lineageRecorder.createExternalDataset(tableSchema);
     if (!fieldNames.isEmpty()) {
       lineageRecorder.recordWrite("Write", "Wrote to BigQuery table.", fieldNames);

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
@@ -45,4 +45,5 @@ public interface BigQueryConstants {
   String CONFIG_PARTITION_INTEGER_RANGE_INTERVAL = "cdap.bq.sink.partition.integer.range.interval";
   String CONFIG_TEMPORARY_TABLE_NAME = "cdap.bq.source.temporary.table.name";
   String CDAP_BQ_SINK_OUTPUT_SCHEMA = "cdap.bq.sink.output.schema";
+  String BQ_FQN_PREFIX = "bigquery";
 }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
@@ -759,4 +759,17 @@ public final class BigQueryUtil {
     }
     return timePartitionCondition.toString();
   }
+
+  /**
+   * Get fully-qualified name (FQN) for a BQ table (FQN format: bigquery:{projectId}.{datasetId}.{tableId}).
+   *
+   * @param datasetProject Name of the BQ project
+   * @param datasetName    Name of the BQ dataset
+   * @param tableName      Name of the BQ table
+   * @return String fqn
+   */
+  public static String getFQN(String datasetProject, String datasetName, String tableName) {
+    return String.join(":", BigQueryConstants.BQ_FQN_PREFIX,
+                       datasetProject, datasetName, tableName);
+  }
 }


### PR DESCRIPTION
This PR adds FQN to the BigQuery plugin code.

Jira: [CDAP-19520](https://cdap.atlassian.net/browse/CDAP-19520)

Field-level lineage API output:

```json
{
  "direction": "BOTH",
  "start-ts": 0,
  "end-ts": 1661275067000,
  "entityId": {
    "dataset": "bigquery:mehrdadcdfsandbox:demo:incident",
    "namespace": "default",
    "entity": "DATASET"
  },
  "fields": [ ... ]
  ],
  "incoming": [],
  "outgoing": [
    {
      "entityId": {
        "dataset": "bigquery:mehrdadcdfsandbox:demo:incident_6",
        "namespace": "default",
        "entity": "DATASET"
      },
      "fieldCount": 88,
      "relations": [ ...]
    },
    {
      "entityId": {
        "dataset": "bigquery:mehrdadcdfsandbox:demo:incident_5",
        "namespace": "default",
        "entity": "DATASET"
      },
      "fieldCount": 88,
      "relations": [ ... ]
    }
  ]
}
```