### PR TITLE
remove refernceName as mandatory prop in tests

### DIFF
--- a/src/e2e-test/features/gcs/sink/GCSSinkError.feature
+++ b/src/e2e-test/features/gcs/sink/GCSSinkError.feature
@@ -9,6 +9,5 @@ Feature: GCS sink - Verify GCS Sink plugin error scenarios
     Then Validate mandatory property error for "<property>"
     Examples:
       | property        |
-      | referenceName   |
       | path            |
       | format          |

--- a/src/e2e-test/features/gcs/source/GCSSourceError.feature
+++ b/src/e2e-test/features/gcs/source/GCSSourceError.feature
@@ -9,7 +9,6 @@ Feature: GCS source - Verify GCS Source plugin error scenarios
     Then Validate mandatory property error for "<property>"
     Examples:
       | property        |
-      | referenceName   |
       | path            |
       | format          |
 

--- a/src/e2e-test/features/spanner/sink/SpannerSinkErrorScenarios.feature
+++ b/src/e2e-test/features/spanner/sink/SpannerSinkErrorScenarios.feature
@@ -9,7 +9,6 @@ Feature: Spanner Sink - Verify Spanner sink plugin error scenarios
     Then Validate mandatory property error for "<property>"
     Examples:
       | property        |
-      | referenceName   |
       | instance        |
       | database        |
       | table           |

--- a/src/e2e-test/features/spanner/source/SpannerSourceErrorScenarios.feature
+++ b/src/e2e-test/features/spanner/source/SpannerSourceErrorScenarios.feature
@@ -9,7 +9,6 @@ Feature: Spanner Source - Verify Spanner source plugin error scenarios
     Then Validate mandatory property error for "<property>"
     Examples:
       | property        |
-      | referenceName   |
       | instance        |
       | database        |
       | table           |


### PR DESCRIPTION
This PR removes `refernceName` as mandatory prop in tests