### PR TITLE
[6.9.2][Cherry-pick][PLUGIN-1672] Allowing hyphen in BQ table name

### DIFF
--- a/src/e2e-test/java/io/cdap/plugin/bigquery/stepsdesign/BigQueryBase.java
+++ b/src/e2e-test/java/io/cdap/plugin/bigquery/stepsdesign/BigQueryBase.java
@@ -234,6 +234,9 @@ public class BigQueryBase implements E2EHelper {
     } else if (property.equalsIgnoreCase("bucket")) {
       expectedErrorMessage = PluginPropertyUtils
         .errorProp(E2ETestConstants.ERROR_MSG_BQ_INCORRECT_TEMPORARY_BUCKET);
+    } else if (property.equalsIgnoreCase("table")) {
+      expectedErrorMessage = PluginPropertyUtils
+        .errorProp(E2ETestConstants.ERROR_MSG_INCORRECT_TABLE_NAME);
     } else {
       expectedErrorMessage = PluginPropertyUtils.errorProp(E2ETestConstants.ERROR_MSG_BQ_INCORRECT_PROPERTY).
         replaceAll("PROPERTY", property.substring(0, 1).toUpperCase() + property.substring(1));

--- a/src/e2e-test/java/io/cdap/plugin/utils/E2ETestConstants.java
+++ b/src/e2e-test/java/io/cdap/plugin/utils/E2ETestConstants.java
@@ -7,6 +7,7 @@ public class E2ETestConstants {
   public static final String ERROR_MSG_GCS_INVALID_PATH = "errorMessageGCSInvalidPath";
   public static final String ERROR_MSG_GCS_INVALID_BUCKET_NAME = "errorMessageGCSInvalidBucketName";
   public static final String ERROR_MSG_INCORRECT_TABLE = "errorMessageIncorrectBQTable";
+  public static final String ERROR_MSG_INCORRECT_TABLE_NAME = "errorMessageIncorrectBQTableName";
   public static final String ERROR_MSG_PUBSUB_INVALID_ADVANCED_FIELDS = "errorMessagePubSubInvalidAdvancedField";
   public static final String ERROR_MSG_PUBSUB_MAX_BATCH_COUNT = "errorMessagePubSubMaxBatchCountField";
   public static final String ERROR_MSG_PUBSUB_MAX_BATCH_SIZE = "errorMessagePubSubMaxBatchSizeField";

--- a/src/e2e-test/resources/errorMessage.properties
+++ b/src/e2e-test/resources/errorMessage.properties
@@ -15,6 +15,7 @@ errorMessagePubSubRetryTimeout=Invalid max retry timeout for retrying failed pub
 errorMessagePubSubErrorThreshold=Invalid error threshold for publishing. Ensure the value is a positive number.
 errorMessageIncorrectBQChunkSize=Value must be a multiple of 262144.
 errorMessageIncorrectBQBucketName=Bucket name can only contain lowercase letters, numbers, '.', '_', and '-'.
+errorMessageIncorrectBQTableName=Table name can only contain letters (lower or uppercase), numbers, '_' and '-'.
 errorMessageIncorrectBQProperty=PROPERTY name can only contain letters (lower or uppercase), numbers and '_'.
 errorMessageInvalidPath=Error when trying to detect schema: Input path not found
 errorMessageBQExecuteTableDataset=Dataset and table must be specified together.

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
@@ -83,7 +83,7 @@ public final class BigQueryUtil {
 
   public static final String BUCKET_PATTERN = "[a-z0-9._-]+";
   public static final String DATASET_PATTERN = "[A-Za-z0-9_]+";
-  public static final String TABLE_PATTERN = "[A-Za-z0-9_]+";
+  public static final String TABLE_PATTERN = "[A-Za-z0-9_-]+";
 
   // Tags for BQ Jobs
   public static final String BQ_JOB_TYPE_SOURCE_TAG = "bq_source_plugin";
@@ -675,7 +675,7 @@ public final class BigQueryUtil {
    */
   public static void validateTable(String table, String tablePropertyName, FailureCollector collector) {
     // Allowed character validation for table name as per https://cloud.google.com/bigquery/docs/tables
-    String errorMessage = "Table name can only contain letters (lower or uppercase), numbers and '_'.";
+    String errorMessage = "Table name can only contain letters (lower or uppercase), numbers, '_' and '-'.";
     match(table, tablePropertyName, TABLE_PATTERN, collector, errorMessage);
   }
 

--- a/src/test/java/io/cdap/plugin/gcp/dataplex/source/config/DataplexBatchSourceConfigTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/dataplex/source/config/DataplexBatchSourceConfigTest.java
@@ -129,7 +129,7 @@ public class DataplexBatchSourceConfigTest {
       .setReferenceName("test").build();
     try {
       dataplexBatchSourceConfig.validateBigQueryDataset(mockFailureCollector,
-        "project", "dataset", "table-wrong");
+        "project", "dataset", "table.wrong");
     } catch (Exception e) {
     }
 


### PR DESCRIPTION
Original PR: [#1281](https://github.com/data-integrations/google-cloud/pull/1281), [#1282 ](https://github.com/data-integrations/google-cloud/pull/1282)

BigQuery connector did not allow hyphen in the table name. Added support for that
Jira issue link: [PLUGIN-1672](https://cdap.atlassian.net/browse/PLUGIN-1672)

[PLUGIN-1672]: https://cdap.atlassian.net/browse/PLUGIN-1672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ