### PR TITLE
Add schema to BigQueryRelation

### DIFF
--- a/src/test/java/io/cdap/plugin/gcp/dataplex/sink/DataPlexOutputFormatProviderTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/dataplex/sink/DataPlexOutputFormatProviderTest.java
@@ -40,9 +40,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 
 import java.io.IOException;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
 
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;


### PR DESCRIPTION
This PR adds a Schema field to BigQueryRelation for later use in validating an expression using that schema. Specifically it will be used in any implementation of the method `compile(T expression, Relation relation)` in an `ExpressionFactory`.