### PR TITLE
Update on Bigquery sink to use the config schema for update and upser…

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -308,14 +308,17 @@ public final class BigQuerySink extends AbstractBigQuerySink {
    * Sets the output table for the AbstractBigQuerySink's Hadoop configuration
    */
   private void configureTable(Schema schema) {
-    AbstractBigQuerySinkConfig config = getConfig();
+    BigQuerySinkConfig config = getConfig();
     Table table = BigQueryUtil.getBigQueryTable(config.getDatasetProject(), config.getDataset(),
                                                 config.getTable(),
                                                 config.getServiceAccount(),
                                                 config.isServiceAccountFilePath());
     baseConfiguration.setBoolean(BigQueryConstants.CONFIG_DESTINATION_TABLE_EXISTS, table != null);
     List<String> tableFieldsNames = null;
-    if (table != null) {
+    if (!config.getOperation().equals(Operation.INSERT) && schema != null) {
+      tableFieldsNames = schema.getFields().stream()
+              .map(Schema.Field::getName).collect(Collectors.toList());
+    } else if (table != null) {
        tableFieldsNames = Objects.requireNonNull(table.getDefinition().getSchema()).getFields().stream()
         .map(Field::getName).collect(Collectors.toList());
     } else if (schema != null) {


### PR DESCRIPTION
Hi Team,
This change is done on the Bigquery sink update and upsert with a key, to use the schema from the config. At the moment, the columns not mentioned in the config schema are updated with null value.This change is to fix this and only update the columns only mentioned in the schema from config. Please review

Thanks
Kishore Padman