### PR TITLE
[PLUGIN-1624] fix bytes processed metrics kind to cumulative

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/action/BigQueryExecute.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/action/BigQueryExecute.java
@@ -177,7 +177,7 @@ public final class BigQueryExecute extends AbstractBigQueryAction {
         .put(Constants.Metrics.Tag.APP_ENTITY_TYPE_NAME, BigQueryExecute.NAME)
         .build();
     context.getMetrics().gauge(RECORDS_PROCESSED, rows);
-    context.getMetrics().child(tags).gauge(BigQuerySinkUtils.BYTES_PROCESSED_METRIC,
+    context.getMetrics().child(tags).countLong(BigQuerySinkUtils.BYTES_PROCESSED_METRIC,
         processedBytes);
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -226,7 +226,7 @@ public final class BigQuerySink extends AbstractBigQuerySink {
         .put(Constants.Metrics.Tag.APP_ENTITY_TYPE_NAME, BigQuerySink.NAME)
         .build();
     long totalBytes = getTotalBytes(queryJob);
-    context.getMetrics().child(tags).gauge(BigQuerySinkUtils.BYTES_PROCESSED_METRIC, totalBytes);
+    context.getMetrics().child(tags).countLong(BigQuerySinkUtils.BYTES_PROCESSED_METRIC, totalBytes);
   }
 
   @Nullable


### PR DESCRIPTION
context: When there are more than one plugins of same type in the pipeline the metric should sum the bytes processed by all the plugins instead of overriding the bytes processed by other.

Tested using cdap-sandbox:
![image](https://github.com/data-integrations/google-cloud/assets/88528384/637868aa-efa4-4476-8042-5b1fb7772575)
![image](https://github.com/data-integrations/google-cloud/assets/88528384/6bb4bc34-9e15-4483-b0c7-2ef3b4e36c1c)

