### PR TITLE
[PLUGIN-1647] fix the access token provider

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
@@ -57,22 +57,26 @@ import com.google.cloud.hadoop.io.bigquery.output.BigQueryOutputConfiguration;
 import com.google.cloud.hadoop.io.bigquery.output.ForwardingBigQueryFileOutputCommitter;
 import com.google.cloud.hadoop.io.bigquery.output.ForwardingBigQueryFileOutputFormat;
 import com.google.cloud.hadoop.util.ConfigurationUtil;
-import com.google.cloud.hadoop.util.HadoopConfigurationProperty;
 import com.google.cloud.hadoop.util.ResilientOperation;
 import com.google.cloud.hadoop.util.RetryDeterminer;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.plugin.gcp.bigquery.source.BigQueryFactoryWithScopes;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryConstants;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;
 import io.cdap.plugin.gcp.common.GCPUtils;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapred.FileAlreadyExistsException;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.JobStatus;
 import org.apache.hadoop.mapreduce.OutputCommitter;
 import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.util.Progressable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -138,6 +142,44 @@ public class BigQueryOutputFormat extends ForwardingBigQueryFileOutputFormat<Str
   }
 
   /**
+   * This method is copied from
+   * {@link ForwardingBigQueryFileOutputFormat#checkOutputSpecs(JobContext)} to override
+   * {@link BigQueryFactory} with {@link BigQueryFactoryWithScopes}.
+   */
+  @Override
+  public void checkOutputSpecs(JobContext job) throws FileAlreadyExistsException, IOException {
+    Configuration conf = job.getConfiguration();
+
+    // Validate the output configuration.
+    BigQueryOutputConfiguration.validateConfiguration(conf);
+
+    // Get the output path.
+    Path outputPath = BigQueryOutputConfiguration.getGcsOutputPath(conf);
+    LOG.info("Using output path '%s'.", outputPath);
+
+    // Error if the output path already exists.
+    FileSystem outputFileSystem = outputPath.getFileSystem(conf);
+    if (outputFileSystem.exists(outputPath)) {
+      throw new IOException("The output path '" + outputPath + "' already exists.");
+    }
+
+    // Error if compression is set as there's mixed support in BigQuery.
+    if (FileOutputFormat.getCompressOutput(job)) {
+      throw new IOException("Compression isn't supported for this OutputFormat.");
+    }
+
+    // Error if unable to create a BigQuery helper.
+    try {
+      new BigQueryFactoryWithScopes(GCPUtils.BIGQUERY_SCOPES).getBigQueryHelper(conf);
+    } catch (GeneralSecurityException gse) {
+      throw new IOException("Failed to create BigQuery client", gse);
+    }
+
+    // Let delegate process its checks.
+    getDelegate(conf).checkOutputSpecs(job);
+  }
+
+  /**
    * BigQuery Output committer.
    */
   public static class BigQueryOutputCommitter extends ForwardingBigQueryFileOutputCommitter {
@@ -158,7 +200,7 @@ public class BigQueryOutputFormat extends ForwardingBigQueryFileOutputFormat<Str
     BigQueryOutputCommitter(TaskAttemptContext context, OutputCommitter delegate) throws IOException {
       super(context, delegate);
       try {
-        BigQueryFactory bigQueryFactory = new BigQueryFactory();
+        BigQueryFactory bigQueryFactory = new BigQueryFactoryWithScopes(GCPUtils.BIGQUERY_SCOPES);
         this.bigQueryHelper = bigQueryFactory.getBigQueryHelper(context.getConfiguration());
       } catch (GeneralSecurityException e) {
         throw new IOException("Failed to create Bigquery client.", e);

--- a/src/main/java/io/cdap/plugin/gcp/common/GCPUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCPUtils.java
@@ -172,12 +172,13 @@ public class GCPUtils {
     // AccessTokenProviderClassFromConfigFactory will by default look for
     //   google.cloud.auth.access.token.provider.impl
     // but can be configured to also look for the conf with other prefixes like
-    //   gs.fs.auth.access.token.provider.impl
+    //   fs.gs.auth.access.token.provider.impl
     //   mapred.bq.auth.access.token.provider.impl
     // for use by GCS and BQ.
     for (String prefix : prefixes) {
-      properties.put(prefix + HadoopCredentialConfiguration.ACCESS_TOKEN_PROVIDER_IMPL_SUFFIX,
-                     ServiceAccountAccessTokenProvider.class.getName());
+      properties.put(
+          prefix + HadoopCredentialConfiguration.ACCESS_TOKEN_PROVIDER_IMPL_SUFFIX.getKey(),
+          ServiceAccountAccessTokenProvider.class.getName());
     }
     return properties;
   }

--- a/src/main/java/io/cdap/plugin/gcp/gcs/ServiceAccountAccessTokenProvider.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/ServiceAccountAccessTokenProvider.java
@@ -56,6 +56,12 @@ public class ServiceAccountAccessTokenProvider implements AccessTokenProvider {
 
   private GoogleCredentials getCredentials() throws IOException {
     if (credentials == null) {
+      if (conf == null) {
+        // {@link CredentialFromAccessTokenProviderClassFactory#credential} does not propagate the
+        // config to {@link ServiceAccountAccessTokenProvider} which causes NPE when
+        // initializing {@link ForwardingBigQueryFileOutputCommitter because conf is null.
+        conf = new Configuration();
+      }
       credentials = GCPUtils.loadCredentialsFromConf(conf);
     }
     return credentials;

--- a/src/test/java/io/cdap/plugin/gcp/gcs/ServiceAccountAccessTokenProviderTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/gcs/ServiceAccountAccessTokenProviderTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.gcp.gcs;
+
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration;
+import com.google.cloud.hadoop.util.AccessTokenProvider;
+import com.google.cloud.hadoop.util.CredentialFactory;
+import com.google.cloud.hadoop.util.CredentialFromAccessTokenProviderClassFactory;
+import com.google.cloud.hadoop.util.HadoopCredentialConfiguration;
+import com.google.common.collect.ImmutableList;
+import io.cdap.plugin.gcp.common.GCPUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Test;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Unit Tests for {@link ServiceAccountAccessTokenProvider}.
+ */
+public class ServiceAccountAccessTokenProviderTest {
+
+  @Test
+  public void testServiceAccountAccessTokenProviderIsUsed() throws IOException {
+
+    Map<String, String> authProperties = GCPUtils.generateGCSAuthProperties(null,
+        "filePath");
+    Configuration conf = new Configuration();
+    for (Map.Entry<String, String> prop : authProperties.entrySet()) {
+      conf.set(prop.getKey(), prop.getValue());
+    }
+
+    AccessTokenProvider accessTokenProvider =
+        HadoopCredentialConfiguration.getAccessTokenProvider(conf, ImmutableList.of(
+        GoogleHadoopFileSystemConfiguration.GCS_CONFIG_PREFIX));
+
+    Assert.assertTrue(String.format("AccessTokenProvider should be an instance of %s",
+            ServiceAccountAccessTokenProvider.class.getName()),
+        accessTokenProvider instanceof ServiceAccountAccessTokenProvider);
+  }
+
+  @Test
+  public void testServiceAccountAccessTokenProvider() throws IOException {
+    Map<String, String> authProperties = GCPUtils.generateGCSAuthProperties(null,
+        "filePath");
+    Configuration conf = new Configuration();
+    for (Map.Entry<String, String> prop : authProperties.entrySet()) {
+      conf.set(prop.getKey(), prop.getValue());
+    }
+    // {@link CredentialFromAccessTokenProviderClassFactory#credential} does not propagate the
+    // config to {@link ServiceAccountAccessTokenProvider} which should not cause NPE
+    Credential credential = CredentialFromAccessTokenProviderClassFactory.credential(
+        conf, ImmutableList.of(GoogleHadoopFileSystemConfiguration.GCS_CONFIG_PREFIX),
+        CredentialFactory.DEFAULT_SCOPES
+    );
+    Assert.assertNotNull(credential);
+  }
+}


### PR DESCRIPTION
This PR does the following:

- Context: GCS Hadoop connector version was upgraded in #1270.

- Fixes the `ACCESS_TOKEN_PROVIDER_IMPL_SUFFIX`.

- `hadoop-connector` internall stopped propagating the config to `AccessTokenProvider` in `CredentialFromAccessTokenProviderClassFactory#credential` from `2.2.3` and started propagating the config in `GoogleHadoopFileSystemBase#getAccessTokenProvider` which caused `NPE` while creating `BigQueryCredential`. Hence, provided an empty configuration in `ServiceAccountAccessTokenProvider` when `conf` is `null`.

ref: https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/587/files#diff-bef33ce03ad3ec694eec0ef295fc56cb9240e087f4c3773036fe65d820d68037R1323