### PR TITLE
Remove snapshot for Hub Release for CDAP 6.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>google-cloud</artifactId>
-  <version>0.22.6-SNAPSHOT</version>
+  <version>0.22.6</version>
   <name>Google Cloud Plugins</name>
   <packaging>jar</packaging>
   <description>Plugins for Google Big Query</description>


### PR DESCRIPTION
Changes merged through #1365 and #1366 to be released in Hub