### PR TITLE
[PLUGIN-698] Add wildcard support for copy and move action

### DIFF
--- a/docs/GCSCopy-action.md
+++ b/docs/GCSCopy-action.md
@@ -25,6 +25,7 @@ Properties
 It can be found on the Dashboard in the Google Cloud Platform Console.
 
 **Source Path**: Path to a source object or directory.
+> Use `*` to copy multiple files. For example, `gs://demo0/prod/reports/*.csv` will copy all CSV files in the `reports` directory.
 
 **Destination Path**: Path to the destination. The bucket will be created if it does not exist. 
 

--- a/docs/GCSMove-action.md
+++ b/docs/GCSMove-action.md
@@ -26,6 +26,7 @@ Properties
 It can be found on the Dashboard in the Google Cloud Platform Console.
 
 **Source Path**: Path to a source object or directory.
+> Use `*` to move multiple files. For example, `gs://demo0/prod/reports/*.csv` will move all CSV files in the `reports` directory.
 
 **Destination Path**: Path to the destination. The bucket will be created if it does not exist.
 

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
@@ -35,7 +35,9 @@ import io.cdap.plugin.gcp.gcs.GCSPath;
 import io.cdap.plugin.gcp.gcs.StorageClient;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import javax.annotation.Nullable;
 
 
@@ -75,8 +77,17 @@ public class GCSMove extends Action {
     // create the destination bucket if not exist
     storageClient.createBucketIfNotExists(destPath, config.location, cmekKeyName);
 
-    //noinspection ConstantConditions
-    storageClient.move(config.getSourcePath(), config.getDestPath(), config.recursive, config.shouldOverwrite());
+    List<GCSPath> matchedPaths = new ArrayList<>();
+    if (SourceDestConfig.WILDCARD_REGEX.matcher(config.getSourcePath().getName()).find()) {
+      matchedPaths = storageClient.getMatchedPaths(config.getSourcePath(), config.recursive,
+          SourceDestConfig.WILDCARD_REGEX);
+    } else {
+      matchedPaths.add(config.getSourcePath());
+    }
+    for (GCSPath sourcePath : matchedPaths) {
+      //noinspection ConstantConditions
+      storageClient.move(sourcePath, config.getDestPath(), config.recursive, config.shouldOverwrite());
+    }
   }
 
   /**

--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/SourceDestConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/SourceDestConfig.java
@@ -33,7 +33,9 @@ import io.cdap.plugin.gcp.common.GCPUtils;
 import io.cdap.plugin.gcp.gcs.GCSPath;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 /**
@@ -44,6 +46,7 @@ public class SourceDestConfig extends GCPConfig {
   public static final String NAME_DEST_PATH = "destPath";
   public static final String NAME_LOCATION = "location";
   public static final String READ_TIMEOUT = "readTimeout";
+  public static final Pattern WILDCARD_REGEX = Pattern.compile("[*]");
 
   @Name(NAME_SOURCE_PATH)
   @Macro
@@ -131,6 +134,11 @@ public class SourceDestConfig extends GCPConfig {
         getDestPath();
       } catch (IllegalArgumentException e) {
         collector.addFailure(e.getMessage(), null).withConfigProperty(NAME_DEST_PATH);
+      }
+      if (WILDCARD_REGEX.matcher(destPath).find()) {
+        collector.addFailure("Destination path should not contain wildcard characters.",
+        "Please remove the wildcard characters from the destination path.")
+            .withConfigProperty(NAME_DEST_PATH);
       }
     }
     if (!containsMacro(NAME_CMEK_KEY)) {


### PR DESCRIPTION
## Add wildcard support for copy and move action

Jira : [PLUGIN-698](https://cdap.atlassian.net/browse/PLUGIN-698)

### Description

Adding wild card support in gcs copy and move action !
eg: source path `gs://foobucket/mydir/test_web*/*`

### Docs

- Modified `GCSCopy-action.md`
- Modified `GCSMove-action.md`


![image](https://github.com/data-integrations/google-cloud/assets/122770897/8dff47d6-b5ea-4eb5-a289-275c83c0ef3e)
![image](https://github.com/data-integrations/google-cloud/assets/122770897/955480eb-9fcb-4b49-b578-a8f2f5ea7b9b)

### Code change

- Modified `StorageClient.java`
- Modified `GCSCopy.java`
- Modified `GCSMove.java`
- Modified `SourceDestConfig.java`

### Unit Tests

- Modified `StorageClientTest.java`

![image](https://github.com/data-integrations/google-cloud/assets/122770897/514815ed-9506-46c8-86a1-669d526f5ff8)




[PLUGIN-698]: https://cdap.atlassian.net/browse/PLUGIN-698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ