### PR TITLE
[PLUGIN-1647] Upgrade gcs hadoop2 connector to 2.2.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,13 +70,13 @@
     <jee.version>7</jee.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <avro.version>1.8.2</avro.version>
-    <bigquery.connector.hadoop2.version>hadoop2-1.0.0</bigquery.connector.hadoop2.version>
+    <bigquery.connector.hadoop2.version>hadoop2-1.2.0</bigquery.connector.hadoop2.version>
     <commons.codec.version>1.4</commons.codec.version>
     <cdap.version>6.9.1</cdap.version>
     <cdap.plugin.version>2.11.1</cdap.plugin.version>
     <dropwizard.metrics-core.version>3.2.6</dropwizard.metrics-core.version>
-    <flogger.system.backend.version>0.3.1</flogger.system.backend.version>
-    <gcs.connector.version>hadoop2-2.0.0</gcs.connector.version>
+    <flogger.system.backend.version>0.7.1</flogger.system.backend.version>
+    <gcs.connector.version>hadoop2-2.2.9</gcs.connector.version>
     <google.cloud.bigtable.version>1.17.1</google.cloud.bigtable.version>
     <google.cloud.bigquery.version>1.137.1</google.cloud.bigquery.version>
     <google.cloud.kms.version>2.0.2</google.cloud.kms.version>
@@ -341,6 +341,22 @@
           <groupId>com.google.flogger</groupId>
           <artifactId>flogger-log4j-backend</artifactId>
         </exclusion>
+        <exclusion>
+          <artifactId>guava</artifactId>
+          <groupId>com.google.guava</groupId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.flogger</groupId>
+          <artifactId>flogger</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.cloud.bigdataoss</groupId>
+          <artifactId>util-hadoop</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.cloud.bigdataoss</groupId>
+          <artifactId>util</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -557,12 +573,42 @@
       <groupId>com.google.cloud.bigdataoss</groupId>
       <artifactId>util-hadoop</artifactId>
       <version>${gcs.connector.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.flogger</groupId>
+          <artifactId>flogger</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.flogger</groupId>
+          <artifactId>flogger-log4j-backend</artifactId>
+        </exclusion>
+        <exclusion>
+          <artifactId>guava</artifactId>
+          <groupId>com.google.guava</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.bigdataoss</groupId>
       <artifactId>gcs-connector</artifactId>
       <version>${gcs.connector.version}</version>
       <exclusions>
+        <exclusion>
+          <artifactId>grpc-api</artifactId>
+          <groupId>io.grpc</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>grpc-census</artifactId>
+          <groupId>io.grpc</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>guava</artifactId>
+          <groupId>com.google.guava</groupId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.flogger</groupId>
+          <artifactId>flogger</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>com.google.flogger</groupId>
           <artifactId>flogger-log4j-backend</artifactId>

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
@@ -227,7 +227,7 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, S
                                                                      cmekKeyName, config.getServiceAccountType());
     baseConfiguration.setBoolean(BigQueryConstants.CONFIG_ALLOW_SCHEMA_RELAXATION,
                                  config.isAllowSchemaRelaxation());
-    baseConfiguration.setStrings(BigQueryConfiguration.OUTPUT_TABLE_WRITE_DISPOSITION_KEY,
+    baseConfiguration.setStrings(BigQueryConfiguration.OUTPUT_TABLE_WRITE_DISPOSITION.getKey(),
                                  config.getWriteDisposition().name());
     // this setting is needed because gcs has default chunk size of 64MB. This is large default chunk size which can
     // cause OOM issue if there are many tables being written. See this - CDAP-16670

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQueryFactoryWithScopes.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQueryFactoryWithScopes.java
@@ -17,14 +17,16 @@
 package io.cdap.plugin.gcp.bigquery.source;
 
 import com.google.api.client.auth.oauth2.Credential;
+import com.google.cloud.hadoop.io.bigquery.BigQueryConfiguration;
 import com.google.cloud.hadoop.io.bigquery.BigQueryFactory;
-import com.google.cloud.hadoop.util.AccessTokenProviderClassFromConfigFactory;
 import com.google.cloud.hadoop.util.CredentialFromAccessTokenProviderClassFactory;
 import com.google.cloud.hadoop.util.HadoopCredentialConfiguration;
+import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.conf.Configuration;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -41,18 +43,16 @@ public class BigQueryFactoryWithScopes extends BigQueryFactory {
   @Override
   public Credential createBigQueryCredential(Configuration config) throws GeneralSecurityException, IOException {
     Credential credential =
-      CredentialFromAccessTokenProviderClassFactory.credential(
-        new AccessTokenProviderClassFromConfigFactory().withOverridePrefix("mapred.bq"),
-        config,
-        scopes);
+        CredentialFromAccessTokenProviderClassFactory.credential(
+            config,
+            Collections.singletonList(BigQueryConfiguration.BIGQUERY_CONFIG_PREFIX),
+            scopes);
     if (credential != null) {
       return credential;
     }
 
-    return HadoopCredentialConfiguration.newBuilder()
-      .withConfiguration(config)
-      .withOverridePrefix(BIGQUERY_CONFIG_PREFIX)
-      .build()
-      .getCredential(scopes);
+    return HadoopCredentialConfiguration.getCredentialFactory(
+            config, String.valueOf(ImmutableList.of(BigQueryConfiguration.BIGQUERY_CONFIG_PREFIX)))
+        .getCredential(BIGQUERY_OAUTH_SCOPES);
   }
 }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/PartitionedBigQueryInputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/PartitionedBigQueryInputFormat.java
@@ -18,6 +18,7 @@ import com.google.cloud.hadoop.io.bigquery.BigQueryHelper;
 import com.google.cloud.hadoop.io.bigquery.BigQueryUtils;
 import com.google.cloud.hadoop.io.bigquery.ExportFileFormat;
 import com.google.cloud.hadoop.util.ConfigurationUtil;
+import com.google.cloud.hadoop.util.HadoopConfigurationProperty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -36,6 +37,7 @@ import org.apache.hadoop.util.Progressable;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -95,14 +97,17 @@ public class PartitionedBigQueryInputFormat extends AbstractBigQueryInputFormat<
     } catch (GeneralSecurityException gse) {
       throw new IOException("Failed to create BigQuery client", gse);
     }
+
+    List<HadoopConfigurationProperty<?>> hadoopConfigurationProperties = new ArrayList<>(
+        BigQueryConfiguration.MANDATORY_CONFIG_PROPERTIES_INPUT);
     Map<String, String> mandatoryConfig = ConfigurationUtil.getMandatoryConfig(
-      configuration, BigQueryConfiguration.MANDATORY_CONFIG_PROPERTIES_INPUT);
-    String projectId = mandatoryConfig.get(BigQueryConfiguration.PROJECT_ID_KEY);
-    String datasetProjectId = mandatoryConfig.get(BigQueryConfiguration.INPUT_PROJECT_ID_KEY);
-    String datasetId = mandatoryConfig.get(BigQueryConfiguration.INPUT_DATASET_ID_KEY);
-    String tableName = mandatoryConfig.get(BigQueryConfiguration.INPUT_TABLE_ID_KEY);
+      configuration, hadoopConfigurationProperties);
+    String projectId = mandatoryConfig.get(BigQueryConfiguration.PROJECT_ID.getKey());
+    String datasetProjectId = mandatoryConfig.get(BigQueryConfiguration.INPUT_PROJECT_ID.getKey());
+    String datasetId = mandatoryConfig.get(BigQueryConfiguration.INPUT_DATASET_ID.getKey());
+    String tableName = mandatoryConfig.get(BigQueryConfiguration.INPUT_TABLE_ID.getKey());
     String serviceAccount = configuration.get(BigQueryConstants.CONFIG_SERVICE_ACCOUNT, null);
-    Boolean isServiceAccountFilePath = configuration.getBoolean(BigQueryConstants.CONFIG_SERVICE_ACCOUNT_IS_FILE,
+    boolean isServiceAccountFilePath = configuration.getBoolean(BigQueryConstants.CONFIG_SERVICE_ACCOUNT_IS_FILE,
                                                                 true);
 
     String partitionFromDate = configuration.get(BigQueryConstants.CONFIG_PARTITION_FROM_DATE, null);
@@ -131,11 +136,11 @@ public class PartitionedBigQueryInputFormat extends AbstractBigQueryInputFormat<
       runQuery(configuration, bigQueryHelper, projectId, exportTableReference, query, location);
 
       // Default values come from BigquerySource config, and can be overridden by config.
-      configuration.set(BigQueryConfiguration.INPUT_PROJECT_ID_KEY,
+      configuration.set(BigQueryConfiguration.INPUT_PROJECT_ID.getKey(),
                         configuration.get(BigQueryConstants.CONFIG_VIEW_MATERIALIZATION_PROJECT));
-      configuration.set(BigQueryConfiguration.INPUT_DATASET_ID_KEY,
+      configuration.set(BigQueryConfiguration.INPUT_DATASET_ID.getKey(),
                         configuration.get(BigQueryConstants.CONFIG_VIEW_MATERIALIZATION_DATASET));
-      configuration.set(BigQueryConfiguration.INPUT_TABLE_ID_KEY, temporaryTableName);
+      configuration.set(BigQueryConfiguration.INPUT_TABLE_ID.getKey(), temporaryTableName);
     }
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
@@ -174,9 +174,10 @@ public final class BigQueryUtil {
     configuration.set("fs.AbstractFileSystem.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS");
     configuration.set("fs.gs.project.id", projectId);
     configuration.set("fs.gs.working.dir", GCSPath.ROOT_DIR);
-    configuration.set(BigQueryConfiguration.PROJECT_ID_KEY, projectId);
+    configuration.set(BigQueryConfiguration.PROJECT_ID.getKey(), projectId);
     if (cmekKeyName != null) {
-      configuration.set(BigQueryConfiguration.OUTPUT_TABLE_KMS_KEY_NAME_KEY, cmekKeyName.toString());
+      configuration.set(BigQueryConfiguration.OUTPUT_TABLE_KMS_KEY_NAME.getKey(),
+          cmekKeyName.toString());
     }
     return configuration;
   }

--- a/src/main/java/io/cdap/plugin/gcp/common/GCPUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCPUtils.java
@@ -26,8 +26,8 @@ import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS;
 import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem;
-import com.google.cloud.hadoop.util.AccessTokenProviderClassFromConfigFactory;
 import com.google.cloud.hadoop.util.CredentialFactory;
+import com.google.cloud.hadoop.util.HadoopCredentialConfiguration;
 import com.google.cloud.kms.v1.CryptoKeyName;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
@@ -129,7 +129,7 @@ public class GCPUtils {
    */
   public static Map<String, String> generateGCSAuthProperties(@Nullable String serviceAccount,
                                                               String serviceAccountType) {
-    return generateAuthProperties(serviceAccount, serviceAccountType, CredentialFactory.GCS_SCOPES, GCS_PREFIX);
+    return generateAuthProperties(serviceAccount, serviceAccountType, CredentialFactory.DEFAULT_SCOPES, GCS_PREFIX);
   }
 
   /**
@@ -142,7 +142,7 @@ public class GCPUtils {
    */
   public static Map<String, String> generateBigQueryAuthProperties(@Nullable String serviceAccount,
                                                                    String serviceAccountType) {
-    List<String> scopes = new ArrayList<>(CredentialFactory.GCS_SCOPES);
+    List<String> scopes = new ArrayList<>(CredentialFactory.DEFAULT_SCOPES);
     scopes.addAll(BIGQUERY_SCOPES);
     return generateAuthProperties(serviceAccount, serviceAccountType, scopes, GCS_PREFIX, BQ_PREFIX);
   }
@@ -176,7 +176,7 @@ public class GCPUtils {
     //   mapred.bq.auth.access.token.provider.impl
     // for use by GCS and BQ.
     for (String prefix : prefixes) {
-      properties.put(prefix + AccessTokenProviderClassFromConfigFactory.ACCESS_TOKEN_PROVIDER_IMPL_SUFFIX,
+      properties.put(prefix + HadoopCredentialConfiguration.ACCESS_TOKEN_PROVIDER_IMPL_SUFFIX,
                      ServiceAccountAccessTokenProvider.class.getName());
     }
     return properties;

--- a/src/main/java/io/cdap/plugin/gcp/dataplex/sink/DataplexBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/dataplex/sink/DataplexBatchSink.java
@@ -382,7 +382,7 @@ public final class DataplexBatchSink extends BatchSink<StructuredRecord, Object,
       cmekKey, config.getServiceAccountType());
     baseConfiguration.setBoolean(BigQueryConstants.CONFIG_ALLOW_SCHEMA_RELAXATION,
       config.isUpdateTableSchema());
-    baseConfiguration.setStrings(BigQueryConfiguration.OUTPUT_TABLE_WRITE_DISPOSITION_KEY,
+    baseConfiguration.setStrings(BigQueryConfiguration.OUTPUT_TABLE_WRITE_DISPOSITION.getKey(),
       config.getWriteDisposition().name());
     // this setting is needed because gcs has default chunk size of 64MB. This is large default chunk size which can
     // cause OOM issue if there are many tables being written. See this - CDAP-16670

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormatTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormatTest.java
@@ -69,8 +69,8 @@ public class BigQueryOutputFormatTest {
 
     Configuration conf = new Configuration();
     conf.set("mapred.bq.output.project.id", "test_project");
-    conf.set(BigQueryConfiguration.OUTPUT_DATASET_ID_KEY, "test_dataset");
-    conf.set(BigQueryConfiguration.OUTPUT_TABLE_ID_KEY, "test_table");
+    conf.set(BigQueryConfiguration.OUTPUT_DATASET_ID.getKey(), "test_dataset");
+    conf.set(BigQueryConfiguration.OUTPUT_TABLE_ID.getKey(), "test_table");
     conf.set("mapred.bq.output.gcs.fileformat", BigQueryFileFormat.AVRO.toString());
     conf.set(BigQueryConstants.CONFIG_OPERATION, operation);
 


### PR DESCRIPTION
This PR does the following:

- Upgrades GCS Hadoop Connector version to `hadoop2-2.2.9`
- Upgrades BigQuery Hadoop Connector version to `hadoop2-1.2.0`.
- Upgrades Flogger version to `0.7.1`