### PR TITLE
Fix e2e tests for Google Cloud Plugins corresponding to CDAP 6.9 versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1185,7 +1185,7 @@
         <dependency>
           <groupId>io.cdap.tests.e2e</groupId>
           <artifactId>cdap-e2e-framework</artifactId>
-          <version>0.2.2</version>
+          <version>0.2.3</version>
           <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
The updated version `0.2.3` of `cdap-e2e-framework` contains the fix https://github.com/cdapio/cdap-e2e-tests/pull/245 that is needed for e2e tests to succeed.