### PR TITLE
Bigquery Update - Changes in the validation and to use schema from the config

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
@@ -147,9 +147,15 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, S
                                   FailureCollector collector) throws IOException {
     LOG.debug("Init output for table '{}' with schema: {}", tableName, tableSchema);
 
+    boolean isUpdateOperation = false;
+
+    if (getConfig() instanceof  BigQuerySinkConfig) {
+      isUpdateOperation = Operation.UPDATE.equals(((BigQuerySinkConfig) getConfig()).getOperation());
+    }
+
     List<BigQueryTableFieldSchema> fields = BigQuerySinkUtils.getBigQueryTableFields(bigQuery, tableName, tableSchema,
       getConfig().isAllowSchemaRelaxation(), getConfig().getDatasetProject(),
-      getConfig().getDataset(), getConfig().isTruncateTableSet(), collector);
+      getConfig().getDataset(), getConfig().isTruncateTableSet(), isUpdateOperation , collector);
 
     Configuration configuration = new Configuration(baseConfiguration);
 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
@@ -289,7 +289,7 @@ public class BigQueryOutputFormat extends ForwardingBigQueryFileOutputFormat<Str
 
       // If schema change is not allowed and if the destination table already exists, use the destination table schema
       // See PLUGIN-395
-      if (!allowSchemaRelaxation && tableExists) {
+      if (!Operation.UPDATE.equals(operation) && !allowSchemaRelaxation && tableExists) {
         loadConfig.setSchema(bigQueryHelper.getTable(tableRef).getSchema());
       } else {
         loadConfig.setSchema(schema);

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -308,14 +308,17 @@ public final class BigQuerySink extends AbstractBigQuerySink {
    * Sets the output table for the AbstractBigQuerySink's Hadoop configuration
    */
   private void configureTable(Schema schema) {
-    AbstractBigQuerySinkConfig config = getConfig();
+    BigQuerySinkConfig config = getConfig();
     Table table = BigQueryUtil.getBigQueryTable(config.getDatasetProject(), config.getDataset(),
                                                 config.getTable(),
                                                 config.getServiceAccount(),
                                                 config.isServiceAccountFilePath());
     baseConfiguration.setBoolean(BigQueryConstants.CONFIG_DESTINATION_TABLE_EXISTS, table != null);
     List<String> tableFieldsNames = null;
-    if (table != null) {
+    if (!config.getOperation().equals(Operation.INSERT) && schema != null) {
+      tableFieldsNames = schema.getFields().stream()
+              .map(Schema.Field::getName).collect(Collectors.toList());
+    } else if (table != null) {
        tableFieldsNames = Objects.requireNonNull(table.getDefinition().getSchema()).getFields().stream()
         .map(Field::getName).collect(Collectors.toList());
     } else if (schema != null) {

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -175,7 +175,8 @@ public final class BigQuerySink extends AbstractBigQuerySink {
 
     List<BigQueryTableFieldSchema> fields = BigQuerySinkUtils.getBigQueryTableFields(bigQuery, tableName, tableSchema,
       getConfig().isAllowSchemaRelaxation(),
-      config.getDatasetProject(), config.getDataset(), config.isTruncateTableSet(), collector);
+      config.getDatasetProject(), config.getDataset(), config.isTruncateTableSet(),
+            Operation.UPDATE.equals(config.getOperation()) , collector);
 
     List<String> fieldNames = fields.stream()
       .map(BigQueryTableFieldSchema::getName)
@@ -315,7 +316,7 @@ public final class BigQuerySink extends AbstractBigQuerySink {
                                                 config.isServiceAccountFilePath());
     baseConfiguration.setBoolean(BigQueryConstants.CONFIG_DESTINATION_TABLE_EXISTS, table != null);
     List<String> tableFieldsNames = null;
-    if (!config.getOperation().equals(Operation.INSERT) && schema != null) {
+    if (config.getOperation().equals(Operation.UPDATE) && schema != null) {
       tableFieldsNames = schema.getFields().stream()
               .map(Schema.Field::getName).collect(Collectors.toList());
     } else if (table != null) {

--- a/src/test/java/io/cdap/plugin/gcp/dataplex/sink/config/DataplexBatchSinkTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/dataplex/sink/config/DataplexBatchSinkTest.java
@@ -287,7 +287,7 @@ public class DataplexBatchSinkTest {
     Mockito.when(BigQuerySinkUtils.getBigQueryTableFields(bigQuery, "table", schema,
         false,
         "datasetProjectName", "datasetName",
-        false, mockFailureCollector)).
+        false, false, mockFailureCollector)).
       thenReturn(fields);
     DatasetId datasetId = DatasetId.of("datasetProjectName", "datasetName");
     Dataset dataset = Mockito.mock(Dataset.class);


### PR DESCRIPTION
Hi Team, 

For BigQuery update , changes have been done to use the schema from the config. This will enable to update the BigQuery table for few columns. The current code updates  the missing columns with null value, if those are not in schema. 

Also validation has been changed to remove the missing field check in the schema.

Please review.

Thanks