### PR TITLE
Remove Snapshot for Hub Release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>google-cloud</artifactId>
-  <version>0.23.1-SNAPSHOT</version>
+  <version>0.23.1</version>
   <name>Google Cloud Plugins</name>
   <packaging>jar</packaging>
   <description>Plugins for Google Big Query</description>


### PR DESCRIPTION
PR to remove snapshot in order to perform Hub release for the fixes introduced by #1364 and #1367 