### PR TITLE
advanced cucumber report fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1157,7 +1157,6 @@
           <execution>
             <goals>
               <goal>integration-test</goal>
-              <goal>verify</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
The advanced cucumber reports are not getting generated due to the verify goal changes, which was added earlier in the GCS copy PR. The issue is also observed in google cloud tests. Hence removing this change.
