### PR TITLE
[Dependency Bump] Resolve log4j vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -338,6 +338,10 @@
           <groupId>javax.jms</groupId>
           <artifactId>jms</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.google.flogger</groupId>
+          <artifactId>flogger-log4j-backend</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -352,6 +356,10 @@
         <exclusion>
           <groupId>org.apache.hbase</groupId>
           <artifactId>hbase-server</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-annotations</artifactId>
         </exclusion>
         <!-- bigtable-hbase-1.x-mapreduce version 1.17.1 has a dependency on hbase-common:1.4.12
         which masks the shaded dependencies below . Exclude this dependency.
@@ -376,6 +384,10 @@
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -391,6 +403,10 @@
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -518,6 +534,14 @@
           <groupId>org.apache.avro</groupId>
           <artifactId>avro</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-client</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -539,6 +563,12 @@
       <groupId>com.google.cloud.bigdataoss</groupId>
       <artifactId>gcs-connector</artifactId>
       <version>${gcs.connector.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.flogger</groupId>
+          <artifactId>flogger-log4j-backend</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>


### PR DESCRIPTION
Removed all dependencies leading to log4j version 1.2.17.