### PR TITLE
gcs failure tests fix

### DIFF
--- a/src/e2e-test/features/gcs/source/GCSourceSchema.feature
+++ b/src/e2e-test/features/gcs/source/GCSourceSchema.feature
@@ -38,14 +38,14 @@ Feature: GCS source - Validate GCS plugin output schema for different formats
     Examples:
       | GcsPath      | FileFormat  | ExpectedSchema     |
       | gcsTextFile  | text        | gcsTextFileSchema  |
-    @GCS_PARQUET_TEST @CDAP-18494
+    @GCS_PARQUET_TEST
     Examples:
       | GcsPath        | FileFormat | ExpectedSchema       |
       | gcsParquetFile | parquet    | gcsParquetFileSchema |
-    @GCS_AVRO_TEST @CDAP-18494
+    @GCS_AVRO_FILE
     Examples:
-      | GcsPath        | FileFormat | ExpectedSchema       |
-      | gcsAvroFile    | avro       | gcsAvroFileSchema    |
+      | GcsPath             | FileFormat | ExpectedSchema           |
+      | gcsAvroAllDataFile  | avro       | gcsAvroAllTypeDataSchema |
 
   @GCS_Source
   Scenario Outline:GCS Source output schema validation for delimited files

--- a/src/e2e-test/java/io/cdap/plugin/gcs/runners/sourcerunner/TestRunner.java
+++ b/src/e2e-test/java/io/cdap/plugin/gcs/runners/sourcerunner/TestRunner.java
@@ -28,10 +28,9 @@ import org.junit.runner.RunWith;
   features = {"src/e2e-test/features"},
   glue = {"io.cdap.plugin.gcs.stepsdesign", "io.cdap.plugin.bigquery.stepsdesign",
     "stepsdesign", "io.cdap.plugin.common.stepsdesign"},
-  tags = {"@GCS_Source and not @PLUGIN-823 and not @PLUGIN-1113 and not @CDAP-18494 and not @PLUGIN-825"},
+  tags = {"@GCS_Source and not @PLUGIN-823 and not @PLUGIN-1113 and not @PLUGIN-825"},
   /* TODO :Enable tests once issues fixed https://cdap.atlassian.net/browse/PLUGIN-823,
-      https://cdap.atlassian.net/browse/PLUGIN-1113,
-  https://cdap.atlassian.net/browse/PLUGIN-825, https://cdap.atlassian.net/browse/CDAP-18494  */
+      https://cdap.atlassian.net/browse/PLUGIN-1113, https://cdap.atlassian.net/browse/PLUGIN-825 */
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/gcs-source",
     "json:target/cucumber-reports/cucumber-gcs-source.json",

--- a/src/e2e-test/resources/pluginParameters.properties
+++ b/src/e2e-test/resources/pluginParameters.properties
@@ -154,6 +154,11 @@ gcsInvalidMinSplitSize=10000000000000000000000000
 gcsInvalidRegexPathFilter=\\\is
 gcsInvalidFileSysProperty=**
 gcsInvalidRefName=invalidRef&^*&&*
+gcsParquetFileSchema=[{"key":"workforce","value":"string"},{"key":"report_year","value":"long"},\
+  {"key":"gender_us","value":"string"},{"key":"race_asian","value":"long"},\
+  {"key":"race_black","value":"long"},{"key":"race_hispanic_latinx","value":"long"},\
+  {"key":"race_native_american","value":"long"},{"key":"race_white","value":"long"},\
+  {"key":"tablename","value":"string"}]
 ## GCS-PLUGIN-PROPERTIES-END
 
 ## BIGQUERY-PLUGIN-PROPERTIES-START


### PR DESCRIPTION
Two of the e2e tests related to GCS source plugin using Avro and Parquet formats are getting failed on GitHub actions as required tag is added on this scenario. Since the bug(https://cdap.atlassian.net/browse/CDAP-18494) is fixed for these two formats, required changes are made accordingly.