### PR TITLE
add FQN to Dataplex

### DIFF
--- a/src/e2e-test/java/io/cdap/plugin/bigquery/stepsdesign/BigQuerySink.java
+++ b/src/e2e-test/java/io/cdap/plugin/bigquery/stepsdesign/BigQuerySink.java
@@ -35,7 +35,7 @@ public class BigQuerySink implements E2EHelper {
 
   @When("Sink is BigQuery")
   public void sinkIsBigQuery() {
-    CdfStudioActions.clickSink();
+    CdfStudioActions.expandPluginGroupIfNotAlreadyExpanded("Sink");
     selectSinkPlugin("BigQueryTable");
   }
 

--- a/src/e2e-test/java/io/cdap/plugin/gcs/stepsdesign/GCSSink.java
+++ b/src/e2e-test/java/io/cdap/plugin/gcs/stepsdesign/GCSSink.java
@@ -37,7 +37,7 @@ public class GCSSink implements E2EHelper {
 
   @When("Sink is GCS")
   public void sinkIsGCS() {
-    CdfStudioActions.clickSink();
+    CdfStudioActions.expandPluginGroupIfNotAlreadyExpanded("Sink");
     selectSinkPlugin("GCS");
   }
 

--- a/src/e2e-test/java/io/cdap/plugin/pubsub/stepsdesign/PubSubSink.java
+++ b/src/e2e-test/java/io/cdap/plugin/pubsub/stepsdesign/PubSubSink.java
@@ -43,7 +43,7 @@ public class PubSubSink implements E2EHelper {
 
   @When("Sink is PubSub")
   public void sinkIsPubSub() {
-    CdfStudioActions.clickSink();
+    CdfStudioActions.expandPluginGroupIfNotAlreadyExpanded("Sink");
     selectSinkPlugin("GooglePublisher");
   }
 

--- a/src/e2e-test/java/io/cdap/plugin/spanner/stepsdesign/SpannerSink.java
+++ b/src/e2e-test/java/io/cdap/plugin/spanner/stepsdesign/SpannerSink.java
@@ -33,7 +33,7 @@ public class SpannerSink implements CdfHelper {
 
   @When("Sink is Spanner")
   public void sinkIsSpanner() {
-    CdfStudioActions.clickSink();
+    CdfStudioActions.expandPluginGroupIfNotAlreadyExpanded("Sink");
     selectSinkPlugin("Spanner");
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/dataplex/common/config/DataplexBaseConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/dataplex/common/config/DataplexBaseConfig.java
@@ -21,11 +21,13 @@ import com.google.api.gax.rpc.StatusCode;
 import com.google.auth.oauth2.ComputeEngineCredentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.common.base.Strings;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.plugin.PluginConfig;
 import io.cdap.cdap.etl.api.FailureCollector;
+import io.cdap.plugin.common.ReferenceNames;
 import io.cdap.plugin.gcp.common.GCPConnectorConfig;
 import io.cdap.plugin.gcp.common.GCPUtils;
 import org.slf4j.Logger;
@@ -74,6 +76,10 @@ public class DataplexBaseConfig extends PluginConfig {
 
   public String getReferenceName() {
     return referenceName;
+  }
+
+  public String getReferenceNameOrNormalizedFQN(String fqn) {
+    return Strings.isNullOrEmpty(referenceName) ? ReferenceNames.normalizeFqn(fqn) : referenceName;
   }
 
   public String getLake() {


### PR DESCRIPTION
This PR adds FQN to the Dataplex plugin code for gcs buckets. Asset types of BigQuery are handled in the BQ [PR](https://github.com/data-integrations/google-cloud/pull/1115)

Jira: [CDAP-19546](https://cdap.atlassian.net/browse/CDAP-19546)