### PR TITLE
[Dependency Bump] Resolve log4j vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -627,6 +627,10 @@
           <groupId>io.cdap.cdap</groupId>
           <artifactId>cdap-explore-jdbc</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <!-- Start: Testing dependencies -->


### PR DESCRIPTION
Exclude log4j from cdap-unit-test