### PR TITLE
PLUGIN-1537 - Refactor code to facilitate reuse and use in serializable streams.

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/publisher/source/BackoffConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/publisher/source/BackoffConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.gcp.publisher.source;
+
+import java.io.Serializable;
+
+/**
+ * Class used to configure exponential backoff for Pub/Sub API requests.
+ */
+public class BackoffConfig implements Serializable {
+  private final int initialBackoffMs;
+  private final int maximumBackoffMs;
+  private final double backoffFactor;
+
+  static final BackoffConfig defaultInstance() {
+    return new BackoffConfig(100, 10000, 2.0);
+  }
+
+  public BackoffConfig(int initialBackoffMs, int maximumBackoffMs, double backoffFactor) {
+    this.initialBackoffMs = initialBackoffMs;
+    this.maximumBackoffMs = maximumBackoffMs;
+    this.backoffFactor = backoffFactor;
+  }
+
+  public int getInitialBackoffMs() {
+    return initialBackoffMs;
+  }
+
+  public int getMaximumBackoffMs() {
+    return maximumBackoffMs;
+  }
+
+  public double getBackoffFactor() {
+    return backoffFactor;
+  }
+}

--- a/src/main/java/io/cdap/plugin/gcp/publisher/source/GoogleSubscriber.java
+++ b/src/main/java/io/cdap/plugin/gcp/publisher/source/GoogleSubscriber.java
@@ -15,9 +15,7 @@
  */
 package io.cdap.plugin.gcp.publisher.source;
 
-import com.google.common.base.Strings;
 import io.cdap.cdap.api.annotation.Description;
-import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.data.format.StructuredRecord;
@@ -26,29 +24,9 @@ import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.streaming.StreamingSource;
 import io.cdap.cdap.etl.api.streaming.StreamingSourceContext;
-import io.cdap.cdap.format.StructuredRecordStringConverter;
 import io.cdap.plugin.common.LineageRecorder;
-import io.cdap.plugin.format.avro.AvroToStructuredTransformer;
-import io.cdap.plugin.gcp.common.MappingException;
-import io.cdap.plugin.gcp.publisher.PubSubConstants;
-import org.apache.avro.generic.GenericDatumReader;
-import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.io.BinaryDecoder;
-import org.apache.avro.io.DatumReader;
-import org.apache.avro.io.DecoderFactory;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.Serializable;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Objects;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 
 /**
  * Realtime source plugin to read from Google PubSub.
@@ -57,15 +35,6 @@ import javax.annotation.Nullable;
 @Name("GoogleSubscriber")
 @Description("Streaming Source to read messages from Google PubSub.")
 public class GoogleSubscriber extends PubSubSubscriber<StructuredRecord> {
-  private static final String SCHEMA = "schema";
-  private static final Schema DEFAULT_SCHEMA =
-    Schema.recordOf("event",
-                    Schema.Field.of("message", Schema.of(Schema.Type.BYTES)),
-                    Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
-                    Schema.Field.of("timestamp", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)),
-                    Schema.Field.of("attributes", Schema.mapOf(Schema.of(Schema.Type.STRING),
-                                                               Schema.of(Schema.Type.STRING)))
-    );
 
   private GoogleSubscriberConfig config;
 
@@ -74,7 +43,7 @@ public class GoogleSubscriber extends PubSubSubscriber<StructuredRecord> {
     this.config = config;
 
     //Set mapping function for output records.
-    super.setMappingFunction(pubSubMessageToStructuredRecordMappingFunction);
+    super.setMappingFunction(new PubSubStructuredRecordConverter(config));
   }
 
   @Override
@@ -97,211 +66,6 @@ public class GoogleSubscriber extends PubSubSubscriber<StructuredRecord> {
       LineageRecorder recorder = new LineageRecorder(context, config.referenceName);
       recorder.recordRead("Read", "Read from Pub/Sub",
                           schema.getFields().stream().map(Schema.Field::getName).collect(Collectors.toList()));
-    }
-  }
-
-  /**
-   * Converts a PubSubMessage into a StructuredRecord based on the specified schema.
-   * If no schema is specified, the default schema is used.
-   */
-  private final SerializableFunction<PubSubMessage, StructuredRecord> pubSubMessageToStructuredRecordMappingFunction =
-    (SerializableFunction<PubSubMessage, StructuredRecord>) (pubSubMessage) -> {
-
-      Schema customMessageSchema = getCustomMessageSchema();
-      final Schema outputSchema = config.getSchema();
-      final String format = config.getFormat();
-
-      // Convert to a HashMap because com.google.api.client.util.ArrayMap is not serializable.
-      HashMap<String, String> hashMap = new HashMap<>();
-      if (pubSubMessage.getAttributes() != null) {
-        hashMap.putAll(pubSubMessage.getAttributes());
-      }
-
-      try {
-        StructuredRecord payload = getStructuredRecord(config, customMessageSchema, format, pubSubMessage);
-
-        return StructuredRecord.builder(outputSchema)
-          .set("message", (format.equalsIgnoreCase(PubSubConstants.TEXT) ||
-            format.equalsIgnoreCase(PubSubConstants.BLOB)) ?
-            pubSubMessage.getData() : payload)
-          .set("id", pubSubMessage.getMessageId())
-          .setTimestamp("timestamp", getTimestamp(pubSubMessage.getPublishTime()))
-          .set("attributes", hashMap)
-          .build();
-      } catch (IOException ioe) {
-        throw new MappingException(ioe);
-      }
-    };
-
-  private static ZonedDateTime getTimestamp(Instant instant) {
-    return ZonedDateTime.ofInstant(instant, ZoneId.ofOffset("UTC", ZoneOffset.UTC));
-  }
-
-  private static StructuredRecord getStructuredRecord(GoogleSubscriberConfig config, Schema customMessageSchema,
-                                                      String format, PubSubMessage pubSubMessage) throws IOException {
-    StructuredRecord payload = null;
-    final String data = pubSubMessage.getData() != null ? new String(pubSubMessage.getData()) : "";
-
-    switch (format) {
-      case PubSubConstants.AVRO:
-      case PubSubConstants.PARQUET: {
-        final byte[] payloadData = pubSubMessage.getData();
-        final org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().
-          parse(String.valueOf(customMessageSchema));
-        DatumReader<GenericRecord> datumReader = new GenericDatumReader<>(avroSchema);
-        ByteArrayInputStream in = new ByteArrayInputStream(payloadData);
-        BinaryDecoder decoder = DecoderFactory.get().binaryDecoder(in, null);
-        GenericRecord record = datumReader.read(null, decoder);
-        payload = new AvroToStructuredTransformer().transform(record);
-        break;
-      }
-      case PubSubConstants.CSV: {
-        payload = StructuredRecordStringConverter.fromDelimitedString(data, ",", customMessageSchema);
-        break;
-      }
-      case PubSubConstants.DELIMITED: {
-        payload = StructuredRecordStringConverter.fromDelimitedString(data, config.getDelimiter(),
-                                                                      customMessageSchema);
-        break;
-      }
-      case PubSubConstants.JSON: {
-        payload = StructuredRecordStringConverter.fromJsonString(data, customMessageSchema);
-        break;
-      }
-      case PubSubConstants.TSV: {
-        payload = StructuredRecordStringConverter.fromDelimitedString(data, "\t", customMessageSchema);
-        break;
-      }
-    }
-    return payload;
-  }
-
-  private Schema.Field getMessageField() {
-    Schema schema = config.getSchema();
-    return schema.getField("message");
-  }
-
-  private Schema getCustomMessageSchema() {
-    Schema.Field messageField = getMessageField();
-    if (messageField == null) {
-      return null;
-    }
-    return messageField.getSchema();
-  }
-
-  /**
-   * Extension to the PubSubSubscriberConfig class with additional fields related to record schema.
-   */
-  public class GoogleSubscriberConfig extends PubSubSubscriberConfig implements Serializable {
-
-    @Macro
-    @Nullable
-    @Description("Format of the data to read. Supported formats are 'avro', 'blob', 'tsv', 'csv', 'delimited', 'json', "
-      + "'parquet' and 'text'.")
-    protected String format;
-
-    @Description("The delimiter to use if the format is 'delimited'. The delimiter will be ignored if the format "
-      + "is anything other than 'delimited'.")
-    @Macro
-    @Nullable
-    protected String delimiter;
-
-    @Name(SCHEMA)
-    @Macro
-    @Nullable
-    protected String schema;
-
-    @Override
-    public void validate(FailureCollector collector) {
-      super.validate(collector);
-
-      final Schema outputSchema = getSchema();
-      final ArrayList<String> defaultSchemaFields = getFieldsOfDefaultSchema();
-      ArrayList<String> outputSchemaFields = new ArrayList<>();
-
-      if (outputSchema != null) {
-        for (Schema.Field field : Objects.requireNonNull(outputSchema.getFields())) {
-          outputSchemaFields.add(field.getName());
-        }
-
-        for (Schema.Field field : Objects.requireNonNull(DEFAULT_SCHEMA.getFields())) {
-          if (!outputSchemaFields.contains(field.getName())) {
-            collector.addFailure("Some required fields are missing from the schema.",
-                                 String.format("You should use the existing fields of default schema %s.",
-                                               defaultSchemaFields))
-              .withConfigProperty(schema);
-          }
-        }
-
-        for (Schema.Field field : Objects.requireNonNull(outputSchema.getFields())) {
-          Schema.Field outputField = DEFAULT_SCHEMA.getField(field.getName());
-          if (field.getSchema().isNullable()) {
-            collector.addFailure(String.format("Null is not allowed in %s.", field.getName()),
-                                 "Schema is non-nullable")
-              .withConfigProperty(schema);
-          }
-          if (outputField == null) {
-            collector.addFailure(String.format("Field %s is not allowed.", field.getName()),
-                                 "You should use the existing fields of default schema.")
-              .withConfigProperty(schema);
-          } else {
-            Schema.Type fieldType = field.getSchema().getType();
-            if (field.getName().equals("message")) {
-              if (!(fieldType == Schema.Type.RECORD || fieldType == Schema.Type.BYTES)) {
-                collector.addFailure(String.format("Type %s is not allowed in %s.",
-                                                   fieldType.toString().toLowerCase(), field.getName()),
-                                     "Type should be record or byte.")
-                  .withConfigProperty(schema);
-              }
-              continue;
-            }
-            if (!fieldType.equals(outputField.getSchema().getType())) {
-              collector.addFailure(String.format("Type %s is not allowed in %s.",
-                                                 fieldType.toString().toLowerCase(), field.getName()),
-                                   String.format("You should use the same type [%s] as in default schema.",
-                                                 outputField.getSchema().toString()))
-                .withConfigProperty(schema);
-            }
-          }
-        }
-      }
-
-      if (!containsMacro(PubSubConstants.DELIMITER) && (!containsMacro(PubSubConstants.FORMAT) &&
-        getFormat().equalsIgnoreCase(PubSubConstants.DELIMITED) && delimiter == null)) {
-        collector.addFailure(String.format("Delimiter is required when format is set to %s.", getFormat()),
-                             "Ensure the delimiter is provided.")
-          .withConfigProperty(delimiter);
-      }
-
-      collector.getOrThrowException();
-    }
-
-    public String getFormat() {
-      return Strings.isNullOrEmpty(format) ? PubSubConstants.TEXT : format;
-    }
-
-    public String getDelimiter() {
-      return delimiter;
-    }
-
-    public ArrayList<String> getFieldsOfDefaultSchema() {
-      ArrayList<String> outputSchemaAttributes = new ArrayList<>();
-      for (Schema.Field field : Objects.requireNonNull(DEFAULT_SCHEMA.getFields())) {
-        outputSchemaAttributes.add(field.getName());
-      }
-      return outputSchemaAttributes;
-    }
-
-    public Schema getSchema() {
-      try {
-        if (containsMacro(SCHEMA)) {
-          return null;
-        }
-        return Strings.isNullOrEmpty(schema) ? DEFAULT_SCHEMA : Schema.parseJson(schema);
-      } catch (Exception e) {
-        throw new IllegalArgumentException(String.format("Unable to parse schema with error %s, %s",
-                                                         e.getMessage(), e));
-      }
     }
   }
 }

--- a/src/main/java/io/cdap/plugin/gcp/publisher/source/GoogleSubscriberConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/publisher/source/GoogleSubscriberConfig.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.gcp.publisher.source;
+
+import com.google.common.base.Strings;
+import io.cdap.cdap.api.annotation.Description;
+import io.cdap.cdap.api.annotation.Macro;
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.FailureCollector;
+import io.cdap.plugin.gcp.publisher.PubSubConstants;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Extension to the PubSubSubscriberConfig class with additional fields related to record schema.
+ */
+public class GoogleSubscriberConfig extends PubSubSubscriberConfig implements Serializable {
+
+  private static final String SCHEMA = "schema";
+  private static final Schema DEFAULT_SCHEMA =
+    Schema.recordOf("event",
+                    Schema.Field.of("message", Schema.of(Schema.Type.BYTES)),
+                    Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+                    Schema.Field.of("timestamp", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)),
+                    Schema.Field.of("attributes", Schema.mapOf(Schema.of(Schema.Type.STRING),
+                                                               Schema.of(Schema.Type.STRING)))
+    );
+
+  @Macro
+  @Nullable
+  @Description("Format of the data to read. Supported formats are 'avro', 'blob', 'tsv', 'csv', 'delimited', 'json', "
+    + "'parquet' and 'text'.")
+  protected String format;
+
+  @Description("The delimiter to use if the format is 'delimited'. The delimiter will be ignored if the format "
+    + "is anything other than 'delimited'.")
+  @Macro
+  @Nullable
+  protected String delimiter;
+
+  @Name(SCHEMA)
+  @Macro
+  @Nullable
+  protected String schema;
+
+  @Override
+  public void validate(FailureCollector collector) {
+    super.validate(collector);
+
+    final Schema outputSchema = getSchema();
+    final ArrayList<String> defaultSchemaFields = getFieldsOfDefaultSchema();
+    ArrayList<String> outputSchemaFields = new ArrayList<>();
+
+    if (outputSchema != null) {
+      for (Schema.Field field : Objects.requireNonNull(outputSchema.getFields())) {
+        outputSchemaFields.add(field.getName());
+      }
+
+      for (Schema.Field field : Objects.requireNonNull(DEFAULT_SCHEMA.getFields())) {
+        if (!outputSchemaFields.contains(field.getName())) {
+          collector.addFailure("Some required fields are missing from the schema.",
+                               String.format("You should use the existing fields of default schema %s.",
+                                             defaultSchemaFields))
+            .withConfigProperty(schema);
+        }
+      }
+
+      for (Schema.Field field : Objects.requireNonNull(outputSchema.getFields())) {
+        Schema.Field outputField = DEFAULT_SCHEMA.getField(field.getName());
+        if (field.getSchema().isNullable()) {
+          collector.addFailure(String.format("Null is not allowed in %s.", field.getName()),
+                               "Schema is non-nullable")
+            .withConfigProperty(schema);
+        }
+        if (outputField == null) {
+          collector.addFailure(String.format("Field %s is not allowed.", field.getName()),
+                               "You should use the existing fields of default schema.")
+            .withConfigProperty(schema);
+        } else {
+          Schema.Type fieldType = field.getSchema().getType();
+          if (field.getName().equals("message")) {
+            if (!(fieldType == Schema.Type.RECORD || fieldType == Schema.Type.BYTES)) {
+              collector.addFailure(String.format("Type %s is not allowed in %s.",
+                                                 fieldType.toString().toLowerCase(), field.getName()),
+                                   "Type should be record or byte.")
+                .withConfigProperty(schema);
+            }
+            continue;
+          }
+          if (!fieldType.equals(outputField.getSchema().getType())) {
+            collector.addFailure(String.format("Type %s is not allowed in %s.",
+                                               fieldType.toString().toLowerCase(), field.getName()),
+                                 String.format("You should use the same type [%s] as in default schema.",
+                                               outputField.getSchema().toString()))
+              .withConfigProperty(schema);
+          }
+        }
+      }
+    }
+
+    if (!containsMacro(PubSubConstants.DELIMITER) && (!containsMacro(PubSubConstants.FORMAT) &&
+      getFormat().equalsIgnoreCase(PubSubConstants.DELIMITED) && delimiter == null)) {
+      collector.addFailure(String.format("Delimiter is required when format is set to %s.", getFormat()),
+                           "Ensure the delimiter is provided.")
+        .withConfigProperty(delimiter);
+    }
+
+    collector.getOrThrowException();
+  }
+
+  public String getFormat() {
+    return Strings.isNullOrEmpty(format) ? PubSubConstants.TEXT : format;
+  }
+
+  public String getDelimiter() {
+    return delimiter;
+  }
+
+  public ArrayList<String> getFieldsOfDefaultSchema() {
+    ArrayList<String> outputSchemaAttributes = new ArrayList<>();
+    for (Schema.Field field : Objects.requireNonNull(DEFAULT_SCHEMA.getFields())) {
+      outputSchemaAttributes.add(field.getName());
+    }
+    return outputSchemaAttributes;
+  }
+
+  public Schema getSchema() {
+    try {
+      if (containsMacro(SCHEMA)) {
+        return null;
+      }
+      return Strings.isNullOrEmpty(schema) ? DEFAULT_SCHEMA : Schema.parseJson(schema);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(String.format("Unable to parse schema with error %s, %s",
+                                                       e.getMessage(), e));
+    }
+  }
+}

--- a/src/main/java/io/cdap/plugin/gcp/publisher/source/PubSubReceiver.java
+++ b/src/main/java/io/cdap/plugin/gcp/publisher/source/PubSubReceiver.java
@@ -29,7 +29,6 @@ import com.google.pubsub.v1.AcknowledgeRequest;
 import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.PullRequest;
 import com.google.pubsub.v1.PullResponse;
-import com.google.pubsub.v1.PushConfig;
 import com.google.pubsub.v1.ReceivedMessage;
 import com.google.pubsub.v1.TopicName;
 import io.cdap.plugin.gcp.common.GCPUtils;
@@ -40,10 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -74,20 +70,6 @@ public class PubSubReceiver extends Receiver<PubSubMessage> {
     "Failed to fetch new messages using subscription '%s' for project '%s'.";
   private static final String INTERRUPTED_EXCEPTION_MSG =
     "Interrupted Exception when sleeping during backoff.";
-
-  // Retryable status codes. These need to be handled in case Pub/Sub throws a StatusRuntimeException.
-  private static final int RESOURCE_EXHAUSTED = StatusCode.Code.RESOURCE_EXHAUSTED.getHttpStatusCode();
-  private static final int CANCELLED = StatusCode.Code.CANCELLED.getHttpStatusCode();
-  private static final int INTERNAL = StatusCode.Code.INTERNAL.getHttpStatusCode();
-  private static final int UNAVAILABLE = StatusCode.Code.UNAVAILABLE.getHttpStatusCode();
-  private static final int DEADLINE_EXCEEDED = StatusCode.Code.DEADLINE_EXCEEDED.getHttpStatusCode();
-  private static final Set<Integer> RETRYABLE_STATUS_CODES = Collections.unmodifiableSet(new HashSet<Integer>() {{
-    add(RESOURCE_EXHAUSTED);
-    add(CANCELLED);
-    add(INTERNAL);
-    add(UNAVAILABLE);
-    add(DEADLINE_EXCEEDED);
-  }});
 
   private final PubSubSubscriberConfig config;
   private final boolean autoAcknowledge;
@@ -223,55 +205,26 @@ public class PubSubReceiver extends Receiver<PubSubMessage> {
       return;
     }
 
-    int backoff = backoffConfig.getInitialBackoffMs();
-    int attempts = 5;
-
-    ApiException lastApiException = null;
-
-    while (!isStopped() && attempts-- > 0) {
-
-      try (SubscriptionAdminClient subscriptionAdminClient = buildSubscriptionAdminClient()) {
-
-        int ackDeadline = 60; // 60 seconds before resending the message.
-        subscriptionAdminClient.createSubscription(
-          subscription, topic, PushConfig.getDefaultInstance(), ackDeadline);
-        return;
-
-      } catch (ApiException ae) {
-
-        lastApiException = ae;
-
-        //If the subscription already exists, ignore the error.
-        if (ae.getStatusCode().getCode().equals(StatusCode.Code.ALREADY_EXISTS)) {
-          return;
-        }
-
-        //This error is thrown is the Topic does not exist.
-        // Call the stop method so the pipeline fails.
-        if (ae.getStatusCode().getCode().equals(StatusCode.Code.NOT_FOUND)) {
-          String message = String.format(MISSING_TOPIC_ERROR_MSG, topic, project);
-          stop(message, ae);
-          return;
-        }
-
-        //Retry if the exception is retryable.
-        if (isApiExceptionRetryable(ae)) {
-          backoff = sleepAndIncreaseBackoff(backoff);
-          continue;
-        }
-
-        //Report that we were not able to create the subscription and stop the receiver.
-        stop(String.format(CREATE_SUBSCRIPTION_ERROR_MSG, subscription), ae);
-        return;
-      } catch (IOException ioe) {
-        //Report that we were not able to create the subscription admin client and stop the receiver.
-        stop(String.format(CREATE_SUBSCRIPTION_ADMIN_CLIENT_ERROR_MSG, subscription), ioe);
+    try {
+      PubSubSubscriberUtil.createSubscription(() -> !isStopped(), backoffConfig, subscription, topic,
+                                              this::buildSubscriptionAdminClient, this::isApiExceptionRetryable);
+    } catch (InterruptedException e) {
+      stop(INTERRUPTED_EXCEPTION_MSG, e);
+    } catch (IOException e) {
+      //Report that we were not able to create the subscription admin client and stop the receiver.
+      stop(String.format(CREATE_SUBSCRIPTION_ADMIN_CLIENT_ERROR_MSG, subscription), e);
+    } catch (ApiException e) {
+      if (e.getStatusCode().getCode().equals(StatusCode.Code.NOT_FOUND)) {
+        String message = String.format(MISSING_TOPIC_ERROR_MSG, topic, project);
+        stop(message, e);
         return;
       }
+      //Report that we were not able to create the subscription and stop the receiver.
+      stop(String.format(CREATE_SUBSCRIPTION_ERROR_MSG, subscription), e);
+    } catch (RuntimeException e) {
+      //If we were not able to create the subscription after re-attempts, stop the pipeline and report the error.
+      stop(String.format(CREATE_SUBSCRIPTION_RETRY_ERROR_MSG, subscription), e);
     }
-
-    //If we were not able to create the subscription after 5 attempts, stop the pipeline and report the error.
-    stop(String.format(CREATE_SUBSCRIPTION_RETRY_ERROR_MSG, subscription), lastApiException);
   }
 
   /**
@@ -432,8 +385,12 @@ public class PubSubReceiver extends Receiver<PubSubMessage> {
    * @return Subscription Admin Client instance.
    * @throws IOException if the subscription admin client could not be created.
    */
-  protected SubscriptionAdminClient buildSubscriptionAdminClient() throws IOException {
-    return SubscriptionAdminClient.create(buildSubscriptionAdminSettings());
+  protected SubscriptionAdminClient buildSubscriptionAdminClient()  {
+    try {
+      return SubscriptionAdminClient.create(buildSubscriptionAdminSettings());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   /**
@@ -503,38 +460,7 @@ public class PubSubReceiver extends Receiver<PubSubMessage> {
    * @return boolean stating whether we should retry this request.
    */
   protected boolean isApiExceptionRetryable(ApiException ae) {
-    return ae.isRetryable() || RETRYABLE_STATUS_CODES.contains(ae.getStatusCode().getCode().getHttpStatusCode());
-  }
-
-  /**
-   * Class used to configure exponential backoff for Pub/Sub API requests.
-   */
-  public static class BackoffConfig implements Serializable {
-    final int initialBackoffMs;
-    final int maximumBackoffMs;
-    final double backoffFactor;
-
-    static final BackoffConfig defaultInstance() {
-      return new BackoffConfig(100, 10000, 2.0);
-    }
-
-    public BackoffConfig(int initialBackoffMs, int maximumBackoffMs, double backoffFactor) {
-      this.initialBackoffMs = initialBackoffMs;
-      this.maximumBackoffMs = maximumBackoffMs;
-      this.backoffFactor = backoffFactor;
-    }
-
-    public int getInitialBackoffMs() {
-      return initialBackoffMs;
-    }
-
-    public int getMaximumBackoffMs() {
-      return maximumBackoffMs;
-    }
-
-    public double getBackoffFactor() {
-      return backoffFactor;
-    }
+    return PubSubSubscriberUtil.isApiExceptionRetryable(ae);
   }
 
   /**

--- a/src/main/java/io/cdap/plugin/gcp/publisher/source/PubSubStructuredRecordConverter.java
+++ b/src/main/java/io/cdap/plugin/gcp/publisher/source/PubSubStructuredRecordConverter.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.gcp.publisher.source;
+
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.format.StructuredRecordStringConverter;
+import io.cdap.plugin.format.avro.AvroToStructuredTransformer;
+import io.cdap.plugin.gcp.common.MappingException;
+import io.cdap.plugin.gcp.publisher.PubSubConstants;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DecoderFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+
+/**
+ * PubSubStructuredRecordConverter for converting a PubSubMessage to StructuredRecord.
+ */
+public class PubSubStructuredRecordConverter implements SerializableFunction<PubSubMessage, StructuredRecord> {
+
+  private final GoogleSubscriberConfig config;
+
+  public PubSubStructuredRecordConverter(GoogleSubscriberConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public StructuredRecord apply(PubSubMessage pubSubMessage) {
+    Schema customMessageSchema = getCustomMessageSchema(config);
+    final Schema outputSchema = config.getSchema();
+    final String format = config.getFormat();
+
+    // Convert to a HashMap because com.google.api.client.util.ArrayMap is not serializable.
+    HashMap<String, String> attributeMap = new HashMap<>();
+    if (pubSubMessage.getAttributes() != null) {
+      attributeMap.putAll(pubSubMessage.getAttributes());
+    }
+
+    try {
+      StructuredRecord payload = getStructuredRecord(config, customMessageSchema, format, pubSubMessage);
+
+      return StructuredRecord.builder(outputSchema)
+        .set("message", (format.equalsIgnoreCase(PubSubConstants.TEXT) ||
+          format.equalsIgnoreCase(PubSubConstants.BLOB)) ?
+          pubSubMessage.getData() : payload)
+        .set("id", pubSubMessage.getMessageId())
+        .setTimestamp("timestamp", getTimestamp(pubSubMessage.getPublishTime()))
+        .set("attributes", attributeMap)
+        .build();
+    } catch (IOException ioe) {
+      throw new MappingException(ioe);
+    }
+  }
+
+  private static ZonedDateTime getTimestamp(Instant instant) {
+    return ZonedDateTime.ofInstant(instant, ZoneId.ofOffset("UTC", ZoneOffset.UTC));
+  }
+
+  private static Schema.Field getMessageField(GoogleSubscriberConfig config) {
+    Schema schema = config.getSchema();
+    return schema.getField("message");
+  }
+
+  private static Schema getCustomMessageSchema(GoogleSubscriberConfig config) {
+    Schema.Field messageField = getMessageField(config);
+    if (messageField == null) {
+      return null;
+    }
+    return messageField.getSchema();
+  }
+
+  private static StructuredRecord getStructuredRecord(GoogleSubscriberConfig config, Schema customMessageSchema,
+                                                      String format, PubSubMessage pubSubMessage) throws IOException {
+    StructuredRecord payload = null;
+    final String data = pubSubMessage.getData() != null ? new String(pubSubMessage.getData()) : "";
+
+    switch (format) {
+      case PubSubConstants.AVRO:
+      case PubSubConstants.PARQUET: {
+        final byte[] payloadData = pubSubMessage.getData();
+        final org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().
+          parse(String.valueOf(customMessageSchema));
+        DatumReader<GenericRecord> datumReader = new GenericDatumReader<>(avroSchema);
+        ByteArrayInputStream in = new ByteArrayInputStream(payloadData);
+        BinaryDecoder decoder = DecoderFactory.get().binaryDecoder(in, null);
+        GenericRecord record = datumReader.read(null, decoder);
+        payload = new AvroToStructuredTransformer().transform(record);
+        break;
+      }
+      case PubSubConstants.CSV: {
+        payload = StructuredRecordStringConverter.fromDelimitedString(data, ",", customMessageSchema);
+        break;
+      }
+      case PubSubConstants.DELIMITED: {
+        payload = StructuredRecordStringConverter.fromDelimitedString(data, config.getDelimiter(),
+                                                                      customMessageSchema);
+        break;
+      }
+      case PubSubConstants.JSON: {
+        payload = StructuredRecordStringConverter.fromJsonString(data, customMessageSchema);
+        break;
+      }
+      case PubSubConstants.TSV: {
+        payload = StructuredRecordStringConverter.fromDelimitedString(data, "\t", customMessageSchema);
+        break;
+      }
+    }
+    return payload;
+  }
+}
+

--- a/src/main/java/io/cdap/plugin/gcp/publisher/source/PubSubSubscriberUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/publisher/source/PubSubSubscriberUtil.java
@@ -15,6 +15,13 @@
  */
 package io.cdap.plugin.gcp.publisher.source;
 
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.auth.Credentials;
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.cloud.pubsub.v1.SubscriptionAdminSettings;
+import com.google.pubsub.v1.PushConfig;
 import io.cdap.cdap.etl.api.streaming.StreamingContext;
 import org.apache.spark.storage.StorageLevel;
 import org.apache.spark.streaming.api.java.JavaDStream;
@@ -25,7 +32,14 @@ import org.slf4j.LoggerFactory;
 import scala.collection.JavaConverters;
 import scala.reflect.ClassTag;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Set;
+import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Utility class to create a JavaDStream of received messages.
@@ -33,6 +47,17 @@ import java.util.ArrayList;
 public final class PubSubSubscriberUtil {
 
   protected static final Logger LOG = LoggerFactory.getLogger(PubSubSubscriberUtil.class);
+
+  // Retryable status codes. These need to be handled in case Pub/Sub throws a StatusRuntimeException.
+  private static final int RESOURCE_EXHAUSTED = StatusCode.Code.RESOURCE_EXHAUSTED.getHttpStatusCode();
+  private static final int CANCELLED = StatusCode.Code.CANCELLED.getHttpStatusCode();
+  private static final int INTERNAL = StatusCode.Code.INTERNAL.getHttpStatusCode();
+  private static final int UNAVAILABLE = StatusCode.Code.UNAVAILABLE.getHttpStatusCode();
+  private static final int DEADLINE_EXCEEDED = StatusCode.Code.DEADLINE_EXCEEDED.getHttpStatusCode();
+
+  private static final Set<Integer> RETRYABLE_STATUS_CODES =
+    Stream.of(RESOURCE_EXHAUSTED, CANCELLED, INTERNAL, UNAVAILABLE, DEADLINE_EXCEEDED).
+      collect(Collectors.toSet());
 
   private PubSubSubscriberUtil() {
   }
@@ -86,4 +111,91 @@ public final class PubSubSubscriberUtil {
     return new JavaDStream<>(dStream, tag);
   }
 
+  /**
+   * Create a new subscription (if needed) for the supplied topic.
+   *
+   * @param preCheck      Any checks that need to be applied before each retry.
+   * @param backoffConfig {@link BackoffConfig} for retries.
+   * @param subscription  Subscription name string.
+   * @param topic         Topic name string.
+   * @param clientSupplier Supplier for creating {@link SubscriptionAdminClient}
+   * @param isRetryableException Predicate for checking if the exception is retryable.
+   * @throws InterruptedException If the wait for retry is interrupted.
+   * @throws IOException          If {@link SubscriptionAdminClient} cannot be created.
+   */
+  public static void createSubscription(BooleanSupplier preCheck, BackoffConfig backoffConfig, String subscription,
+                                        String topic, Supplier<SubscriptionAdminClient> clientSupplier,
+                                        Predicate<ApiException> isRetryableException)
+    throws InterruptedException, IOException {
+
+    int backoff = backoffConfig.getInitialBackoffMs();
+    int attempts = 5;
+
+    ApiException lastApiException = null;
+
+    while (preCheck.getAsBoolean() && attempts-- > 0) {
+
+      try (SubscriptionAdminClient subscriptionAdminClient = clientSupplier.get()) {
+
+        int ackDeadline = 60; // 60 seconds before resending the message.
+        subscriptionAdminClient.createSubscription(
+          subscription, topic, PushConfig.getDefaultInstance(), ackDeadline);
+        return;
+
+      } catch (ApiException ae) {
+
+        lastApiException = ae;
+
+        //If the subscription already exists, ignore the error.
+        if (ae.getStatusCode().getCode().equals(StatusCode.Code.ALREADY_EXISTS)) {
+          return;
+        }
+
+        //Retry if the exception is retryable.
+        if (isRetryableException.test(ae)) {
+          backoff = sleepAndIncreaseBackoff(preCheck, backoff, backoffConfig);
+          continue;
+        }
+        throw ae;
+      }
+    }
+
+    throw new RuntimeException(lastApiException);
+  }
+
+  /**
+   * Method to determine if an API Exception is retryable. This uses the built-in method in API Exception as well
+   * as checking the status code.
+   * <p>
+   * In testing, we noticed the client was wrapping some network exceptions declaring those as not retryable,
+   * even when the Pub/Sub documentation states that the request may be retryable.
+   *
+   * @param ae the API Exception
+   * @return boolean stating whether we should retry this request.
+   */
+  public static boolean isApiExceptionRetryable(ApiException ae) {
+    return ae.isRetryable() || RETRYABLE_STATUS_CODES.contains(ae.getStatusCode().getCode().getHttpStatusCode());
+  }
+
+  private static SubscriptionAdminClient buildSubscriptionAdminClient(Credentials credentials) throws IOException {
+    SubscriptionAdminSettings.Builder builder = SubscriptionAdminSettings.newBuilder();
+    if (credentials != null) {
+      builder.setCredentialsProvider(FixedCredentialsProvider.create(credentials));
+    }
+    return SubscriptionAdminClient.create(builder.build());
+  }
+
+  private static int sleepAndIncreaseBackoff(BooleanSupplier preCheck, int backoff,
+                                             BackoffConfig backoffConfig) throws InterruptedException {
+    if (preCheck.getAsBoolean()) {
+      LOG.trace("Backoff - Sleeping for {} ms.", backoff);
+      Thread.sleep(backoff);
+    }
+
+    return calculateUpdatedBackoff(backoff, backoffConfig);
+  }
+
+  private static int calculateUpdatedBackoff(int backoff, BackoffConfig backoffConfig) {
+    return Math.min((int) (backoff * backoffConfig.getBackoffFactor()), backoffConfig.getMaximumBackoffMs());
+  }
 }

--- a/src/test/java/io/cdap/plugin/gcp/publisher/source/PubSubReceiverMessagePullingTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/publisher/source/PubSubReceiverMessagePullingTest.java
@@ -73,7 +73,7 @@ public class PubSubReceiverMessagePullingTest {
   @Mock
   UnaryCallable<AcknowledgeRequest, Empty> acknowledgeCallable;
   @Mock
-  PubSubReceiver.BackoffConfig backoffConfig;
+  BackoffConfig backoffConfig;
   @Mock
   ScheduledThreadPoolExecutor executor;
 

--- a/src/test/java/io/cdap/plugin/gcp/publisher/source/PubSubReceiverSubscriptionTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/publisher/source/PubSubReceiverSubscriptionTest.java
@@ -65,7 +65,7 @@ public class PubSubReceiverSubscriptionTest {
   @Mock
   SubscriptionAdminClient subscriptionAdminClient;
   @Mock
-  PubSubReceiver.BackoffConfig backoffConfig;
+  BackoffConfig backoffConfig;
   @Mock
   ScheduledThreadPoolExecutor executor;
   @Mock


### PR DESCRIPTION
[PLUGIN-1537](https://cdap.atlassian.net/browse/PLUGIN-1537) State management changes for PubSub part1. Follow up PR will include the changes for direct Dstream.
- Refactor code to reuse common functionality like creating subscription for receiver based Dstream and direct DStream.
- Move structured record mapping function and GoogleSubscriberConfig out of GoogleSubscriber so that they can be used in serializable Dstream.
- Introduce SerializableFunction1 for using in direct dstream.

[PLUGIN-1502]: https://cdap.atlassian.net/browse/PLUGIN-1502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PLUGIN-1537]: https://cdap.atlassian.net/browse/PLUGIN-1537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ