### PR TITLE
[PLUGIN-1537] - State management changes for Pub/Sub streaming source.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <avro.version>1.8.2</avro.version>
     <bigquery.connector.hadoop2.version>hadoop2-1.0.0</bigquery.connector.hadoop2.version>
     <commons.codec.version>1.4</commons.codec.version>
-    <cdap.version>6.9.0-SNAPSHOT</cdap.version>
+    <cdap.version>6.9.1-SNAPSHOT</cdap.version>
     <cdap.plugin.version>2.11.0-SNAPSHOT</cdap.plugin.version>
     <dropwizard.metrics-core.version>3.2.6</dropwizard.metrics-core.version>
     <flogger.system.backend.version>0.3.1</flogger.system.backend.version>
@@ -886,8 +886,8 @@
         <version>1.1.0</version>
         <configuration>
           <cdapArtifacts>
-            <parent>system:cdap-data-pipeline[6.8.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
-            <parent>system:cdap-data-streams[6.8.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-pipeline[6.9.1-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-streams[6.9.1-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
           </cdapArtifacts>
         </configuration>
         <executions>

--- a/src/main/java/io/cdap/plugin/gcp/publisher/source/PubSubDirectDStream.java
+++ b/src/main/java/io/cdap/plugin/gcp/publisher/source/PubSubDirectDStream.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.gcp.publisher.source;
+
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.rpc.NotFoundException;
+import com.google.auth.Credentials;
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.cloud.pubsub.v1.SubscriptionAdminSettings;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.pubsub.v1.CreateSnapshotRequest;
+import com.google.pubsub.v1.ProjectSnapshotName;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.SeekRequest;
+import com.google.pubsub.v1.Snapshot;
+import com.google.pubsub.v1.TopicName;
+import io.cdap.cdap.etl.api.streaming.StreamingEventHandler;
+import io.cdap.plugin.gcp.common.GCPUtils;
+import org.apache.spark.rdd.RDD;
+import org.apache.spark.streaming.StreamingContext;
+import org.apache.spark.streaming.Time;
+import org.apache.spark.streaming.dstream.InputDStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Option;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+import javax.annotation.Nullable;
+
+/**
+ * PubSubDirectDStream implementation.
+ * A snapshot is taken and saved before each batch and deleted on successful completion.
+ * On retrying a batch, snapshot is restored.
+ *
+ * @param <T> Type of object returned by RDD
+ */
+public class PubSubDirectDStream<T> extends InputDStream<T> implements StreamingEventHandler {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PubSubDirectDStream.class);
+  private static final String CDAP_PIPELINE = "cdap_pipeline";
+
+  private final Credentials credentials;
+  private final PubSubSubscriberConfig config;
+  private final long readDuration;
+  private final io.cdap.cdap.etl.api.streaming.StreamingContext context;
+  private final boolean autoAcknowledge;
+  private final SerializableFunction<PubSubMessage, T> mappingFn;
+  private final StreamingContext streamingContext;
+  private final String pipeline;
+
+  private SubscriptionAdminClient subscriptionAdminClient;
+  private ProjectSnapshotName currentSnapshotName;
+  private boolean takeSnapshot;
+
+  public PubSubDirectDStream(io.cdap.cdap.etl.api.streaming.StreamingContext context, PubSubSubscriberConfig config,
+                             long readDuration, boolean autoAcknowledge,
+                             SerializableFunction<PubSubMessage, T> mappingFn) {
+    super(context.getSparkStreamingContext().ssc(), scala.reflect.ClassTag$.MODULE$.apply(PubSubMessage.class));
+    this.streamingContext = context.getSparkStreamingContext().ssc();
+    this.config = config;
+    this.readDuration = readDuration;
+    this.context = context;
+    this.autoAcknowledge = autoAcknowledge;
+    this.mappingFn = mappingFn;
+    this.pipeline = context.getPipelineName();
+    this.credentials = createCredentials(config.getServiceAccount(), config.isServiceAccountFilePath());
+  }
+
+  @Override
+  public Option<RDD<T>> compute(Time validTime) {
+    LOG.debug("Computing RDD for time {}.", validTime);
+    PubSubRDD pubSubRDD = new PubSubRDD(streamingContext.sparkContext(), validTime, readDuration, config,
+                                        autoAcknowledge, credentials);
+    RDD<T> mapped = pubSubRDD.map(mappingFn, scala.reflect.ClassTag$.MODULE$.apply(PubSubMessage.class));
+    return Option.apply(mapped);
+  }
+
+  @Override
+  public void start() {
+    if (config.getTopic() != null) {
+      try {
+        createSubscriptionIfNotPresent();
+      } catch (IOException | InterruptedException e) {
+        throw new RuntimeException("Subscription creation failed.", e);
+      }
+    }
+
+    try {
+      subscriptionAdminClient = buildSubscriptionAdminClient(credentials);
+    } catch (IOException e) {
+      throw new RuntimeException("SubscriptionAdminClient creation failed.", e);
+    }
+
+    // If state with snapshot is present, seek to it.
+    this.currentSnapshotName = fetchSnapShot(config.getSubscription(), context);
+    if (this.currentSnapshotName != null) {
+      seekSnapshot(currentSnapshotName, ProjectSubscriptionName.of(config.getProject(), config.getSubscription()));
+      // Can use the same snapshot till end of the batch.
+      takeSnapshot = false;
+    } else {
+      takeSnapshot = true;
+    }
+  }
+
+  @Override
+  public void stop() {
+    if (subscriptionAdminClient == null) {
+      return;
+    }
+
+    subscriptionAdminClient.close();
+  }
+
+  @Override
+  public void onBatchStarted(io.cdap.cdap.etl.api.streaming.StreamingContext streamingContext) {
+    LOG.debug("Starting a batch.");
+    if (!takeSnapshot) {
+      return;
+    }
+
+    String generatedSnapshotName = generateName(config.getSubscription());
+    ProjectSnapshotName projectSnapshotName = ProjectSnapshotName.of(config.getProject(), generatedSnapshotName);
+    ProjectSubscriptionName projectSubscriptionName = ProjectSubscriptionName.of(config.getProject(),
+                                                                                 config.getSubscription());
+    // Create in Pub/Sub
+    Snapshot snapshot = createSnapshot(projectSnapshotName, projectSubscriptionName);
+    // Save snapshot as state
+    try {
+      saveSnapshotAsState(snapshot, config.getSubscription(), context);
+    } catch (IOException e) {
+      // Delete the snapshot from Pub/Sub to avoid abandoned snapshots.
+      // Snapshots have a max expiry of 7 days after which it gets auto deleted.
+      deleteSnapshot(projectSnapshotName);
+
+      // Retries are already part of the state saving library, so just throw here.
+      throw new RuntimeException("Error while saving state.", e);
+    }
+    this.currentSnapshotName = projectSnapshotName;
+  }
+
+  @Override
+  public void onBatchRetry(io.cdap.cdap.etl.api.streaming.StreamingContext streamingContext) {
+    LOG.debug("Batch is about to be retried. Seeking to snapshot {} for the current batch.", currentSnapshotName);
+    seekSnapshot(currentSnapshotName, ProjectSubscriptionName.of(config.getProject(), config.getSubscription()));
+  }
+
+  @Override
+  public void onBatchCompleted(io.cdap.cdap.etl.api.streaming.StreamingContext streamingContext) {
+    LOG.debug("Batch completed called.");
+    try {
+      streamingContext.deleteState(config.getSubscription());
+    } catch (IOException e) {
+      throw new RuntimeException("Deleting state failed. ", e);
+    }
+    // delete the snapshot from Pub/Sub .
+    deleteSnapshot(currentSnapshotName);
+
+    // For next batch
+    takeSnapshot = true;
+    LOG.debug("Batch completed successfully. Deleted snapshot {} for the current batch.", currentSnapshotName);
+  }
+
+  private String generateName(String subscription) {
+    // Rules for name
+    // Not begin with the string goog
+    // Start with a letter
+    // Contain between 3 and 255 characters
+    // Contain only the following characters:
+    // Letters [A-Za-z], numbers [0-9], dashes -, underscores _, periods ., tildes ~, plus signs +, and percent signs %
+
+    // Starting with subscription name should take care of the beginning reqs.
+    String uuidString = UUID.randomUUID().toString();
+    int maxLenForSubscriptionPrefix = 255 - uuidString.length() - 1;
+    String subscriptionPrefix = subscription.length() > maxLenForSubscriptionPrefix ?
+      subscription.substring(0, maxLenForSubscriptionPrefix) : subscription;
+    return String.format("%s-%s", subscriptionPrefix, uuidString);
+  }
+
+  private void createSubscriptionIfNotPresent() throws IOException, InterruptedException {
+    PubSubSubscriberUtil.createSubscription(() -> true, BackoffConfig.defaultInstance(),
+                                            ProjectSubscriptionName.format(config.getProject(),
+                                                                           config.getSubscription()),
+                                            TopicName.format(config.getProject(), config.getTopic()),
+                                            () -> subscriptionAdminClient,
+                                            PubSubSubscriberUtil::isApiExceptionRetryable);
+  }
+
+  private void seekSnapshot(ProjectSnapshotName projectSnapshotName,
+                            ProjectSubscriptionName projectSubscriptionName) {
+    try {
+      subscriptionAdminClient.seek(SeekRequest.newBuilder().setSnapshot(projectSnapshotName.toString())
+                                     .setSubscription(projectSubscriptionName.toString())
+                                     .build());
+    } catch (NotFoundException e) {
+      throw new RuntimeException(String.format(
+        "Saved snapshot %s not found. Please clear the application state to proceed. " +
+          "REST api for state deletion is namespaces/{namespace-id}/apps/{app-id}/state .",
+        projectSnapshotName.toString()), e);
+    }
+  }
+
+  @Nullable
+  private ProjectSnapshotName fetchSnapShot(String subscriptionId,
+                                            io.cdap.cdap.etl.api.streaming.StreamingContext context) {
+    Optional<byte[]> state = null;
+    try {
+      state = context.getState(subscriptionId);
+    } catch (IOException e) {
+      throw new RuntimeException(String.format("Error fetching saved state for subscription %s.", subscriptionId), e);
+    }
+
+    if (!state.isPresent()) {
+      LOG.debug("No saved state for {}.", subscriptionId);
+      return null;
+    }
+
+    try {
+      Snapshot snapshot = Snapshot.parseFrom(state.get());
+      LOG.debug("Found existing snapshot {} .", snapshot.getName());
+      return ProjectSnapshotName.parse(snapshot.getName());
+    } catch (InvalidProtocolBufferException e) {
+      throw new RuntimeException(String.format("Error parsing saved state for subscription %s.", subscriptionId), e);
+    }
+  }
+
+  private Snapshot createSnapshot(ProjectSnapshotName projectSnapshotName,
+                                  ProjectSubscriptionName projectSubscriptionName) {
+    // Creation takes around 3.5 s .
+    LOG.debug("Creating snapshot {} for subscription {} in Pub/Sub .", projectSnapshotName.toString(),
+              projectSubscriptionName.toString());
+    CreateSnapshotRequest request = CreateSnapshotRequest.newBuilder()
+      .setName(projectSnapshotName.toString())
+      .setSubscription(projectSubscriptionName.toString())
+      .putAllLabels(Collections.singletonMap(CDAP_PIPELINE, pipeline))
+      .build();
+    return subscriptionAdminClient.createSnapshot(request);
+  }
+
+  private void deleteSnapshot(ProjectSnapshotName projectSnapshotName) {
+    // Deletion takes around 2.5 s .
+    // TODO - Consider making this asynchronous
+    subscriptionAdminClient.deleteSnapshot(projectSnapshotName);
+  }
+
+  private void saveSnapshotAsState(Snapshot snapshot, String subscription,
+                                   io.cdap.cdap.etl.api.streaming.StreamingContext context) throws IOException {
+    LOG.debug("Saving snapshot {} in state .", snapshot.getName());
+    context.saveState(subscription, snapshot.toByteArray());
+  }
+
+  private SubscriptionAdminClient buildSubscriptionAdminClient(Credentials credentials) throws IOException {
+    SubscriptionAdminSettings.Builder builder = SubscriptionAdminSettings.newBuilder();
+
+    if (credentials != null) {
+      builder.setCredentialsProvider(FixedCredentialsProvider.create(credentials));
+    }
+
+    RetrySettings retrySettings = PubSubSubscriberUtil.getRetrySettings();
+    builder.seekSettings().setRetrySettings(retrySettings);
+    builder.createSnapshotSettings().setRetrySettings(retrySettings);
+    builder.deleteSnapshotSettings().setRetrySettings(retrySettings);
+
+    return SubscriptionAdminClient.create(builder.build());
+  }
+
+  private Credentials createCredentials(String serviceAccount, boolean serviceAccountFilePath) {
+    try {
+      return serviceAccount == null ? null : GCPUtils.loadServiceAccountCredentials(serviceAccount,
+                                                                                    serviceAccountFilePath);
+    } catch (IOException e) {
+      throw new RuntimeException("error creating credentials from service account.", e);
+    }
+  }
+}

--- a/src/main/java/io/cdap/plugin/gcp/publisher/source/PubSubRDD.java
+++ b/src/main/java/io/cdap/plugin/gcp/publisher/source/PubSubRDD.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.gcp.publisher.source;
+
+import com.google.auth.Credentials;
+import org.apache.spark.Partition;
+import org.apache.spark.SparkContext;
+import org.apache.spark.TaskContext;
+import org.apache.spark.rdd.RDD;
+import org.apache.spark.streaming.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.collection.Iterator;
+
+import java.util.Collections;
+
+/**
+ * PubSubRDD that returns PubSubMessage for each partition.
+ * Partition count is same as the number of readers.
+ */
+public class PubSubRDD extends RDD<PubSubMessage> {
+  private static final Logger LOG = LoggerFactory.getLogger(PubSubRDD.class);
+
+  private final Time batchTime;
+  private final long readDuration;
+  private final PubSubSubscriberConfig config;
+  private final boolean autoAcknowledge;
+  private final Credentials credentials;
+
+  PubSubRDD(SparkContext sparkContext, Time batchTime, long readDuration, PubSubSubscriberConfig config,
+            boolean autoAcknowledge, Credentials credentials) {
+    super(sparkContext, scala.collection.JavaConverters.asScalaBuffer(Collections.emptyList()),
+          scala.reflect.ClassTag$.MODULE$.apply(PubSubMessage.class));
+    this.batchTime = batchTime;
+    this.readDuration = readDuration;
+    this.config = config;
+    this.autoAcknowledge = autoAcknowledge;
+    this.credentials = credentials;
+  }
+
+  @Override
+  public Iterator<PubSubMessage> compute(Partition split, TaskContext context) {
+    LOG.debug("Computing for partition {} .", split.index());
+    return new PubSubRDDIterator(config, context, batchTime, readDuration, autoAcknowledge, credentials);
+  }
+
+  @Override
+  public Partition[] getPartitions() {
+    int partitionCount = config.getNumberOfReaders();
+    Partition[] partitions = new Partition[partitionCount];
+    for (int i = 0; i < partitionCount; i++) {
+      final int index = i;
+      partitions[i] = () -> index;
+    }
+    return partitions;
+  }
+}

--- a/src/main/java/io/cdap/plugin/gcp/publisher/source/PubSubRDDIterator.java
+++ b/src/main/java/io/cdap/plugin/gcp/publisher/source/PubSubRDDIterator.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.gcp.publisher.source;
+
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.auth.Credentials;
+import com.google.cloud.pubsub.v1.stub.GrpcSubscriberStub;
+import com.google.cloud.pubsub.v1.stub.SubscriberStub;
+import com.google.cloud.pubsub.v1.stub.SubscriberStubSettings;
+import com.google.pubsub.v1.AcknowledgeRequest;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.PullRequest;
+import com.google.pubsub.v1.PullResponse;
+import com.google.pubsub.v1.ReceivedMessage;
+import org.apache.spark.TaskContext;
+import org.apache.spark.streaming.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.collection.Iterator;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * Iterator for PubSub RDD.
+ * Fetches a fixed amount of messages at a time and acknowledges them.
+ * Finishes when the acknowledged messages are completed and the batch time limit is met.
+ * Returns immediately if there are no more messages to read.
+ */
+public class PubSubRDDIterator implements Iterator<PubSubMessage> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PubSubRDDIterator.class);
+  private static final int MAX_MESSAGES = 1000;
+
+  private final long startTime;
+  private final PubSubSubscriberConfig config;
+  private final TaskContext context;
+  private final long batchDuration;
+  private final Credentials credentials;
+  private final String subscriptionFormatted;
+  private final boolean autoAcknowledge;
+  private final Queue<ReceivedMessage> receivedMessages;
+
+  private PullRequest pullRequest;
+  private SubscriberStub subscriber;
+  private long messageCount;
+
+  public PubSubRDDIterator(PubSubSubscriberConfig config, TaskContext context, Time batchTime, long batchDuration,
+                           boolean autoAcknowledge, Credentials credentials) {
+    this.config = config;
+    this.context = context;
+    this.batchDuration = batchDuration;
+    this.credentials = credentials;
+    this.startTime = batchTime.milliseconds();
+    this.autoAcknowledge = autoAcknowledge;
+    subscriptionFormatted = ProjectSubscriptionName.format(this.config.getProject(), this.config.getSubscription());
+    receivedMessages = new ConcurrentLinkedDeque<>();
+  }
+
+  @Override
+  public boolean hasNext() {
+    // Complete processing of acknowledged messages before finishing the batch.
+    if (!receivedMessages.isEmpty()) {
+      return true;
+    }
+
+    long currentTimeMillis = System.currentTimeMillis();
+    if (currentTimeMillis >= (startTime + batchDuration)) {
+      LOG.debug("Time exceeded for batch. Total time is {} millis. Total messages returned is {} .",
+                currentTimeMillis - startTime, messageCount);
+      return false;
+    }
+
+    try {
+      List<ReceivedMessage> messages = fetchAndAck();
+      //If there are no messages to process, continue.
+      if (messages.isEmpty()) {
+        LOG.debug("No more messages. Total messages returned is {} .", messageCount);
+        return false;
+      }
+      receivedMessages.addAll(messages);
+      return true;
+    } catch (IOException e) {
+      throw new RuntimeException("Error reading messages from Pub/Sub. ", e);
+    }
+  }
+
+  @Override
+  public PubSubMessage next() {
+    if (receivedMessages.isEmpty()) {
+      // This should not happen, if hasNext() returns true, then a message should be available in queue.
+      throw new IllegalStateException("Unexpected state. No messages available.");
+    }
+
+    ReceivedMessage currentMessage = receivedMessages.poll();
+    messageCount += 1;
+    return new PubSubMessage(currentMessage);
+  }
+
+  private SubscriberStub buildSubscriberClient() throws IOException {
+    SubscriberStubSettings.Builder builder = SubscriberStubSettings.newBuilder();
+    if (credentials != null) {
+      builder.setCredentialsProvider(FixedCredentialsProvider.create(credentials));
+    }
+    builder.getSubscriptionSettings().setRetrySettings(PubSubSubscriberUtil.getRetrySettings());
+    return GrpcSubscriberStub.create(builder.build());
+  }
+
+  private List<ReceivedMessage> fetchAndAck() throws IOException {
+    if (this.subscriber == null) {
+      this.subscriber = buildSubscriberClient();
+      context.addTaskCompletionListener(context1 -> {
+        if (subscriber != null && !subscriber.isShutdown()) {
+          subscriber.shutdown();
+          try {
+            subscriber.awaitTermination(30, TimeUnit.SECONDS);
+          } catch (InterruptedException e) {
+            LOG.warn("Exception in shutting down subscriber. ", e);
+          }
+        }
+      });
+      this.pullRequest = PullRequest.newBuilder()
+        .setMaxMessages(MAX_MESSAGES)
+        .setSubscription(subscriptionFormatted)
+        .build();
+    }
+
+    PullResponse pullResponse = subscriber.pullCallable().call(pullRequest);
+    List<ReceivedMessage> receivedMessagesList = pullResponse.getReceivedMessagesList();
+    if (receivedMessagesList.isEmpty()) {
+      return receivedMessagesList;
+    }
+
+    List<String> ackIds =
+      receivedMessagesList.stream().map(ReceivedMessage::getAckId).collect(Collectors.toList());
+    ackMessages(ackIds, autoAcknowledge, subscriptionFormatted);
+    return receivedMessagesList;
+  }
+
+  private void ackMessages(List<String> ackIds, boolean autoAcknowledge, String subscriptionFormatted) {
+    if (!autoAcknowledge) {
+      return;
+    }
+    // Acknowledge received messages.
+    AcknowledgeRequest acknowledgeRequest =
+      AcknowledgeRequest.newBuilder()
+        .setSubscription(subscriptionFormatted)
+        .addAllAckIds(ackIds)
+        .build();
+    subscriber.acknowledgeCallable().call(acknowledgeRequest);
+  }
+}

--- a/src/main/java/io/cdap/plugin/gcp/publisher/source/PubSubSubscriber.java
+++ b/src/main/java/io/cdap/plugin/gcp/publisher/source/PubSubSubscriber.java
@@ -48,8 +48,7 @@ public abstract class PubSubSubscriber<T> extends StreamingSource<T> {
       throw new IllegalArgumentException("Mapping Function must be specified for a PubSubSubscriber");
     }
 
-    return (JavaDStream<T>) PubSubSubscriberUtil.getStream(context, config)
-      .map(pubSubMessage -> mappingFunction.apply(pubSubMessage));
+    return PubSubSubscriberUtil.getStream(context, config, mappingFunction);
   }
 
   @Override

--- a/src/main/java/io/cdap/plugin/gcp/publisher/source/SerializableFunction.java
+++ b/src/main/java/io/cdap/plugin/gcp/publisher/source/SerializableFunction.java
@@ -15,6 +15,8 @@
  */
 package io.cdap.plugin.gcp.publisher.source;
 
+import scala.Function1;
+
 import java.io.Serializable;
 import java.util.function.Function;
 
@@ -23,5 +25,5 @@ import java.util.function.Function;
  * @param <T> the type of the input to the function
  * @param <R> the type of the result of the function
  */
-public interface SerializableFunction<T, R> extends Function<T, R>, Serializable {
+public interface SerializableFunction<T, R> extends Function<T, R>, Function1<T, R>, Serializable {
 }


### PR DESCRIPTION
[PLUGIN-1537](https://cdap.atlassian.net/browse/PLUGIN-1537)
- Direct dstream implementation is used when state store is enabled.
- A snapshot is created before each batch and deleted after the batch completes successfully.
- Seek is only done on pipeline restarts if a snapshot is present in saved state and on job restarts.
- RDD reads data using a lazy iterator that reads a fixed amount of records at a time and acknowledges them. 
- RDD finishes processing once the read data is processed and batch duration is complete.
- Retries for stages and tasks are disabled.
- RDD partition count is same as the number of readers config in the plugin.

[PLUGIN-1537]: https://cdap.atlassian.net/browse/PLUGIN-1537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ