### PR TITLE
PLUGIN-1621 : Remove Credential object from RDD constructor to prevent serializing.

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/publisher/source/PubSubRDD.java
+++ b/src/main/java/io/cdap/plugin/gcp/publisher/source/PubSubRDD.java
@@ -15,7 +15,6 @@
  */
 package io.cdap.plugin.gcp.publisher.source;
 
-import com.google.auth.Credentials;
 import org.apache.spark.Partition;
 import org.apache.spark.SparkContext;
 import org.apache.spark.TaskContext;
@@ -38,23 +37,21 @@ public class PubSubRDD extends RDD<PubSubMessage> {
   private final long readDuration;
   private final PubSubSubscriberConfig config;
   private final boolean autoAcknowledge;
-  private final Credentials credentials;
 
   PubSubRDD(SparkContext sparkContext, Time batchTime, long readDuration, PubSubSubscriberConfig config,
-            boolean autoAcknowledge, Credentials credentials) {
+            boolean autoAcknowledge) {
     super(sparkContext, scala.collection.JavaConverters.asScalaBuffer(Collections.emptyList()),
           scala.reflect.ClassTag$.MODULE$.apply(PubSubMessage.class));
     this.batchTime = batchTime;
     this.readDuration = readDuration;
     this.config = config;
     this.autoAcknowledge = autoAcknowledge;
-    this.credentials = credentials;
   }
 
   @Override
   public Iterator<PubSubMessage> compute(Partition split, TaskContext context) {
     LOG.debug("Computing for partition {} .", split.index());
-    return new PubSubRDDIterator(config, context, batchTime, readDuration, autoAcknowledge, credentials);
+    return new PubSubRDDIterator(config, context, batchTime, readDuration, autoAcknowledge);
   }
 
   @Override

--- a/src/main/java/io/cdap/plugin/gcp/publisher/source/PubSubRDDIterator.java
+++ b/src/main/java/io/cdap/plugin/gcp/publisher/source/PubSubRDDIterator.java
@@ -56,7 +56,6 @@ public class PubSubRDDIterator implements Iterator<PubSubMessage> {
   private final PubSubSubscriberConfig config;
   private final TaskContext context;
   private final long batchDuration;
-  private final Credentials credentials;
   private final String subscriptionFormatted;
   private final boolean autoAcknowledge;
   private final Queue<ReceivedMessage> receivedMessages;
@@ -66,11 +65,10 @@ public class PubSubRDDIterator implements Iterator<PubSubMessage> {
   private long messageCount;
 
   public PubSubRDDIterator(PubSubSubscriberConfig config, TaskContext context, Time batchTime, long batchDuration,
-                           boolean autoAcknowledge, Credentials credentials) {
+                           boolean autoAcknowledge) {
     this.config = config;
     this.context = context;
     this.batchDuration = batchDuration;
-    this.credentials = credentials;
     this.startTime = batchTime.milliseconds();
     this.autoAcknowledge = autoAcknowledge;
     subscriptionFormatted = ProjectSubscriptionName.format(this.config.getProject(), this.config.getSubscription());
@@ -120,6 +118,8 @@ public class PubSubRDDIterator implements Iterator<PubSubMessage> {
 
   private SubscriberStub buildSubscriberClient() throws IOException {
     SubscriberStubSettings.Builder builder = SubscriberStubSettings.newBuilder();
+    Credentials credentials = PubSubSubscriberUtil.createCredentials(config.getServiceAccount(),
+                                                                     config.isServiceAccountFilePath());
     if (credentials != null) {
       builder.setCredentialsProvider(FixedCredentialsProvider.create(credentials));
     }

--- a/src/main/java/io/cdap/plugin/gcp/publisher/source/PubSubSubscriberUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/publisher/source/PubSubSubscriberUtil.java
@@ -25,6 +25,7 @@ import com.google.cloud.pubsub.v1.SubscriptionAdminSettings;
 import com.google.pubsub.v1.PushConfig;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.etl.api.streaming.StreamingContext;
+import io.cdap.plugin.gcp.common.GCPUtils;
 import org.apache.spark.storage.StorageLevel;
 import org.apache.spark.streaming.api.java.JavaDStream;
 import org.apache.spark.streaming.dstream.DStream;
@@ -43,6 +44,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 
 /**
  * Utility class to create a JavaDStream of received messages.
@@ -207,6 +209,22 @@ public final class PubSubSubscriberUtil {
       .setInitialRetryDelay(Duration.ofMillis(backoffConfig.getInitialBackoffMs()))
       .setMaxRetryDelay(Duration.ofMillis(backoffConfig.getMaximumBackoffMs()))
       .setRetryDelayMultiplier(backoffConfig.getBackoffFactor()).setMaxAttempts(MAX_ATTEMPTS).build();
+  }
+
+  /**
+   * Create {@link Credentials} based on the params.
+   * @param serviceAccount Service account string, could be a path or JSON.
+   * @param serviceAccountFilePath Indicates whether first param is service account path.
+   * @return {@link Credentials} or null.
+   */
+  @Nullable
+  public static Credentials createCredentials(String serviceAccount, boolean serviceAccountFilePath) {
+    try {
+      return serviceAccount == null ? null : GCPUtils.loadServiceAccountCredentials(serviceAccount,
+                                                                                    serviceAccountFilePath);
+    } catch (IOException e) {
+      throw new RuntimeException("Error creating credentials from service account.", e);
+    }
   }
 
   private static SubscriptionAdminClient buildSubscriptionAdminClient(Credentials credentials) throws IOException {


### PR DESCRIPTION
[PLUGIN-1621](https://cdap.atlassian.net/browse/PLUGIN-1621) : Remove Credential object from RDD constructor to prevent serializing. This causes a class loading error when service account JSON is present.

Cherry pick for https://github.com/data-integrations/google-cloud/pull/1252 . 

[PLUGIN-1621]: https://cdap.atlassian.net/browse/PLUGIN-1621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ