### PR TITLE
PLUGIN-1704: Enhance BigQuery Fully-Qualified Name (FQN) handling

### DIFF
--- a/src/test/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtilTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtilTest.java
@@ -146,6 +146,44 @@ public class BigQueryUtilTest {
   }
 
   @Test
+  public void testFormatAsFQNComponentWithReservedCharacters() {
+    String input = ":special`chars \t\n";
+    String expected = "`:special`chars \t\n`";
+    String result = BigQueryUtil.formatAsFQNComponent(input);
+    Assert.assertEquals(expected, result);
+  }
+
+  @Test
+  public void testFormatAsFQNComponentWithoutReservedCharacters() {
+    String input = "validComponent";
+    String expected = "validComponent";
+    String result = BigQueryUtil.formatAsFQNComponent(input);
+    Assert.assertEquals(expected, result);
+  }
+
+  @Test
+  public void testGetFQNWithReservedCharacters() {
+    String datasetProject = "google.com:project";
+    String datasetName = "dataset";
+    String tableName = "table";
+    String expectedFQN = "bigquery:`google.com:project`.dataset.table";
+
+    String result = BigQueryUtil.getFQN(datasetProject, datasetName, tableName);
+    Assert.assertEquals(result, expectedFQN);
+  }
+
+  @Test
+  public void testGetFQNWithoutReservedCharacters() {
+    String datasetProject = "project";
+    String datasetName = "dataset";
+    String tableName = "table";
+    String expectedFQN = "bigquery:project.dataset.table";
+
+    String result = BigQueryUtil.getFQN(datasetProject, datasetName, tableName);
+    Assert.assertEquals(result, expectedFQN);
+  }
+
+  @Test
   public void testGetBucketPrefixNotSet() {
     Map<String, String> args = new HashMap<>();
     Assert.assertNull(BigQueryUtil.getBucketPrefix(args));


### PR DESCRIPTION
## Description
Support data lineage predefined formats in the BigQuery plugin

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [PLUGIN-1704](https://cdap.atlassian.net/browse/PLUGIN-1704)

## Test Plan
## Screenshots
<img width="1242" alt="Screenshot 2023-10-24 at 12 26 07 AM" src="https://github.com/data-integrations/google-cloud/assets/63417899/c0d774fe-0359-4382-a02f-b593f12b6a66">

[PLUGIN-1704]: https://cdap.atlassian.net/browse/PLUGIN-1704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ