### PR TITLE
[PLUGIN-1727] Remove opencensus-impl dependency from GCS connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -598,6 +598,10 @@
           <groupId>io.grpc</groupId>
         </exclusion>
         <exclusion>
+          <groupId>io.opencensus</groupId>
+          <artifactId>opencensus-impl</artifactId>
+        </exclusion>
+        <exclusion>
           <artifactId>grpc-census</artifactId>
           <groupId>io.grpc</groupId>
         </exclusion>
@@ -959,6 +963,39 @@
             <goals>
               <goal>create-plugin-json</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.4.1</version>
+        <executions>
+          <execution>
+            <id>enforce-banned-dependencies</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>io.opencensus:opencensus-impl</exclude>
+                  </excludes>
+                  <message>
+                    Exclude Open Census implementations to disable Open Census stats and tracing.
+                    They are not used by the plugins. For tracing, Open Census spawns a new thread
+                    and loads a single global instance of a TracingComponent. CDAP uses a separate
+                    class loader for each plugin. This leads to spawning a new thread for each plugin
+                    with the Open Census dependency. As this thread keeps a reference to the class
+                    loader, it prevents the class loader from being garbage collected leading
+                    to leaks. If no implementation of TracingComponent is found at runtime,
+                    Open Census uses a NoopTraceComponent.
+                  </message>
+                </bannedDependencies>
+              </rules>
+              <fail>true</fail>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
## [PLUGIN-1727](https://cdap.atlassian.net/browse/PLUGIN-1727)

This PR removes the only dependency on `opencensus-impl` and adds a build rule to ensure build fails when if the dependency is re-introduced again. See Jira for more details.

[PLUGIN-1727]: https://cdap.atlassian.net/browse/PLUGIN-1727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ