### PR TITLE
[CDAP-20238] Remove Spark2 references and update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,6 @@
     <junit.version>4.13.1</junit.version>
     <powermock.version>2.0.2</powermock.version>
     <slf4j.version>1.7.5</slf4j.version>
-    <spark.version>2.3.1</spark.version>
     <spark3.version>3.1.1</spark3.version>
     <spark-bq-connector.version>0.23.1</spark-bq-connector.version>
     <testSourceLocation>${project.basedir}/src/test/java/</testSourceLocation>
@@ -655,14 +654,14 @@
     <!-- End: Testing dependencies -->
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_2.11</artifactId>
-      <version>${spark.version}</version>
+      <artifactId>spark-streaming_2.12</artifactId>
+      <version>${spark3.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.11</artifactId>
-      <version>${spark.version}</version>
+      <artifactId>spark-core_2.12</artifactId>
+      <version>${spark3.version}</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>
@@ -711,7 +710,7 @@
     <!-- Start: dependency for Google PubSub Streaming Source -->
     <dependency>
       <groupId>org.apache.bahir</groupId>
-      <artifactId>spark-streaming-pubsub_2.11</artifactId>
+      <artifactId>spark-streaming-pubsub_2.12</artifactId>
       <version>2.4.0</version>
     </dependency>
     <!-- End: dependency for Google PubSub Streaming Source -->
@@ -741,7 +740,7 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-api-spark2_2.11</artifactId>
+      <artifactId>cdap-api-spark3_2.12</artifactId>
       <version>${cdap.version}</version>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
As part of cdapio/cdap/pull/14797, the spark2 modules and references have been removed. Similar references in this repo need to be done and subsequent dependencies need to be updated.