### PR TITLE
[CDAP-20659] Added snapshot label value validations.

### DIFF
--- a/src/test/java/io/cdap/plugin/gcp/publisher/source/PubSubDirectStreamTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/publisher/source/PubSubDirectStreamTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.gcp.publisher.source;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Unit tests for PubSubDirectStream
+ */
+public class PubSubDirectStreamTest {
+
+  @Test
+  public void testLabelValue() {
+    Map<String, String> testAndResults = new HashMap<>();
+    testAndResults.put("abc", "abc");
+    testAndResults.put("Abc", "abc");
+    testAndResults.put("AbcAbcAbcAbcAbcAbcAbcAbcAbcAbcAbcAbcAbcAbcAbcAbcAbcAbcAbcAbcAbc123",
+                       "AbcAbcAbcAbcAbcAbcAbcAbcAbcAbcAbcAbcAbcAbcAbcAbcAbcAbcAbcAbcAbc".toLowerCase());
+    testAndResults.forEach((test, expected) -> {
+      String actual = PubSubDirectDStream.getLabelValue(test);
+      Assert.assertEquals(expected, actual);
+      Assert.assertTrue(actual.length() <= 63);
+    });
+  }
+}


### PR DESCRIPTION
Cherry pick for https://github.com/data-integrations/google-cloud/pull/1248 .

[CDAP-20659](https://cdap.atlassian.net/browse/CDAP-20659) : Added snapshot label value validations

[CDAP-20659]: https://cdap.atlassian.net/browse/CDAP-20659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ