### PR TITLE
[PLUGIN-1672] Allowing hyphen in BQ table name

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
@@ -83,7 +83,7 @@ public final class BigQueryUtil {
 
   public static final String BUCKET_PATTERN = "[a-z0-9._-]+";
   public static final String DATASET_PATTERN = "[A-Za-z0-9_]+";
-  public static final String TABLE_PATTERN = "[A-Za-z0-9_]+";
+  public static final String TABLE_PATTERN = "[A-Za-z0-9_-]+";
 
   // Tags for BQ Jobs
   public static final String BQ_JOB_TYPE_SOURCE_TAG = "bq_source_plugin";
@@ -676,7 +676,7 @@ public final class BigQueryUtil {
    */
   public static void validateTable(String table, String tablePropertyName, FailureCollector collector) {
     // Allowed character validation for table name as per https://cloud.google.com/bigquery/docs/tables
-    String errorMessage = "Table name can only contain letters (lower or uppercase), numbers and '_'.";
+    String errorMessage = "Table name can only contain letters (lower or uppercase), numbers, '_' and '-'.";
     match(table, tablePropertyName, TABLE_PATTERN, collector, errorMessage);
   }
 


### PR DESCRIPTION
BigQuery connector did not allow hyphen in the table name. Added support for that
Jira issue link: [PLUGIN-1672](https://cdap.atlassian.net/browse/PLUGIN-1672)

[PLUGIN-1672]: https://cdap.atlassian.net/browse/PLUGIN-1672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ