### PR TITLE
[PLUGIN-1599] Move mapping function to a different class to prevent validation failure

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/publisher/source/GoogleSubscriber.java
+++ b/src/main/java/io/cdap/plugin/gcp/publisher/source/GoogleSubscriber.java
@@ -45,10 +45,8 @@ public class GoogleSubscriber extends PubSubSubscriber<StructuredRecord> impleme
   public GoogleSubscriber(GoogleSubscriberConfig config) {
     super(config);
     this.config = config;
-
-    //Set mapping function for output records.
-    super.setMappingFunction(new PubSubStructuredRecordConverter(config));
   }
+
 
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
@@ -82,5 +80,10 @@ public class GoogleSubscriber extends PubSubSubscriber<StructuredRecord> impleme
       recorder.recordRead("Read", "Read from Pub/Sub",
                           schema.getFields().stream().map(Schema.Field::getName).collect(Collectors.toList()));
     }
+  }
+
+  @Override
+  public SerializableFunction<PubSubMessage, StructuredRecord> getMappingFunction() {
+    return PubSubSubscriberUtil.getMappingFunction(config);
   }
 }

--- a/src/main/java/io/cdap/plugin/gcp/publisher/source/PubSubSubscriber.java
+++ b/src/main/java/io/cdap/plugin/gcp/publisher/source/PubSubSubscriber.java
@@ -38,14 +38,14 @@ public abstract class PubSubSubscriber<T> extends StreamingSource<T> {
     this.mappingFunction = mappingFunction;
   }
 
-  protected void setMappingFunction(SerializableFunction<PubSubMessage, T> mappingFunction) {
-    this.mappingFunction = mappingFunction;
-  }
-
   @Override
   public JavaDStream<T> getStream(StreamingContext context) throws Exception {
     if (mappingFunction == null) {
-      throw new IllegalArgumentException("Mapping Function must be specified for a PubSubSubscriber");
+      SerializableFunction<PubSubMessage, T> serializableFunction = getMappingFunction();
+      if (serializableFunction == null) {
+        throw new IllegalArgumentException("Mapping Function must be specified for a PubSubSubscriber");
+      }
+      mappingFunction = serializableFunction;
     }
 
     return PubSubSubscriberUtil.getStream(context, config, mappingFunction);
@@ -56,4 +56,10 @@ public abstract class PubSubSubscriber<T> extends StreamingSource<T> {
     return config.getNumberOfReaders();
   }
 
+  /**
+   * Get the mapping function
+   *
+   * @return {@link SerializableFunction<PubSubMessage, T>}
+   */
+  public abstract SerializableFunction<PubSubMessage, T> getMappingFunction();
 }

--- a/src/main/java/io/cdap/plugin/gcp/publisher/source/PubSubSubscriberUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/publisher/source/PubSubSubscriberUtil.java
@@ -23,6 +23,7 @@ import com.google.auth.Credentials;
 import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.cloud.pubsub.v1.SubscriptionAdminSettings;
 import com.google.pubsub.v1.PushConfig;
+import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.etl.api.streaming.StreamingContext;
 import org.apache.spark.storage.StorageLevel;
 import org.apache.spark.streaming.api.java.JavaDStream;
@@ -187,6 +188,17 @@ public final class PubSubSubscriberUtil {
    */
   public static boolean isApiExceptionRetryable(ApiException ae) {
     return ae.isRetryable() || RETRYABLE_STATUS_CODES.contains(ae.getStatusCode().getCode().getHttpStatusCode());
+  }
+
+  /**
+   * Return the mapping function to convert PubSubMessage to StructuredRecord.
+   *
+   * @param config {@link GoogleSubscriberConfig}
+   * @return {@link SerializableFunction}
+   */
+  public static SerializableFunction<PubSubMessage, StructuredRecord>
+  getMappingFunction(GoogleSubscriberConfig config) {
+    return new PubSubStructuredRecordConverter(config);
   }
 
   public static RetrySettings getRetrySettings() {


### PR DESCRIPTION
[PLUGIN-1599](https://cdap.atlassian.net/browse/PLUGIN-1599)

- Currently validation for PubSub streaming source plugin fails because the scala.Function1 class is not found. Root cause for this is mentioned in this bug - https://cdap.atlassian.net/browse/CDAP-16979
- As a workaround, move the mapping function out of GoogleSubscriber class and also remove setting it from the constructor. This will avoid creation of PubSubStructuredRecordConverter during validation and fixes the issue.

[PLUGIN-1599]: https://cdap.atlassian.net/browse/PLUGIN-1599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ