### PR TITLE
Use securekey-textarea widget for SA json fields

### DIFF
--- a/widgets/BigQuery-connector.json
+++ b/widgets/BigQuery-connector.json
@@ -76,7 +76,7 @@
           }
         },
         {
-          "widget-type": "textarea",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/BigQueryArgumentSetter-action.json
+++ b/widgets/BigQueryArgumentSetter-action.json
@@ -108,7 +108,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/BigQueryExecute-action.json
+++ b/widgets/BigQueryExecute-action.json
@@ -199,7 +199,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         },

--- a/widgets/BigQueryMultiTable-batchsink.json
+++ b/widgets/BigQueryMultiTable-batchsink.json
@@ -75,7 +75,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/BigQueryPushdownEngine-sqlengine.json
+++ b/widgets/BigQueryPushdownEngine-sqlengine.json
@@ -98,7 +98,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         },

--- a/widgets/BigQueryTable-batchsink.json
+++ b/widgets/BigQueryTable-batchsink.json
@@ -75,7 +75,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/BigQueryTable-batchsource.json
+++ b/widgets/BigQueryTable-batchsource.json
@@ -75,7 +75,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/Bigtable-batchsink.json
+++ b/widgets/Bigtable-batchsink.json
@@ -101,7 +101,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/Bigtable-batchsource.json
+++ b/widgets/Bigtable-batchsource.json
@@ -133,7 +133,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/Dataplex-batchsink.json
+++ b/widgets/Dataplex-batchsink.json
@@ -64,7 +64,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/Dataplex-batchsource.json
+++ b/widgets/Dataplex-batchsource.json
@@ -64,7 +64,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/Datastore-batchsink.json
+++ b/widgets/Datastore-batchsink.json
@@ -102,7 +102,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/Datastore-batchsource.json
+++ b/widgets/Datastore-batchsource.json
@@ -106,7 +106,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/GCS-batchsink.json
+++ b/widgets/GCS-batchsink.json
@@ -68,7 +68,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/GCS-connector.json
+++ b/widgets/GCS-connector.json
@@ -52,7 +52,7 @@
           }
         },
         {
-          "widget-type": "textarea",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/GCSArgumentSetter-action.json
+++ b/widgets/GCSArgumentSetter-action.json
@@ -59,7 +59,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/GCSBucketCreate-action.json
+++ b/widgets/GCSBucketCreate-action.json
@@ -75,7 +75,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/GCSBucketDelete-action.json
+++ b/widgets/GCSBucketDelete-action.json
@@ -56,7 +56,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/GCSCopy-action.json
+++ b/widgets/GCSCopy-action.json
@@ -102,7 +102,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/GCSDoneFileMarker-postaction.json
+++ b/widgets/GCSDoneFileMarker-postaction.json
@@ -68,7 +68,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/GCSFile-batchsource.json
+++ b/widgets/GCSFile-batchsource.json
@@ -67,7 +67,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/GCSMove-action.json
+++ b/widgets/GCSMove-action.json
@@ -102,7 +102,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/GCSMultiFiles-batchsink.json
+++ b/widgets/GCSMultiFiles-batchsink.json
@@ -67,7 +67,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/GooglePublisher-batchsink.json
+++ b/widgets/GooglePublisher-batchsink.json
@@ -98,7 +98,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/GoogleSubscriber-streamingsource.json
+++ b/widgets/GoogleSubscriber-streamingsource.json
@@ -98,7 +98,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/Spanner-batchsink.json
+++ b/widgets/Spanner-batchsink.json
@@ -67,7 +67,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/Spanner-batchsource.json
+++ b/widgets/Spanner-batchsource.json
@@ -67,7 +67,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/Spanner-connector.json
+++ b/widgets/Spanner-connector.json
@@ -48,7 +48,7 @@
           }
         },
         {
-          "widget-type": "textarea",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }

--- a/widgets/SpeechToText-transform.json
+++ b/widgets/SpeechToText-transform.json
@@ -131,7 +131,7 @@
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "securekey-textarea",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
         }


### PR DESCRIPTION
Changes the widget type for SA json fields from `textbox` to `secure-textarea`

Please notice the shield icon in the SA json field. Clicking the shield lets the user select one of the secure keys defined in the namespace.

A corresponding [PR in cdap-ui](https://github.com/cdapio/cdap-ui/pull/1217) adds the securekeys tab in Namespace Admin and also makes the securekey-textarea widget non-editable (so that the user will only be able to add the value as a secure macro).

<img width="1512" alt="Screenshot 2024-05-13 at 10 21 28 AM" src="https://github.com/data-integrations/google-cloud/assets/4161531/c81dda95-78d4-4dd9-8ed0-d49d7083b8de">
