### PR TITLE
[PLUGIN-1742] Add GCSEmptyInputFormat (Allow Empty Input)

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/common/GCSEmptyInputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCSEmptyInputFormat.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.plugin.gcp.common;
+
+import io.cdap.plugin.format.input.AbstractEmptyInputFormat;
+
+
+/**
+ * An InputFormat that returns no data.
+ * @param <K> the type of key
+ * @param <V> the type of value
+ */
+public class GCSEmptyInputFormat<K, V> extends AbstractEmptyInputFormat<K, V> {
+  // no-op
+}

--- a/src/main/java/io/cdap/plugin/gcp/gcs/source/GCSSource.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/source/GCSSource.java
@@ -43,6 +43,7 @@ import io.cdap.plugin.format.plugin.AbstractFileSourceConfig;
 import io.cdap.plugin.format.plugin.FileSourceProperties;
 import io.cdap.plugin.gcp.common.GCPConnectorConfig;
 import io.cdap.plugin.gcp.common.GCPUtils;
+import io.cdap.plugin.gcp.common.GCSEmptyInputFormat;
 import io.cdap.plugin.gcp.crypto.EncryptedFileSystem;
 import io.cdap.plugin.gcp.gcs.GCSPath;
 import io.cdap.plugin.gcp.gcs.connector.GCSConnector;
@@ -75,6 +76,11 @@ public class GCSSource extends AbstractFileSource<GCSSource.GCSSourceConfig> {
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     super.configurePipeline(pipelineConfigurer);
+  }
+
+  @Override
+  protected String getEmptyInputFormatClassName() {
+    return GCSEmptyInputFormat.class.getName();
   }
 
   @Override
@@ -266,11 +272,6 @@ public class GCSSource extends AbstractFileSource<GCSSource.GCSSourceConfig> {
     @Nullable
     public Long getMinSplitSize() {
       return minSplitSize;
-    }
-
-    @Override
-    public boolean shouldAllowEmptyInput() {
-      return false;
     }
 
     public boolean isCopyHeader() {


### PR DESCRIPTION
## Add GCSEmptyInputFormat (Allow Empty Input)

Jira : [PLUGIN-1742](https://cdap.atlassian.net/browse/PLUGIN-1742)

### Description

Add `GCSEmptyInputFormat` to allow user to run the pipeline with invalid source if `Allow Empty Input` is set to true.
- The pipeline would fail with an invalid source, when the option is set to false (default behavior)
  - Invalid source refers to a GCS path that does not exist
- This was hard coded to false to avoid the class loading error, which requires to add a separate `EmptyInputFormat`

### Code change

- Added `GCSEmptyInputFormat.java`
- Modified `GCSSource.java`


## Testing

- ( Current Release Version ) with `Allow Empty Input` (True/False)
  -  FAILED with does not exist error
  
  
![image](https://github.com/user-attachments/assets/9589bd94-5e7b-47ce-95d6-0daddbd8a765)

  
<details>
  <summary>📒Error Log</summary>
  
```
2024-09-12 12:35:01,639 - ERROR [SparkRunner-phase-1:i.c.c.i.a.r.ProgramControllerServiceAdapter@100] - Spark program 'phase-1' failed with error: Input path 00000000-e2e-000a5066-c14f-49c7-b68d-fe3b3b0fdf70/gcs_empty_input_test_case/sad_case/fail.csv does not exist. Please check the system logs for more details.
java.io.IOException: Input path 00000000-e2e-000a5066-c14f-49c7-b68d-fe3b3b0fdf70/gcs_empty_input_test_case/sad_case/fail.csv does not exist
	at io.cdap.plugin.format.plugin.AbstractFileSource.prepareRun(AbstractFileSource.java:208)
	at io.cdap.plugin.gcp.gcs.source.GCSSource.prepareRun(GCSSource.java:106)
	at io.cdap.plugin.gcp.gcs.source.GCSSource.prepareRun(GCSSource.java:61)
	at io.cdap.cdap.etl.common.plugin.WrappedBatchSource.lambda$prepareRun$0(WrappedBatchSource.java:53)
	at io.cdap.cdap.etl.common.plugin.Caller$1.call(Caller.java:30)
....
```
</details>

---

- Version with `Allow Empty Input` True (Removing hard coding)
  -  FAILED with class loading 
  
  
![image](https://github.com/user-attachments/assets/57ffef78-8b3d-4083-bfe1-356a7ac32f72)


<details>
  <summary>📒Error Log</summary>
  
```
2024-09-12 12:45:33,599 - ERROR [SparkRunner-phase-1:i.c.c.i.a.r.ProgramControllerServiceAdapter@98] - Spark Program 'phase-1' failed.
java.util.concurrent.ExecutionException: java.io.IOException: Unable to instantiate delegate input format io.cdap.plugin.format.input.EmptyInputFormat
	at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:357)
	at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1908)
	at io.cdap.cdap.app.runtime.spark.submit.AbstractSparkJobFuture.get(AbstractSparkJobFuture.java:119)
	at io.cdap.cdap.app.runtime.spark.SparkRuntimeService.run(SparkRuntimeService.java:444)
	at com.google.common.util.concurrent.AbstractExecutionThreadService$1$1.run(AbstractExecutionThreadService.java:52)
	at io.cdap.cdap.app.runtime.spark.SparkRuntimeService.lambda$null$2(SparkRuntimeService.java:525)
	at java.lang.Thread.run(Thread.java:750)
Caused by: java.io.IOException: Unable to instantiate delegate input format io.cdap.plugin.format.input.EmptyInputFormat
	at io.cdap.cdap.etl.batch.DelegatingInputFormat.getDelegate(DelegatingInputFormat.java:80)
	at io.cdap.cdap.etl.batch.DelegatingInputFormat.getSplits(DelegatingInputFormat.java:45)
	
....
```
</details>

---

- Version with `Allow Empty Input` True (with GCSEmptyInputFormat)
  -  PASSED
   
![image](https://github.com/user-attachments/assets/36a072a0-07bf-43af-b19a-ca6cafec1418)


---

- Config for the runs
![image](https://github.com/user-attachments/assets/c21af0b1-032e-40ff-8d7c-6c9898d1e468)
![image](https://github.com/user-attachments/assets/8d66a267-fa7f-4c87-b25c-2bc5caf7f5d3)



[PLUGIN-1742]: https://cdap.atlassian.net/browse/PLUGIN-1742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ