### PR TITLE
PLUGIN-1671 - Time Partitioning Type Support

### DIFF
--- a/docs/BigQueryTable-batchsink.md
+++ b/docs/BigQueryTable-batchsink.md
@@ -92,6 +92,9 @@ is ignored if the table already exists.
 * When this is set to Integer, table will be created with range partitioning.
 * When this is set to None, table will be created without time partitioning.
 
+**Time Partitioning Type**: Specifies the time partitioning type. Can either be Daily or Hourly or Monthly or Yearly.
+Default is Daily. Ignored when table already exists
+
 **Range Start**: For integer partitioning, specifies the start of the range. Only used when table doesn’t 
 exist already, and partitioning type is set to Integer.
 * The start value is inclusive.

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
@@ -57,7 +57,6 @@ import com.google.cloud.hadoop.io.bigquery.output.BigQueryOutputConfiguration;
 import com.google.cloud.hadoop.io.bigquery.output.ForwardingBigQueryFileOutputCommitter;
 import com.google.cloud.hadoop.io.bigquery.output.ForwardingBigQueryFileOutputFormat;
 import com.google.cloud.hadoop.util.ConfigurationUtil;
-import com.google.cloud.hadoop.util.HadoopConfigurationProperty;
 import com.google.cloud.hadoop.util.ResilientOperation;
 import com.google.cloud.hadoop.util.RetryDeterminer;
 import com.google.common.base.Strings;
@@ -187,6 +186,9 @@ public class BigQueryOutputFormat extends ForwardingBigQueryFileOutputFormat<Str
       LOG.debug("Allow schema relaxation: '{}'", allowSchemaRelaxation);
       PartitionType partitionType = conf.getEnum(BigQueryConstants.CONFIG_PARTITION_TYPE, PartitionType.NONE);
       LOG.debug("Create Partitioned Table type: '{}'", partitionType);
+      com.google.cloud.bigquery.TimePartitioning.Type timePartitioningType = conf.getEnum(
+              BigQueryConstants.CONFIG_TIME_PARTITIONING_TYPE, com.google.cloud.bigquery.TimePartitioning.Type.DAY
+      );
       Range range = partitionType == PartitionType.INTEGER ? createRangeForIntegerPartitioning(conf) : null;
       String partitionByField = conf.get(BigQueryConstants.CONFIG_PARTITION_BY_FIELD, null);
       LOG.debug("Partition Field: '{}'", partitionByField);
@@ -212,7 +214,7 @@ public class BigQueryOutputFormat extends ForwardingBigQueryFileOutputFormat<Str
 
       try {
         importFromGcs(destProjectId, destTable, destSchema.orElse(null), kmsKeyName, outputFileFormat,
-                      writeDisposition, sourceUris, partitionType, range, partitionByField,
+                      writeDisposition, sourceUris, partitionType, timePartitioningType, range, partitionByField,
                       requirePartitionFilter, clusteringOrderList, tableExists, conf);
       } catch (Exception e) {
         throw new IOException("Failed to import GCS into BigQuery. ", e);
@@ -256,8 +258,9 @@ public class BigQueryOutputFormat extends ForwardingBigQueryFileOutputFormat<Str
      */
     private void importFromGcs(String projectId, TableReference tableRef, @Nullable TableSchema schema,
                                @Nullable String kmsKeyName, BigQueryFileFormat sourceFormat, String writeDisposition,
-                               List<String> gcsPaths, PartitionType partitionType, @Nullable Range range,
-                               @Nullable String partitionByField, boolean requirePartitionFilter,
+                               List<String> gcsPaths, PartitionType partitionType,
+                               com.google.cloud.bigquery.TimePartitioning.Type timePartitioningType,
+                               @Nullable Range range, @Nullable String partitionByField, boolean requirePartitionFilter,
                                List<String> clusteringOrderList, boolean tableExists, Configuration conf)
       throws IOException, InterruptedException {
       LOG.info("Importing into table '{}' from {} paths; path[0] is '{}'; awaitCompletion: {}",
@@ -315,7 +318,8 @@ public class BigQueryOutputFormat extends ForwardingBigQueryFileOutputFormat<Str
       if (!tableExists) {
         switch (partitionType) {
           case TIME:
-            TimePartitioning timePartitioning = createTimePartitioning(partitionByField, requirePartitionFilter);
+            TimePartitioning timePartitioning = createTimePartitioning(partitionByField, requirePartitionFilter,
+                    timePartitioningType);
             loadConfig.setTimePartitioning(timePartitioning);
             break;
           case INTEGER:
@@ -714,9 +718,10 @@ public class BigQueryOutputFormat extends ForwardingBigQueryFileOutputFormat<Str
     }
 
     private TimePartitioning createTimePartitioning(
-      @Nullable String partitionByField, boolean requirePartitionFilter) {
+            @Nullable String partitionByField, boolean requirePartitionFilter,
+      com.google.cloud.bigquery.TimePartitioning.Type timePartitioningType) {
       TimePartitioning timePartitioning = new TimePartitioning();
-      timePartitioning.setType("DAY");
+      timePartitioning.setType(timePartitioningType.name());
       if (partitionByField != null) {
         timePartitioning.setField(partitionByField);
       }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -24,6 +24,7 @@ import com.google.cloud.bigquery.JobConfiguration;
 import com.google.cloud.bigquery.JobId;
 import com.google.cloud.bigquery.JobStatistics;
 import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.hadoop.io.bigquery.output.BigQueryTableFieldSchema;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
@@ -315,6 +316,9 @@ public final class BigQuerySink extends AbstractBigQuerySink {
 
     PartitionType partitioningType = getConfig().getPartitioningType();
     baseConfiguration.setEnum(BigQueryConstants.CONFIG_PARTITION_TYPE, partitioningType);
+
+    TimePartitioning.Type timePartitioningType = getConfig().getTimePartitioningType();
+    baseConfiguration.setEnum(BigQueryConstants.CONFIG_TIME_PARTITIONING_TYPE, timePartitioningType);
 
     if (config.getRangeStart() != null) {
       baseConfiguration.setLong(BigQueryConstants.CONFIG_PARTITION_INTEGER_RANGE_START, config.getRangeStart());

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQueryWrite.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQueryWrite.java
@@ -405,8 +405,9 @@ public class BigQueryWrite {
    * @return Time Partitioning configuration
    */
   protected TimePartitioning getTimePartitioning(BigQuerySinkConfig config) {
-    // Create time partitioning based on DAY
-    TimePartitioning.Builder timePartitioningBuilder = TimePartitioning.newBuilder(TimePartitioning.Type.DAY);
+
+    // Default partitioning type is DAY if not specified
+    TimePartitioning.Builder timePartitioningBuilder = TimePartitioning.newBuilder(config.getTimePartitioningType());
 
     // Set partition field if specified
     if (config.getPartitionByField() != null) {

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
@@ -40,6 +40,7 @@ public interface BigQueryConstants {
   String CONFIG_VIEW_MATERIALIZATION_PROJECT = "cdap.bq.source.view.materialization.project";
   String CONFIG_VIEW_MATERIALIZATION_DATASET = "cdap.bq.source.view.materialization.dataset";
   String CONFIG_PARTITION_TYPE = "cdap.bq.sink.partition.type";
+  String CONFIG_TIME_PARTITIONING_TYPE = "cdap.bq.sink.time.partitioning.type";
   String CONFIG_PARTITION_INTEGER_RANGE_START = "cdap.bq.sink.partition.integer.range.start";
   String CONFIG_PARTITION_INTEGER_RANGE_END = "cdap.bq.sink.partition.integer.range.end";
   String CONFIG_PARTITION_INTEGER_RANGE_INTERVAL = "cdap.bq.sink.partition.integer.range.interval";

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfigTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfigTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.gcp.bigquery.sink;
+
+import com.google.cloud.bigquery.TimePartitioning;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.FailureCollector;
+import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * Tests for {@link BigQuerySinkConfig}.
+ */
+
+public class BigQuerySinkConfigTest {
+    MockFailureCollector collector;
+    BigQuerySinkConfig config;
+    Method validateTimePartitioningColumnMethod;
+
+    @Before
+    public void setup() throws NoSuchMethodException {
+        collector = new MockFailureCollector();
+        config = BigQuerySinkConfig.builder().build();
+        validateTimePartitioningColumnMethod = config.getClass()
+                .getDeclaredMethod("validateTimePartitioningColumn", String.class, FailureCollector.class,
+                        Schema.class, TimePartitioning.Type.class);
+        validateTimePartitioningColumnMethod.setAccessible(true);
+    }
+    @Test
+    public void testValidateTimePartitioningColumnWithHourAndDate() throws
+            InvocationTargetException, IllegalAccessException {
+        String columnName = "partitionFrom";
+        Schema fieldSchema = Schema.recordOf("test", Schema.Field.of("partitionFrom",
+                Schema.of(Schema.LogicalType.DATE)));
+        TimePartitioning.Type timePartitioningType = TimePartitioning.Type.HOUR;
+
+        validateTimePartitioningColumnMethod.invoke(config, columnName, collector, fieldSchema, timePartitioningType);
+        Assert.assertEquals(String.format("Partition column '%s' is of invalid type '%s'.",
+                        columnName, fieldSchema.getDisplayName()),
+                collector.getValidationFailures().stream().findFirst().get().getMessage());
+    }
+
+    @Test
+    public void testValidateTimePartitioningColumnWithHourAndTimestamp() throws
+            InvocationTargetException, IllegalAccessException {
+
+        String columnName = "partitionFrom";
+        Schema schema = Schema.of(Schema.LogicalType.TIMESTAMP_MICROS);
+
+        Schema fieldSchema = schema.isNullable() ? schema.getNonNullable() : schema;
+        TimePartitioning.Type timePartitioningType = TimePartitioning.Type.HOUR;
+
+        validateTimePartitioningColumnMethod.invoke(config, columnName, collector, fieldSchema, timePartitioningType);
+        Assert.assertEquals(0, collector.getValidationFailures().size());
+    }
+
+    @Test
+    public void testValidateTimePartitioningColumnWithDayAndString() throws
+            InvocationTargetException, IllegalAccessException {
+
+        String columnName = "partitionFrom";
+        Schema schema = Schema.of(Schema.Type.STRING);
+
+        Schema fieldSchema = schema.isNullable() ? schema.getNonNullable() : schema;
+        TimePartitioning.Type timePartitioningType = TimePartitioning.Type.DAY;
+
+        validateTimePartitioningColumnMethod.invoke(config, columnName, collector, fieldSchema, timePartitioningType);
+        Assert.assertEquals(String.format("Partition column '%s' is of invalid type '%s'.",
+                        columnName, fieldSchema.getDisplayName()),
+                collector.getValidationFailures().stream().findFirst().get().getMessage());
+    }
+
+    @Test
+    public void testValidateTimePartitioningColumnWithDayAndDate() throws
+            InvocationTargetException, IllegalAccessException {
+
+        String columnName = "partitionFrom";
+        Schema schema = Schema.of(Schema.LogicalType.DATE);
+
+        Schema fieldSchema = schema.isNullable() ? schema.getNonNullable() : schema;
+        TimePartitioning.Type timePartitioningType = TimePartitioning.Type.DAY;
+
+        validateTimePartitioningColumnMethod.invoke(config, columnName, collector, fieldSchema, timePartitioningType);
+        Assert.assertEquals(0, collector.getValidationFailures().size());
+    }
+
+    @Test
+    public void testValidateTimePartitioningColumnWithNullAndDate() throws
+            InvocationTargetException, IllegalAccessException {
+
+        String columnName = "partitionFrom";
+        Schema schema = Schema.of(Schema.LogicalType.DATE);
+
+        Schema fieldSchema = schema.isNullable() ? schema.getNonNullable() : schema;
+        TimePartitioning.Type timePartitioningType = null;
+
+        validateTimePartitioningColumnMethod.invoke(config, columnName, collector, fieldSchema, timePartitioningType);
+        // No error as null time timePartitioningType will default to DAY
+        Assert.assertEquals(0, collector.getValidationFailures().size());
+    }
+
+}

--- a/widgets/BigQueryTable-batchsink.json
+++ b/widgets/BigQueryTable-batchsink.json
@@ -281,6 +281,33 @@
           }
         },
         {
+          "widget-type": "radio-group",
+          "label": "Time Partitioning Type",
+          "name": "timePartitioningType",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "DAY",
+            "options": [
+              {
+                "id": "DAY",
+                "label": "Daily"
+              },
+              {
+                "id": "HOUR",
+                "label": "Hourly"
+              },
+              {
+                "id": "MONTH",
+                "label": "Monthly"
+              },
+              {
+                "id": "YEAR",
+                "label": "Yearly"
+              }
+            ]
+          }
+        },
+        {
           "widget-type": "Number",
           "label": "Range Start (inclusive)",
           "name": "rangeStart",
@@ -372,6 +399,18 @@
         {
           "type": "property",
           "name": "clientAccessToken"
+        }
+      ]
+    },
+    {
+      "name": "PartitioningTimeFieldsFilter",
+      "condition": {
+        "expression": "partitioningType == 'TIME'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "timePartitioningType"
         }
       ]
     },


### PR DESCRIPTION
## Addition of multiple time partitioning strategies in BigQuery Sink 

Previously partitioning by time was hard-coded to DAY
This PR adds a new UI field to let the user decide time partitioning type. (Default to Daily)

## UI Field 

UI field has a filter to only be visible when Partitioning type `TIME` is selected

<img width="385" alt="image" src="https://github.com/data-integrations/google-cloud/assets/122770897/ff358bb0-353e-449b-b126-ba6eabe4c1cf">

## Validations
DATE and TIMESTAMP can be used for partitioning column datatype.
As there is no Hour information in DATE, we cannot use it when user has time partitioning type selected to `Hourly`

This produced a validation failure.

## Unit Test 
Unit test are added to test the new validation logic.

## Update Details document
[Update Details document](https://docs.google.com/document/d/1xoR-r5UOhILZdti0WtQK-kxSbTJvRH4mJ8tdPMwMW9k/edit?usp=sharing)

## Jira Link
[JIRA Link](https://cdap.atlassian.net/browse/PLUGIN-1671)

## Testing Details
[Testing document](https://docs.google.com/spreadsheets/d/1coRfmkKNUAn2h2fTqTNa0xjPvMp56MBCLkAWd6XAMyY/edit?resourcekey=0-EBwRnQjOaPl7hRaYbLM32A#gid=0) prepared by QA 
