### PR TITLE
Revert Bumped awaitility version to next SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
-      <version>3.1.7-SNAPSHOT</version>
+      <version>3.1.6</version>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>


### PR DESCRIPTION
This reverts commit eb09d4e823f79de859b5f873eb7798906ba91d33. which bumbed awaitility to non existing version `3.1.7-SNAPSHOT` and resulted in cdap-build failing with error 

```
Failed to execute goal on project google-cloud: Could not resolve dependencies for project io.cdap.plugin:google-cloud:jar:0.20.5-SNAPSHOT: Failure to find org.awaitility:awaitility:jar:3.1.7-SNAPSHOT in https://oss.sonatype.org/content/repositories/snapshots was cached in the local repository, resolution will not be reattempted until the update interval of sonatype-snapshots has elapsed or updates are forced -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal on project google-cloud: Could not resolve dependencies for project io.cdap.plugin:google-cloud:jar:0.20.5-SNAPSHOT: Failure to find org.awaitility:awaitility:jar:3.1.7-SNAPSHOT in https://oss.sonatype.org/content/repositories/snapshots was cached in the local repository, resolution will not be reattempted until the update interval of sonatype-snapshots has elapsed or updates are forced
```