### PR TITLE
[PLUGIN-430] Remove unused field :ReferenceName: from GCS/BQ argument setter

### DIFF
--- a/docs/BigQueryArgumentSetter-action.md
+++ b/docs/BigQueryArgumentSetter-action.md
@@ -23,8 +23,6 @@
 
  Properties
  ----------
- **Reference Name:** Name used to uniquely identify this source for lineage, annotating metadata, etc.
-
  **Project ID**: Google Cloud Project ID, which uniquely identifies a project.
  It can be found on the Dashboard in the Google Cloud Platform Console. This is the project
  that the BigQuery job will run in. If a temporary bucket needs to be created, the service account

--- a/docs/GCSArgumentSetter-action.md
+++ b/docs/GCSArgumentSetter-action.md
@@ -37,8 +37,6 @@ must be readable by all users running the job.
 
 Properties
 ----------
-**Reference Name:** Name used to uniquely identify this source for lineage, annotating metadata, etc.
-
 **Project ID**: Google Cloud Project ID, which uniquely identifies a project.
 It can be found on the Dashboard in the Google Cloud Platform Console. This is the project
 that the BigQuery job will run in. If a temporary bucket needs to be created, the service account

--- a/widgets/BigQueryArgumentSetter-action.json
+++ b/widgets/BigQueryArgumentSetter-action.json
@@ -8,14 +8,6 @@
       "label": "Basic",
       "properties": [
         {
-          "widget-type": "textbox",
-          "label": "Reference Name",
-          "name": "referenceName",
-          "widget-attributes" : {
-            "placeholder": "Name used to identify this source for lineage"
-          }
-        },
-        {
           "widget-type": "connection-browser",
           "widget-category": "plugin",
           "widget-attributes": {

--- a/widgets/GCSArgumentSetter-action.json
+++ b/widgets/GCSArgumentSetter-action.json
@@ -9,14 +9,6 @@
       "properties": [
         {
           "widget-type": "textbox",
-          "label": "Reference Name",
-          "name": "referenceName",
-          "widget-attributes": {
-            "placeholder": "Name used to identify this source for lineage"
-          }
-        },
-        {
-          "widget-type": "textbox",
           "label": "Project ID",
           "name": "project",
           "widget-attributes": {


### PR DESCRIPTION
## Remove unused field :ReferenceName from GCS/BQ argument setter

Jira : [PLUGIN-430](https://cdap.atlassian.net/browse/PLUGIN-430)

### Description

GCS/BQ argument setters have field :ReferenceName: mentioned in the docs and the plugin design file, being a action plugin the field is not used in the code hence it's mention in the docs may cause confusion.

### UI Field

- Modified `BigQueryArgumentSetter-action.json`
- Modified `GCSArgumentSetter-action.json`
  
  > As the field was not used in code removing them from the plugin design does not cause and visual change on plugin UI on the brower.

### Docs

- Modified `BigQueryArgumentSetter-action.md`
- Modified `GCSArgumentSetter-action.md`

### Code change

- No Changes made to source files (.java)

### Unit Tests

- No Changes made to unit tests.

[PLUGIN-430]: https://cdap.atlassian.net/browse/PLUGIN-430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ