### PR TITLE
[PLUGIN-1563] Update Json supported as string in documentation

### DIFF
--- a/docs/BigQueryTable-batchsource.md
+++ b/docs/BigQueryTable-batchsource.md
@@ -105,4 +105,4 @@ corresponding CDAP data type for each BigQuery type.
 | struct        | record                             |
 | time          | time (microseconds)                |
 | timestamp     | timestamp (microseconds)           |
-| json          | unsupported                        |
+| json          | string                             |


### PR DESCRIPTION
## Update Json supported as string in documentation

Jira : [PLUGIN-1563](https://cdap.atlassian.net/browse/PLUGIN-1563)

### Description

Update Json field as supported and cdap mapping to string in documentation.

### Docs

- Modified `BigQueryTable-batchsource.md`

![Screenshot](https://github.com/data-integrations/google-cloud/assets/122770897/4f547376-c03a-4511-86b0-b5e285920049)


[PLUGIN-1563]: https://cdap.atlassian.net/browse/PLUGIN-1563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ