### PR TITLE
[🍒][PLUGIN-1318] Added ArgumentsColumnsList Exists Validation, Fix PlaceHolder Key

### DIFF
--- a/src/test/java/io/cdap/plugin/gcp/bigquery/action/BigQueryArgumentSetterConfigTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/action/BigQueryArgumentSetterConfigTest.java
@@ -16,12 +16,19 @@
 
 package io.cdap.plugin.gcp.bigquery.action;
 
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.FieldList;
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.common.collect.ImmutableList;
 import io.cdap.cdap.etl.api.validation.CauseAttributes;
 import io.cdap.cdap.etl.api.validation.ValidationException;
 import io.cdap.cdap.etl.api.validation.ValidationFailure;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+
+import java.util.List;
 
 public class BigQueryArgumentSetterConfigTest {
 
@@ -30,6 +37,12 @@ public class BigQueryArgumentSetterConfigTest {
   private static final String VALID_TABLE = "table";
   private static final String VALID_ARGUMENT_SELECTION_CONDITIONS = "feed=10;id=0";
   private static final String VALID_ARGUMENT_COLUMN = "name";
+  private MockFailureCollector mockFailureCollector;
+
+  @Before
+  public void setUp() {
+    mockFailureCollector = new MockFailureCollector();
+  }
 
   @Test
   public void testValidateMissingArgumentSelectionConditions() {
@@ -41,6 +54,47 @@ public class BigQueryArgumentSetterConfigTest {
   public void testValidateMissingArgumentColumns() {
     BigQueryArgumentSetterConfig config = getBuilder().setArgumentsColumns(null).build();
     validateConfigValidationFail(config, BigQueryArgumentSetterConfig.NAME_ARGUMENTS_COLUMNS);
+  }
+
+  @Test
+  public void testCheckIfArgumentsColumnsListExistsInSourceMatchOne() {
+    List<String> argumentsColumnsList = ImmutableList.of("name");
+    FieldList fields = FieldList.of(Field.newBuilder("name", LegacySQLTypeName.STRING).build());
+    BigQueryArgumentSetterConfig.checkIfArgumentsColumnsListExistsInSource(argumentsColumnsList, fields,
+        mockFailureCollector);
+    Assert.assertEquals(0, mockFailureCollector.getValidationFailures().size());
+  }
+
+  @Test
+  public void testCheckIfArgumentsColumnsListExistsInSourceMatchSome() {
+    List<String> argumentsColumnsList = ImmutableList.of("name");
+    FieldList fields = FieldList.of(Field.newBuilder("name", LegacySQLTypeName.STRING).build(),
+        Field.newBuilder("age", LegacySQLTypeName.INTEGER).build());
+    BigQueryArgumentSetterConfig.checkIfArgumentsColumnsListExistsInSource(argumentsColumnsList, fields,
+        mockFailureCollector);
+    Assert.assertEquals(0, mockFailureCollector.getValidationFailures().size());
+  }
+
+  @Test
+  public void testCheckIfArgumentsColumnsListExistsInSourceFailedMatchOne() {
+    List<String> argumentsColumnsList = ImmutableList.of("name");
+    FieldList fields = FieldList.of(Field.newBuilder("age", LegacySQLTypeName.INTEGER).build());
+    BigQueryArgumentSetterConfig.checkIfArgumentsColumnsListExistsInSource(argumentsColumnsList, fields,
+        mockFailureCollector);
+    Assert.assertEquals(1, mockFailureCollector.getValidationFailures().size());
+    Assert.assertEquals("Column: \"name\" does not exist in table. Argument columns must exist in table.",
+        mockFailureCollector.getValidationFailures().get(0).getMessage());
+  }
+
+  @Test
+  public void testCheckIfArgumentsColumnsListExistsInSourceFailedMatchSome() {
+    List<String> argumentsColumnsList = ImmutableList.of("name", "city");
+    FieldList fields = FieldList.of(Field.newBuilder("age", LegacySQLTypeName.INTEGER).build());
+    BigQueryArgumentSetterConfig.checkIfArgumentsColumnsListExistsInSource(argumentsColumnsList, fields,
+        mockFailureCollector);
+    Assert.assertEquals(1, mockFailureCollector.getValidationFailures().size());
+    Assert.assertEquals("Columns: \"name ,city\" do not exist in table. Argument columns must exist in table.",
+        mockFailureCollector.getValidationFailures().get(0).getMessage());
   }
 
   private static BigQueryArgumentSetterConfig.Builder getBuilder() {

--- a/widgets/BigQueryArgumentSetter-action.json
+++ b/widgets/BigQueryArgumentSetter-action.json
@@ -72,7 +72,7 @@
           "widget-type": "csv",
           "widget-attributes" : {
             "delimiter": ",",
-            "placeholder": "The name of the column that contains the arguments for this run."
+            "value-placeholder": "The name of the column that contains the arguments for this run."
           }
         }
       ]


### PR DESCRIPTION
[Cherrypick]
Commit : 25f06063d68ca4bf26831064bba9a46298583d65
PR: https://github.com/data-integrations/google-cloud/pull/1396

---

## Added ArgumentsColumnsList Exists Validation, Fix PlaceHolder Key

Jira : [PLUGIN-1318](https://cdap.atlassian.net/browse/PLUGIN-1318)

### Description

This PR adds validation for `Argument Columns` field.
- Checks if passed value is present in source table as a column.
- Fixes the placeholder key.

![image](https://github.com/data-integrations/google-cloud/assets/122770897/e7c1cb0e-ac3f-4f29-abf8-1e8d825d9b7b)

### UI Field

- Modified `BigQueryArgumentSetter-action.json`

### Docs

- No Changes made to docs.

### Code change

- Modified `BigQueryArgumentSetterConfig.java`

### Unit Tests

Added new unit tests
- testCheckIfArgumentsColumnsListExistsInSourceMatchOne
- testCheckIfArgumentsColumnsListExistsInSourceMatchSome
- testCheckIfArgumentsColumnsListExistsInSourceFailedMatchOne
- testCheckIfArgumentsColumnsListExistsInSourceFailedMatchSome

![image](https://github.com/data-integrations/google-cloud/assets/122770897/02b34e9d-4761-4599-88a7-de4d2e35470b)


[PLUGIN-1318]: https://cdap.atlassian.net/browse/PLUGIN-1318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ