### PR TITLE
[PLUGIN-1692] Remove duplicate path when writing nested JSON array

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryRecordToJson.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryRecordToJson.java
@@ -250,14 +250,10 @@ public final class BigQueryRecordToJson {
         }
         if (element instanceof StructuredRecord) {
           StructuredRecord record = (StructuredRecord) element;
-          path.add(name);
           processRecord(writer, record, Objects.requireNonNull(record.getSchema().getFields()),
                   path, jsonStringFieldsPaths);
-          path.remove(path.size() - 1);
         } else {
-          path.add(name);
           write(writer, name, true, element, componentSchema, path, jsonStringFieldsPaths);
-          path.remove(path.size() - 1);
         }
       }
     }


### PR DESCRIPTION
JIRA: [PLUGIN-1692](https://cdap.atlassian.net/browse/PLUGIN-1692)

Hotfix for bq sink json support , data was not formatted when writing nested json array.

This was caused due to path having duplicate entry, which is removed in this fix.

[PLUGIN-1692]: https://cdap.atlassian.net/browse/PLUGIN-1692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ