### PR TITLE
Added Spark Window Frame related query changes in Bigquery

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/builder/BigQueryBaseSQLBuilder.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/builder/BigQueryBaseSQLBuilder.java
@@ -36,6 +36,7 @@ public abstract class BigQueryBaseSQLBuilder {
   public static final String EQ = " = ";
   public static final String AND = " AND ";
   public static final String OR = " OR ";
+  public static final String CURRENT_ROW = " CURRENT ROW ";
   public static final String ROWS = "ROWS";
   public static final String RANGE = "RANGE";
   public static final String BETWEEN = " BETWEEN ";

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/builder/BigQueryWindowsAggregationSQLBuilder.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/builder/BigQueryWindowsAggregationSQLBuilder.java
@@ -123,13 +123,29 @@ public class BigQueryWindowsAggregationSQLBuilder extends BigQueryBaseSQLBuilder
     if (windowAggregationDefinition.getUnboundedPreceding()) {
       def = def + UNBOUNDED_PRECEDING;
     } else {
-      def = def + windowAggregationDefinition.getPreceding() + PRECEDING;
+      int preceding = Integer.parseInt(windowAggregationDefinition.getPreceding());
+      if (preceding == 0) {
+        def = def + CURRENT_ROW;
+      } else if (preceding < 0) {
+        preceding = preceding * -1;
+        def = def + preceding + PRECEDING;
+      } else {
+        def = def + preceding + FOLLOWING;
+      }
     }
     def = def + AND;
     if (windowAggregationDefinition.getUnboundedFollowing()) {
       def = def + UNBOUNDED_FOLLOWING;
     } else {
-      def = def + windowAggregationDefinition.getFollowing() + FOLLOWING;
+      int following = Integer.parseInt(windowAggregationDefinition.getFollowing());
+      if (following == 0) {
+        def = def + CURRENT_ROW;
+      } else if (following < 0) {
+        following = following * -1;
+        def = def + following + PRECEDING;
+      } else {
+        def = def + following + FOLLOWING;
+      }
     }
     return def;
   }

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/relational/BigQueryRelationTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/relational/BigQueryRelationTest.java
@@ -333,7 +333,7 @@ BigQueryRelationTest {
                                                                       WindowAggregationDefinition.OrderBy.ASCENDING));
     frame = WindowAggregationDefinition.WindowFrameType.ROW;
     following = "1";
-    preceding = "1";
+    preceding = "-1";
 
     //Set Definition
     def = builder.windowFrameType(frame).partition(partitionFields).aggregate(aggregationFields)


### PR DESCRIPTION
As per spark Window Frame(Row,Range), if a value 0 is given it becomes CURRENT ROW .If a value greater than 0 is entered it becomes value Following and if less than 0 it becomes value preceding.This PR has changes of Bigquery as per spark Window Frame