### PR TITLE
[🍒][PLUGIN-1563] Add support in BQ Source to read JSON columns

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryDataParser.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryDataParser.java
@@ -159,7 +159,9 @@ public final class BigQueryDataParser {
      */
   public static Object convertValue(Field field, FieldValue fieldValue) {
     LegacySQLTypeName type = field.getType();
-    StandardSQLTypeName standardType = type.getStandardType();
+    // Treat JSON as string
+    StandardSQLTypeName standardType = LegacySQLTypeName.valueOf("JSON").equals(type) ?
+    StandardSQLTypeName.STRING : type.getStandardType();
     switch (standardType) {
       case TIME:
         return LocalTime.parse(fieldValue.getStringValue());

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
@@ -292,7 +292,9 @@ public final class BigQueryUtil {
   public static Schema convertFieldType(Field field, @Nullable FailureCollector collector,
                                         @Nullable String recordPrefix) {
     LegacySQLTypeName type = field.getType();
-    StandardSQLTypeName standardType = type.getStandardType();
+    // Treat JSON as string
+    StandardSQLTypeName standardType = LegacySQLTypeName.valueOf("JSON").equals(type) ?
+    StandardSQLTypeName.STRING : type.getStandardType();
     switch (standardType) {
       case FLOAT64:
         // float is a float64, so corresponding type becomes double

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/util/BigQueryDataParserTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/util/BigQueryDataParserTest.java
@@ -20,6 +20,7 @@ import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.FieldList;
 import com.google.cloud.bigquery.FieldValue;
 import com.google.cloud.bigquery.FieldValueList;
+import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.bigquery.TableResult;
 import com.google.common.io.BaseEncoding;
@@ -158,5 +159,14 @@ public class BigQueryDataParserTest {
       return value;
     }
     return Strings.repeat('0', length - value.length()) + value;
+  }
+
+  @Test
+  public void testJsonFieldConversionToString() {
+    Field field = Field.newBuilder("demo", LegacySQLTypeName.valueOf("JSON")).build();
+    String jsonValue = "{\"key\":\"value\"}";
+    FieldValue fieldValue = FieldValue.of(FieldValue.Attribute.PRIMITIVE, jsonValue);
+    Object result = BigQueryDataParser.convertValue(field, fieldValue);
+    Assert.assertEquals(jsonValue, result);
   }
 }

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtilTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtilTest.java
@@ -17,6 +17,7 @@
 package io.cdap.plugin.gcp.bigquery.util;
 
 import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.StandardSQLTypeName;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.FailureCollector;
@@ -470,4 +471,11 @@ public class BigQueryUtilTest {
             collector.getValidationFailures().get(0).getMessage());
   }
 
+  @Test
+  public void testConvertFieldTypeJsonToString() {
+      Field field = Field.newBuilder("demo", LegacySQLTypeName.valueOf("JSON")).build();
+      Schema expectedSchema = Schema.of(Schema.Type.STRING);
+      Schema result = BigQueryUtil.convertFieldType(field, null, null);
+      Assert.assertEquals(expectedSchema, result);
+  }
 }


### PR DESCRIPTION
[Cherrypick]
Commit : 8cfba2024019705cebc8864492b73d6883f11134
PR: https://github.com/data-integrations/google-cloud/pull/1391

---

## Add support in BQ Source to read JSON columns

Jira : [PLUGIN-1563](https://cdap.atlassian.net/browse/PLUGIN-1563)

### Description

This PR adds the ability to read columns with JSON columns.
We treat Json type as a string.

### UI Field

- No Changes made to widget json.

### Docs

- No Changes made to docs.

### Code change

- Modified `BigQueryUtil.java`

### Unit Tests

- Modified `BigQueryUtilTest.java`
  -  Added new Unit Test `testConvertFieldTypeJsonToString`
  
<img width="411" alt="image" src="https://github.com/data-integrations/google-cloud/assets/122770897/1c3fa59f-3640-4427-8ef8-53195f0cf3fa">


[PLUGIN-1563]: https://cdap.atlassian.net/browse/PLUGIN-1563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
