### PR TITLE
[PLUGIN-1672] Fixed unit tests failures

### DIFF
--- a/src/e2e-test/java/io/cdap/plugin/bigquery/stepsdesign/BigQueryBase.java
+++ b/src/e2e-test/java/io/cdap/plugin/bigquery/stepsdesign/BigQueryBase.java
@@ -234,6 +234,9 @@ public class BigQueryBase implements E2EHelper {
     } else if (property.equalsIgnoreCase("bucket")) {
       expectedErrorMessage = PluginPropertyUtils
         .errorProp(E2ETestConstants.ERROR_MSG_BQ_INCORRECT_TEMPORARY_BUCKET);
+    } else if (property.equalsIgnoreCase("table")) {
+      expectedErrorMessage = PluginPropertyUtils
+        .errorProp(E2ETestConstants.ERROR_MSG_INCORRECT_TABLE_NAME);
     } else {
       expectedErrorMessage = PluginPropertyUtils.errorProp(E2ETestConstants.ERROR_MSG_BQ_INCORRECT_PROPERTY).
         replaceAll("PROPERTY", property.substring(0, 1).toUpperCase() + property.substring(1));

--- a/src/e2e-test/java/io/cdap/plugin/utils/E2ETestConstants.java
+++ b/src/e2e-test/java/io/cdap/plugin/utils/E2ETestConstants.java
@@ -7,6 +7,7 @@ public class E2ETestConstants {
   public static final String ERROR_MSG_GCS_INVALID_PATH = "errorMessageGCSInvalidPath";
   public static final String ERROR_MSG_GCS_INVALID_BUCKET_NAME = "errorMessageGCSInvalidBucketName";
   public static final String ERROR_MSG_INCORRECT_TABLE = "errorMessageIncorrectBQTable";
+  public static final String ERROR_MSG_INCORRECT_TABLE_NAME = "errorMessageIncorrectBQTableName";
   public static final String ERROR_MSG_PUBSUB_INVALID_ADVANCED_FIELDS = "errorMessagePubSubInvalidAdvancedField";
   public static final String ERROR_MSG_PUBSUB_MAX_BATCH_COUNT = "errorMessagePubSubMaxBatchCountField";
   public static final String ERROR_MSG_PUBSUB_MAX_BATCH_SIZE = "errorMessagePubSubMaxBatchSizeField";

--- a/src/e2e-test/resources/errorMessage.properties
+++ b/src/e2e-test/resources/errorMessage.properties
@@ -15,6 +15,7 @@ errorMessagePubSubRetryTimeout=Invalid max retry timeout for retrying failed pub
 errorMessagePubSubErrorThreshold=Invalid error threshold for publishing. Ensure the value is a positive number.
 errorMessageIncorrectBQChunkSize=Value must be a multiple of 262144.
 errorMessageIncorrectBQBucketName=Bucket name can only contain lowercase letters, numbers, '.', '_', and '-'.
+errorMessageIncorrectBQTableName=Table name can only contain letters (lower or uppercase), numbers, '_' and '-'.
 errorMessageIncorrectBQProperty=PROPERTY name can only contain letters (lower or uppercase), numbers and '_'.
 errorMessageInvalidPath=Error when trying to detect schema: Input path not found
 errorMessageBQExecuteTableDataset=Dataset and table must be specified together.

--- a/src/test/java/io/cdap/plugin/gcp/dataplex/source/config/DataplexBatchSourceConfigTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/dataplex/source/config/DataplexBatchSourceConfigTest.java
@@ -129,7 +129,7 @@ public class DataplexBatchSourceConfigTest {
       .setReferenceName("test").build();
     try {
       dataplexBatchSourceConfig.validateBigQueryDataset(mockFailureCollector,
-        "project", "dataset", "table-wrong");
+        "project", "dataset", "table.wrong");
     } catch (Exception e) {
     }
 


### PR DESCRIPTION
BUT tests in develop were failing after the recent change [PR](https://github.com/data-integrations/google-cloud/pull/1281). Fixed DataplexBatchSourceConfigTest unit test. Also fixed error message in e2e tests for incorrect table name scenario.

Related Jira ticket: [PLUGIN-1672](https://cdap.atlassian.net/browse/PLUGIN-1672)

[PLUGIN-1672]: https://cdap.atlassian.net/browse/PLUGIN-1672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ