### PR TITLE
[Cherrypick][HotFix] Remove duplicate path when writing nested JSON array

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>google-cloud</artifactId>
-  <version>0.23.0</version>
+  <version>0.23.1-SNAPSHOT</version>
   <name>Google Cloud Plugins</name>
   <packaging>jar</packaging>
   <description>Plugins for Google Big Query</description>

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryRecordToJson.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryRecordToJson.java
@@ -250,14 +250,10 @@ public final class BigQueryRecordToJson {
         }
         if (element instanceof StructuredRecord) {
           StructuredRecord record = (StructuredRecord) element;
-          path.add(name);
           processRecord(writer, record, Objects.requireNonNull(record.getSchema().getFields()),
                   path, jsonStringFieldsPaths);
-          path.remove(path.size() - 1);
         } else {
-          path.add(name);
           write(writer, name, true, element, componentSchema, path, jsonStringFieldsPaths);
-          path.remove(path.size() - 1);
         }
       }
     }


### PR DESCRIPTION
[Cherrypick] Remove duplicate path when writing nested JSON array

Commit : ca5b35907d4c9f8cac80042ff24292657000b54d
PR : #1350 

---


Hotfix for bq sink json support , data was not formatted when writing nested json array.

This was caused due to path having duplicate entry, which is removed in this fix.
