### PR TITLE
version bump from 0.20.6-SNAPSHOT to 0.20.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>google-cloud</artifactId>
-  <version>0.20.6-SNAPSHOT</version>
+  <version>0.20.6</version>
   <name>Google Cloud Plugins</name>
   <packaging>jar</packaging>
   <description>Plugins for Google Big Query</description>


### PR DESCRIPTION
Google-Cloud plugin version bump from 0.20.6-SNAPSHOT to 0.20.6