### PR TITLE
Add a method to add schema information to a BigQueryRelation

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/relational/BigQueryRelation.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/relational/BigQueryRelation.java
@@ -349,6 +349,16 @@ public class BigQueryRelation implements Relation {
     return new BigQueryRelation(datasetName, columns, featureFlagsProvider, this, supplier);
   }
 
+  /**
+   * Adds schema information to the relation. This can be used for validation purposes.
+   *
+   * @param schema The schema.
+   * @return A new relation with the schema added.
+   */
+  public Relation addSchema(@Nullable Schema schema) {
+    return new BigQueryRelation(datasetName, columns, featureFlagsProvider, this, sqlStatementSupplier, schema);
+  }
+
   private static String buildBaseSelect(Map<String, Expression> columns,
                                         String sourceTable,
                                         String datasetName) {


### PR DESCRIPTION
This PR adds a way to add schema information to a relation. This can be called by a plugin that wishes to request validation.

The current intention is that this will be called by Wrangler in the `transform()` method to supply schema information (which Wrangler currently already has in the `oSchema` variable).