### PR TITLE
Fixed log message for BQ read errors

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQueryReadDataset.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQueryReadDataset.java
@@ -194,8 +194,8 @@ public class BigQueryReadDataset implements SQLDataset, BigQuerySQLDataset {
     if (!Objects.equals(srcDataset.getLocation(), destDataset.getLocation())) {
       LOG.error("Direct table read is only supported if both datasets are in the same location. "
                  + "'{}' is '{}' , '{}' is '{}' .",
-               sourceDatasetId.getDataset(), srcDataset.getLocation(),
-               sourceDatasetId.getDataset(), destDataset.getLocation());
+                sourceDatasetId.getDataset(), srcDataset.getLocation(),
+                destinationDatasetId.getDataset(), destDataset.getLocation());
       return SQLReadResult.unsupported(datasetName);
     }
 


### PR DESCRIPTION
I noticed the BQ read error when datasets are in different locations is showing the source dataset name twice. This displays the correct destination dataset name