### PR TITLE
[🍒][PLUGIN-781] Hide Table Key By field on operation insert

### DIFF
--- a/widgets/BigQueryTable-batchsink.json
+++ b/widgets/BigQueryTable-batchsink.json
@@ -530,6 +530,18 @@
           "name": "dedupeBy"
         }
       ]
+    },
+    {
+      "name": "relationTableKeyFilter",
+      "condition": {
+        "expression": "operation == 'update' || operation == 'upsert'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "relationTableKey"
+        }
+      ]
     }
   ],
   "jump-config": {


### PR DESCRIPTION
[Cherrypick]
Commit : cbb5920b5f8d8237dc4c9f3d5bf7bedce4d27fdf
PR: https://github.com/data-integrations/google-cloud/pull/1397

---

## Hide Table Key By field on operation insert

Jira : [PLUGIN-781](https://cdap.atlassian.net/browse/PLUGIN-781)

### Description

This PR adds a simple filter to hide the property when operation in insert.

### UI Field

- Modified `BigQueryTable-batchsink.json`


[PLUGIN-781]: https://cdap.atlassian.net/browse/PLUGIN-781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ