### PR TITLE
[PLUGIN-1735] Fix read timeout issue during GCS Bucket  copy/move actions for large files

### DIFF
--- a/docs/GCSCopy-action.md
+++ b/docs/GCSCopy-action.md
@@ -50,6 +50,10 @@ This value is ignored if the bucket already exists.
 If the bucket already exists, this is ignored. More information can be found 
 [here](https://cloud.google.com/data-fusion/docs/how-to/customer-managed-encryption-keys)
 
+**Read Timeout:** Timeout in seconds to read data from an established HTTP connection (Default value is 20). 
+For performing copy/move operation on large files in GCS buckets, a higher timeout might be needed. Setting it to 0
+implies infinite timeout (no limit on the timeout) [NOT RECOMMENDED]
+
 Example
 -------
 

--- a/docs/GCSMove-action.md
+++ b/docs/GCSMove-action.md
@@ -51,6 +51,10 @@ This value is ignored if the bucket already exists.
 If the bucket already exists, this is ignored. More information can be found 
 [here](https://cloud.google.com/data-fusion/docs/how-to/customer-managed-encryption-keys)
 
+**Read Timeout:** Timeout in seconds to read data from an established HTTP connection (Default value is 20).
+For performing copy/move operation on large files in GCS buckets, a higher timeout might be needed. Setting it to 0
+implies infinite timeout (no limit on the timeout) [NOT RECOMMENDED]
+
 Example
 -------
 

--- a/src/main/java/io/cdap/plugin/gcp/dataplex/sink/DataplexBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/dataplex/sink/DataplexBatchSink.java
@@ -615,7 +615,7 @@ public final class DataplexBatchSink extends BatchSink<StructuredRecord, Object,
     }
     try {
       StorageClient storageClient = StorageClient.create(config.getProject(), config.getServiceAccount(),
-        config.isServiceAccountFilePath());
+        config.isServiceAccountFilePath(), null);
       storageClient.mapMetaDataForAllBlobs(outputPath,
         new MetricsEmitter(context.getMetrics())::emitMetrics);
     } catch (Exception e) {

--- a/src/main/java/io/cdap/plugin/gcp/gcs/StorageClient.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/StorageClient.java
@@ -17,6 +17,7 @@
 package io.cdap.plugin.gcp.gcs;
 
 import com.google.api.gax.paging.Page;
+import com.google.cloud.http.HttpTransportOptions;
 import com.google.cloud.kms.v1.CryptoKeyName;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
@@ -320,17 +321,21 @@ public class StorageClient {
   }
 
   public static StorageClient create(String project, @Nullable String serviceAccount,
-                                     Boolean isServiceAccountFilePath) throws IOException {
+                                     Boolean isServiceAccountFilePath, @Nullable Integer readTimeout)
+    throws IOException {
     StorageOptions.Builder builder = StorageOptions.newBuilder().setProjectId(project);
     if (serviceAccount != null) {
       builder.setCredentials(GCPUtils.loadServiceAccountCredentials(serviceAccount, isServiceAccountFilePath));
+    }
+    if (readTimeout != null) {
+      builder.setTransportOptions(HttpTransportOptions.newBuilder().setReadTimeout(readTimeout * 1000).build());
     }
     Storage storage = builder.build().getService();
     return new StorageClient(storage);
   }
 
   public static StorageClient create(GCPConnectorConfig config) throws IOException {
-    return create(config.getProject(), config.getServiceAccount(), config.isServiceAccountFilePath());
+    return create(config.getProject(), config.getServiceAccount(), config.isServiceAccountFilePath(), null);
   }
 
   /**

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSCopy.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSCopy.java
@@ -67,7 +67,7 @@ public class GCSCopy extends Action {
       return;
     }
     StorageClient storageClient = StorageClient.create(config.getProject(), config.getServiceAccount(),
-                                                       isServiceAccountFilePath);
+                                                       isServiceAccountFilePath, config.readTimeout);
 
     GCSPath destPath = config.getDestPath();
     CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(config.cmekKey, context.getArguments().asMap(), collector);

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
@@ -67,7 +67,7 @@ public class GCSMove extends Action {
       return;
     }
     StorageClient storageClient = StorageClient.create(config.getProject(), config.getServiceAccount(),
-                                                       isServiceAccountFilePath);
+                                                       isServiceAccountFilePath, config.readTimeout);
     GCSPath destPath = config.getDestPath();
     CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(config.cmekKey, context.getArguments().asMap(), collector);
     collector.getOrThrowException();

--- a/widgets/GCSCopy-action.json
+++ b/widgets/GCSCopy-action.json
@@ -128,6 +128,20 @@
           }
         }
       ]
+    },
+    {
+      "label" : "Advanced",
+      "properties" : [
+        {
+          "name": "readTimeout",
+          "label" : "Read Timeout",
+          "widget-type": "number",
+          "widget-attributes": {
+            "default": "20",
+            "minimum": "0"
+          }
+        }
+      ]
     }
   ],
   "filters": [

--- a/widgets/GCSMove-action.json
+++ b/widgets/GCSMove-action.json
@@ -128,6 +128,20 @@
           }
         }
       ]
+    },
+    {
+      "label" : "Advanced",
+      "properties" : [
+        {
+          "name": "readTimeout",
+          "label" : "Read Timeout",
+          "widget-type": "number",
+          "widget-attributes": {
+            "default": "20",
+            "minimum": "0"
+          }
+        }
+      ]
     }
   ],
   "filters": [


### PR DESCRIPTION
[JIRA
](https://cdap.atlassian.net/browse/PLUGIN-1735
)
## Introduction:
- While copying large files using the **GCS Copy** plugin, `Read Timed out` error was occuring as Storage Client was configured with the default timeout of 20 seconds: https://cloud.google.com/storage/docs/retry-strategy#client-libraries

## Fix
- A property **readTimeout** has been introduced for GCS Copy/Move Plugins that enables user to provide the timeout based on their requirements depending on the file size that is being transferred.
- The Retry Settings for the Storage Client are configured to use this property using [this method](https://cloud.google.com/java/docs/reference/google-cloud-core/latest/com.google.cloud.http.HttpTransportOptions.Builder#com_google_cloud_http_HttpTransportOptions_Builder_setReadTimeout_int_)

## Testing
- Tested the changes by running a pipeline with **GCS Copy** plugin in CDAP sandbox

