### PR TITLE
PLUGIN-1704: Enhance GCS Fully-Qualified Name (FQN) handling

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
@@ -84,7 +84,6 @@ public final class BigQueryUtil {
   public static final String BUCKET_PATTERN = "[a-z0-9._-]+";
   public static final String DATASET_PATTERN = "[A-Za-z0-9_]+";
   public static final String TABLE_PATTERN = "[A-Za-z0-9_-]+";
-  public static final String FQN_RESERVED_CHARACTERS_PATTERN = ".*[.:` \t\n].*";
 
   // Tags for BQ Jobs
   public static final String BQ_JOB_TYPE_SOURCE_TAG = "bq_source_plugin";
@@ -776,24 +775,6 @@ public final class BigQueryUtil {
     return timePartitionCondition.toString();
   }
 
-
-  /**
-   * Formats a string as a component of a Fully-Qualified Name (FQN).
-   *
-   * @param component The string component to format.
-   * @return The formatted string component, enclosed in backticks if special characters are
-   *     present.
-   */
-  public static String formatAsFQNComponent(String component) {
-    Pattern pattern = Pattern.compile(FQN_RESERVED_CHARACTERS_PATTERN);
-
-    if (pattern.matcher(component).matches()) {
-      return String.format("`%s`", component);
-    } else {
-      return component;
-    }
-  }
-
   /**
    * Get fully-qualified name (FQN) for a BQ table (FQN format:
    * bigquery:{projectId}.{datasetId}.{tableId}).
@@ -805,9 +786,9 @@ public final class BigQueryUtil {
    */
   public static String getFQN(String datasetProject, String datasetName, String tableName) {
 
-    String formattedProject = formatAsFQNComponent(datasetProject);
-    String formattedDataset = formatAsFQNComponent(datasetName);
-    String formattedTable = formatAsFQNComponent(tableName);
+    String formattedProject = GCPUtils.formatAsFQNComponent(datasetProject);
+    String formattedDataset = GCPUtils.formatAsFQNComponent(datasetName);
+    String formattedTable = GCPUtils.formatAsFQNComponent(tableName);
 
     String fqn = String.format("%s:%s.%s.%s", BigQueryConstants.BQ_FQN_PREFIX, formattedProject,
         formattedDataset, formattedTable);

--- a/src/main/java/io/cdap/plugin/gcp/common/GCPUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCPUtils.java
@@ -54,6 +54,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 /**
@@ -75,6 +76,7 @@ public class GCPUtils {
   // needs to be added, by default, this scope is not included
   public static final List<String> BIGQUERY_SCOPES = Arrays.asList("https://www.googleapis.com/auth/drive",
                                                                    "https://www.googleapis.com/auth/bigquery");
+  public static final String FQN_RESERVED_CHARACTERS_PATTERN = ".*[.:` \t\n].*";
 
   /**
    * Load a service account from the local file system.
@@ -283,5 +285,21 @@ public class GCPUtils {
       builder.setDefaultKmsKeyName(cmekKeyName.toString());
     }
     storage.create(builder.build());
+  }
+  /**
+   * Formats a string as a component of a Fully-Qualified Name (FQN).
+   *
+   * @param component The string component to format.
+   * @return The formatted string component, enclosed in backticks if special characters are
+   * present.
+   */
+  public static String formatAsFQNComponent(String component) {
+    Pattern pattern = Pattern.compile(FQN_RESERVED_CHARACTERS_PATTERN);
+
+    if (pattern.matcher(component).matches()) {
+      return String.format("`%s`", component);
+    } else {
+      return component;
+    }
   }
 }

--- a/src/main/java/io/cdap/plugin/gcp/gcs/GCSPath.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/GCSPath.java
@@ -18,6 +18,7 @@ package io.cdap.plugin.gcp.gcs;
 
 import com.google.common.net.UrlEscapers;
 
+import io.cdap.plugin.gcp.common.GCPUtils;
 import java.net.URI;
 import java.util.Objects;
 import java.util.regex.Pattern;
@@ -32,6 +33,7 @@ public class GCSPath {
   private final URI uri;
   private final String bucket;
   private final String name;
+  public static final String GCS_FQN_PREFIX = "gcs";
 
   private GCSPath(URI uri, String bucket, String name) {
     this.uri = uri;
@@ -114,5 +116,19 @@ public class GCSPath {
     String file = idx > 0 ? path.substring(idx).replaceAll("^/", "") : "";
     URI uri = URI.create(SCHEME + bucket + "/" + UrlEscapers.urlFragmentEscaper().escape(file));
     return new GCSPath(uri, bucket, file);
+  }
+
+  /**
+   * Get fully-qualified name (FQN) with format: gcs:{bucket}.{virtualPath}
+   *
+   * @param path the path string to parse
+   * @return String fqn
+   */
+  public static String getFQN(String path) {
+    GCSPath gcsPath = GCSPath.from(path);
+    String formattedBucket = GCPUtils.formatAsFQNComponent(gcsPath.bucket);
+    String formattedFile = GCPUtils.formatAsFQNComponent(gcsPath.name);
+
+    return String.format("%s:%s.%s", GCS_FQN_PREFIX, formattedBucket, formattedFile);
   }
 }

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java
@@ -144,7 +144,7 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
     this.outputPath = getOutputDir(context);
     // create asset for lineage
     asset = Asset.builder(config.getReferenceName())
-      .setFqn(config.getPath()).setLocation(location).build();
+      .setFqn(GCSPath.getFQN(config.getPath())).setLocation(location).build();
     
     // super is called down here to avoid instantiating the lineage recorder with a null asset
     super.prepareRun(context);
@@ -447,7 +447,8 @@ public class GCSBatchSink extends AbstractFileSink<GCSBatchSink.GCSBatchSinkConf
      */
     @Override
     public String getReferenceName() {
-      return Strings.isNullOrEmpty(referenceName) ? ReferenceNames.normalizeFqn(getPath()) : referenceName;
+      return Strings.isNullOrEmpty(referenceName) ? ReferenceNames.normalizeFqn(
+          GCSPath.getFQN(getPath())) : referenceName;
     }
 
     public GCSBatchSinkConfig(@Nullable String referenceName, @Nullable String project,

--- a/src/main/java/io/cdap/plugin/gcp/gcs/source/GCSSource.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/source/GCSSource.java
@@ -95,11 +95,12 @@ public class GCSSource extends AbstractFileSource<GCSSource.GCSSourceConfig> {
     }
 
     // create asset for lineage
+    String fqn = GCSPath.getFQN(config.getPath());
     String referenceName = Strings.isNullOrEmpty(config.getReferenceName())
-      ? ReferenceNames.normalizeFqn(config.getPath())
-      : config.getReferenceName();
+        ? ReferenceNames.normalizeFqn(fqn)
+        : config.getReferenceName();
     asset = Asset.builder(referenceName)
-      .setFqn(config.getPath()).setLocation(location).build();
+        .setFqn(fqn).setLocation(location).build();
 
     // super is called down here to avoid instantiating the lineage recorder with a null asset
     super.prepareRun(context);

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtilTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtilTest.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.validation.ValidationFailure;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryTypeSize.BigNumeric;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryTypeSize.Numeric;
+import io.cdap.plugin.gcp.common.GCPUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -149,7 +150,7 @@ public class BigQueryUtilTest {
   public void testFormatAsFQNComponentWithReservedCharacters() {
     String input = ":special`chars \t\n";
     String expected = "`:special`chars \t\n`";
-    String result = BigQueryUtil.formatAsFQNComponent(input);
+    String result = GCPUtils.formatAsFQNComponent(input);
     Assert.assertEquals(expected, result);
   }
 
@@ -157,7 +158,7 @@ public class BigQueryUtilTest {
   public void testFormatAsFQNComponentWithoutReservedCharacters() {
     String input = "validComponent";
     String expected = "validComponent";
-    String result = BigQueryUtil.formatAsFQNComponent(input);
+    String result = GCPUtils.formatAsFQNComponent(input);
     Assert.assertEquals(expected, result);
   }
 


### PR DESCRIPTION
## Description
Support data lineage predefined formats in the GCS plugin

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: [PLUGIN-1704](https://cdap.atlassian.net/browse/PLUGIN-1704)

## Test Plan
## Screenshots
<img width="820" alt="Screenshot 2023-10-26 at 1 22 04 PM" src="https://github.com/data-integrations/google-cloud/assets/63417899/723999bc-fe88-4062-be0c-7e6427f4306b">


[PLUGIN-1704]: https://cdap.atlassian.net/browse/PLUGIN-1704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ