### PR TITLE
PLUGIN-1003:support reserved words as column names in big query

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
@@ -585,7 +585,12 @@ public final class BigQuerySinkUtils {
                                                        formatPartitionFilter(partitionFilter), criteria) : criteria;
     String fieldsForUpdate = tableFieldsList.stream().filter(s -> !tableKeyList.contains(s))
       .map(s -> String.format(CRITERIA_TEMPLATE, s, s)).collect(Collectors.joining(", "));
-    String orderedBy = orderedByList.isEmpty() ? "" : " ORDER BY " + "`" + String.join("`, `", orderedByList) + "`";
+
+    orderedByList.replaceAll(s -> "`" + Arrays.stream(s.split(" ")).map(String::trim)
+      .collect(Collectors.toList()).get(0) + "` " + Arrays.stream(s.split(" ")).map(String::trim)
+      .collect(Collectors.toList()).get(1));
+
+    String orderedBy = orderedByList.isEmpty() ? "" : " ORDER BY " + String.join(", ", orderedByList);
     String sourceTable = String.format(SOURCE_DATA_QUERY, "`" + String.join("`, `", tableKeyList) + "`",
                                        orderedBy, source);
     switch (operation) {

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
@@ -586,9 +586,9 @@ public final class BigQuerySinkUtils {
     String fieldsForUpdate = tableFieldsList.stream().filter(s -> !tableKeyList.contains(s))
       .map(s -> String.format(CRITERIA_TEMPLATE, s, s)).collect(Collectors.joining(", "));
 
-    orderedByList.replaceAll(s -> "`" + Arrays.stream(s.split(" ")).map(String::trim)
-      .collect(Collectors.toList()).get(0) + "` " + Arrays.stream(s.split(" ")).map(String::trim)
-      .collect(Collectors.toList()).get(1));
+    orderedByList = orderedByList.stream().map(s -> s.trim()).map(s -> {
+        return "`" + s.split(" ")[0] + "` " + s.split(" ", 2)[1];
+      }).collect(Collectors.toList());
 
     String orderedBy = orderedByList.isEmpty() ? "" : " ORDER BY " + String.join(", ", orderedByList);
     String sourceTable = String.format(SOURCE_DATA_QUERY, "`" + String.join("`, `", tableKeyList) + "`",

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtilsTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtilsTest.java
@@ -35,7 +35,6 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import javax.management.OperationsException;
 
 /**
  * Test for {@link BigQuerySinkUtils}
@@ -530,21 +529,22 @@ public class BigQuerySinkUtilsTest {
   public void testGenerateUpdateUpsertQueryUpdate() {
     Operation operation = Operation.UPDATE;
 
-    TableId sourceTableId = TableId.of("akritigiri-gcp-project0", "test",
-                                       "test_table_csv_8a0febdc_967b_451d_b01d_7558bd2d7a5a");
-    TableId destinationTableId = TableId.of("akritigiri-gcp-project0", "test", "test_table_csv");
+    TableId sourceTableId = TableId.of("dummy_src_project", "dummy_src_dataset",
+                                       "dummy_src_table");
+    TableId destinationTableId = TableId.of("dummy_dest_project", "dummy_dest_dataset",
+                                            "dummy_dest_table");
 
     List<String> tableFieldsList = new ArrayList<>(3);
-    tableFieldsList.add("DESC");
-    tableFieldsList.add("END");
-    tableFieldsList.add("JOIN");
+    tableFieldsList.add("a");
+    tableFieldsList.add("b");
+    tableFieldsList.add("c");
 
     List<String> tableKeyList = new ArrayList<>(1);
-    tableKeyList.add("DESC");
+    tableKeyList.add("a");
 
     List<String> orderedByList = new ArrayList<>(1);
-    orderedByList.add("END ASC");
-    orderedByList.add("DESC DESC");
+    orderedByList.add("b ASC");
+    orderedByList.add("a DESC");
 
     String partitionFilter = null;
 
@@ -552,33 +552,34 @@ public class BigQuerySinkUtilsTest {
                                                                tableFieldsList, tableKeyList, orderedByList,
                                                                partitionFilter);
 
-    Assert.assertEquals("UPDATE `akritigiri-gcp-project0.test.test_table_csv` T SET T.`END` = S.`END`, " +
-                          "T.`JOIN` = S.`JOIN` FROM (SELECT * FROM (SELECT row_number() OVER " +
-                          "(PARTITION BY `DESC` ORDER BY `END` ASC, `DESC` DESC) as rowid, * " +
-                          "FROM `akritigiri-gcp-project0.test.test_table_csv_8a0febdc_967b_451d_b01d_7558bd2d7a5a`) " +
-                          "where rowid = 1) S WHERE T.`DESC` = S.`DESC`", query);
+    Assert.assertEquals("UPDATE `dummy_dest_project.dummy_dest_dataset.dummy_dest_table` T SET " +
+                          "T.`b` = S.`b`, T.`c` = S.`c` FROM (SELECT * FROM (SELECT row_number() OVER " +
+                          "(PARTITION BY `a` ORDER BY `b` ASC, `a` DESC) as rowid, * " +
+                          "FROM `dummy_src_project.dummy_src_dataset.dummy_src_table`) " +
+                          "where rowid = 1) S WHERE T.`a` = S.`a`", query);
   }
 
   @Test
   public void testGenerateUpdateUpsertQueryUpsert() {
     Operation operation = Operation.UPSERT;
 
-    TableId sourceTableId = TableId.of("akritigiri-gcp-project0", "test",
-                                       "test_table_csv_8a0febdc_967b_451d_b01d_7558bd2d7a5a");
-    TableId destinationTableId = TableId.of("akritigiri-gcp-project0", "test", "test_table_csv");
+    TableId sourceTableId = TableId.of("dummy_src_project", "dummy_src_dataset",
+                                       "dummy_src_table");
+    TableId destinationTableId = TableId.of("dummy_dest_project", "dummy_dest_dataset",
+                                            "dummy_dest_table");
 
     List<String> tableFieldsList = new ArrayList<>(3);
-    tableFieldsList.add("DESC");
-    tableFieldsList.add("END");
-    tableFieldsList.add("JOIN");
+    tableFieldsList.add("a");
+    tableFieldsList.add("b");
+    tableFieldsList.add("c");
 
     List<String> tableKeyList = new ArrayList<>(1);
-    tableKeyList.add("END");
-    tableKeyList.add("DESC");
+    tableKeyList.add("a");
+    tableKeyList.add("b");
 
     List<String> orderedByList = new ArrayList<>(1);
-    orderedByList.add("JOIN ASC");
-    orderedByList.add("DESC DESC");
+    orderedByList.add("b ASC");
+    orderedByList.add("c DESC");
 
     String partitionFilter = null;
 
@@ -586,12 +587,12 @@ public class BigQuerySinkUtilsTest {
                                                                tableFieldsList, tableKeyList, orderedByList,
                                                                partitionFilter);
 
-    Assert.assertEquals("MERGE `akritigiri-gcp-project0.test.test_table_csv` T USING (SELECT * " +
-                          "FROM (SELECT row_number() OVER (PARTITION BY `END`, `DESC` " +
-                          "ORDER BY `JOIN` ASC, `DESC` DESC) as rowid, * FROM " +
-                          "`akritigiri-gcp-project0.test.test_table_csv_8a0febdc_967b_451d_b01d_7558bd2d7a5a`) " +
-                          "where rowid = 1) S ON T.`END` = S.`END` AND T.`DESC` = S.`DESC` " +
-                          "WHEN MATCHED THEN UPDATE SET T.`JOIN` = S.`JOIN` " +
-                          "WHEN NOT MATCHED THEN INSERT (`DESC`, `END`, `JOIN`) VALUES(`DESC`, `END`, `JOIN`)", query);
+    Assert.assertEquals("MERGE `dummy_dest_project.dummy_dest_dataset.dummy_dest_table` T USING (SELECT * " +
+                          "FROM (SELECT row_number() OVER (PARTITION BY `a`, `b` " +
+                          "ORDER BY `b` ASC, `c` DESC) as rowid, * FROM " +
+                          "`dummy_src_project.dummy_src_dataset.dummy_src_table`) " +
+                          "where rowid = 1) S ON T.`a` = S.`a` AND T.`b` = S.`b` " +
+                          "WHEN MATCHED THEN UPDATE SET T.`c` = S.`c` " +
+                          "WHEN NOT MATCHED THEN INSERT (`a`, `b`, `c`) VALUES(`a`, `b`, `c`)", query);
   }
 }


### PR DESCRIPTION
_**PLUGIN-1003: Support reserved words as column names in BigQuery**_
**Description:**
Currently using BigQuery reserved word  as a column name does not work and results in SQL errors.
E.g. in queries like `insert into a(DESC, field2, field3) values(1,2,3)` won't work since DESC is a reserved word.

**Solution**
This can be solved by quoting field names with back quotes. 
Fortunately unlike most DBs, BigQuery quoted identifiers are not case-sensitive, but case-retentive, so `Aaa` and `AAA` columns are considered same names, so we don't need to introduce special mode.

**Testing**
The code was thoroughly tested in all possible modes (INSERT/UPDATE/UPSERT, new vs existing table, JSON vs AVRO values, etc).
