### PR TITLE
[🍒][PLUGIN-788] Fixed Partition Field Validation

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
@@ -390,6 +390,10 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
     String tableName = getTable();
     String serviceAccount = getServiceAccount();
 
+    if (shouldCreatePartitionedTable()) {
+      validateColumnForPartition(partitionByField, schema, collector);
+    }
+
     if (project == null || dataset == null || tableName == null || serviceAccount == null) {
       return;
     }
@@ -415,11 +419,6 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
       } else if (rangePartitioning != null) {
         validateRangePartitionTableWithInputConfiguration(table, rangePartitioning, collector);
       }
-      validateColumnForPartition(partitionByField, schema, collector);
-      return;
-    }
-    if (shouldCreatePartitionedTable()) {
-      validateColumnForPartition(partitionByField, schema, collector);
     }
   }
 
@@ -538,6 +537,14 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
       collector.addFailure("Range End is not defined.",
                            "For Integer Partitioning, Range End must be defined.")
         .withConfigProperty(NAME_RANGE_END);
+    }
+
+    if (!containsMacro(NAME_RANGE_START) && !containsMacro(NAME_RANGE_END) && rangeStart != null && rangeEnd != null) {
+      if (rangeEnd <= rangeStart) {
+        collector.addFailure("Range End is less than or equal to Range Start.",
+                             "Range End must be greater than Range Start.")
+          .withConfigProperty(NAME_RANGE_END);
+      }
     }
 
     if (!containsMacro(NAME_RANGE_INTERVAL)) {


### PR DESCRIPTION
[Cherrypick]
Commit : 05b4423040c03237da1afa4c54d31f5aef60b505
PR: https://github.com/data-integrations/google-cloud/pull/1398

---

## Fixed Partition Field Validation

Jira : [PLUGIN-788](https://cdap.atlassian.net/browse/PLUGIN-788)

### Description

- Partition field validation was being skipped due to faulty code logic.
- Reordering the `if` condition solved this issue, and we get proper error messages as expected.

![image](https://github.com/cloudsufi/google-cloud/assets/122770897/955d9d0a-29e3-4f14-8e96-13791b2f457b)

<img width="998" alt="image" src="https://github.com/cloudsufi/google-cloud/assets/122770897/3a59826e-ec0d-43d6-8022-d512c6f9c705">


### UI Field

- No Changes made to widget json.

### Docs

- No Changes made to docs.

### Code change

- Modified `BigQuerySinkConfig.java`

### Unit Tests

- No Changes made to unit tests.


[PLUGIN-788]: https://cdap.atlassian.net/browse/PLUGIN-788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ