### PR TITLE
[PLUGIN-1807] Implement Program Failure Exception Handling in GCS sink plugins to catch known errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1010,8 +1010,8 @@
         <version>1.1.0</version>
         <configuration>
           <cdapArtifacts>
-            <parent>system:cdap-data-pipeline[6.9.1-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
-            <parent>system:cdap-data-streams[6.9.1-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-pipeline[6.11.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-streams[6.11.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
           </cdapArtifacts>
         </configuration>
         <executions>

--- a/src/main/java/io/cdap/plugin/gcp/common/ExceptionUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/ExceptionUtils.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.gcp.common;
+
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpResponseException;
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorCategory.ErrorCategoryEnum;
+import io.cdap.cdap.api.exception.ErrorUtils;
+import io.cdap.cdap.api.exception.ProgramFailureException;
+import java.io.IOException;
+
+/**
+ * Utility class to handle exceptions.
+ */
+public class ExceptionUtils {
+
+  /** Functional interfaces for lambda-friendly method invocations */
+  @FunctionalInterface
+  public interface IOOperation {
+    void execute() throws IOException;
+  }
+
+  /**
+   * Functional interfaces for lambda-friendly method invocations.
+   *
+   * @param <T> the return type of the function
+   */
+  @FunctionalInterface
+  public interface IOFunction<T> {
+    T execute() throws IOException;
+  }
+
+  /** Functional interfaces for lambda-friendly method invocations */
+  @FunctionalInterface
+  public interface IOInterruptibleOperation {
+    void execute() throws IOException, InterruptedException;
+  }
+
+  /**
+   * Functional interfaces for lambda-friendly method invocations.
+   *
+   * @param <T> the return type of the function
+   */
+  @FunctionalInterface
+  public interface IOInterruptibleFunction<T> {
+
+    T execute () throws IOException, InterruptedException;
+  }
+
+  // Generic helper method to handle IOException propagation
+  public static void invokeWithProgramFailureHandling(IOOperation operation) throws IOException {
+    try {
+      operation.execute();
+    } catch (IOException e) {
+      ProgramFailureException exception = getProgramFailureException(e);
+      if (exception != null) {
+        throw exception;
+      }
+      throw e;
+    }
+  }
+
+  // Helper method for returning values (for methods like {@link OutputCommitter#needsTaskCommit})
+  public static <T> T invokeWithProgramFailureHandling(IOFunction<T> function) throws IOException {
+    try {
+      return function.execute();
+    } catch (IOException e) {
+      ProgramFailureException exception = getProgramFailureException(e);
+      if (exception != null) {
+        throw exception;
+      }
+      throw e;
+    }
+  }
+
+  // Helper method for handling both IOException and InterruptedException
+  public static void invokeWithProgramFailureAndInterruptionHandling(
+    IOInterruptibleOperation operation) throws IOException, InterruptedException {
+    try {
+      operation.execute();
+    } catch (IOException e) {
+      ProgramFailureException exception = getProgramFailureException(e);
+      if (exception != null) {
+        throw exception;
+      }
+      throw e;
+    }
+  }
+
+  // Helper method for handling both IOException and InterruptedException
+  public static <T> T invokeWithProgramFailureAndInterruptionHandling(
+    IOInterruptibleFunction<T> function) throws IOException, InterruptedException {
+    try {
+      return function.execute();
+    } catch (IOException e) {
+      ProgramFailureException exception = getProgramFailureException(e);
+      if (exception != null) {
+        throw exception;
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Get a ProgramFailureException with the given error
+   * information from {@link HttpResponseException}.
+   *
+   * @param e The HttpResponseException to get the error information from.
+   * @return A ProgramFailureException with the given error information.
+   */
+  private static ProgramFailureException getProgramFailureException(HttpResponseException e) {
+    Integer statusCode = e.getStatusCode();
+    ErrorUtils.ActionErrorPair pair = ErrorUtils.getActionErrorByStatusCode(statusCode);
+    String errorReason = String.format("%s %s %s", e.getStatusCode(), e.getStatusMessage(),
+      pair.getCorrectiveAction());
+
+    String errorMessage = e.getMessage();
+    if (e instanceof GoogleJsonResponseException) {
+      GoogleJsonResponseException exception = (GoogleJsonResponseException) e;
+      errorMessage = exception.getDetails() != null ? exception.getDetails().getMessage() :
+        exception.getMessage();
+    }
+
+    return ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategoryEnum.PLUGIN),
+      errorReason, errorMessage, pair.getErrorType(), true, e);
+  }
+
+  /**
+   * Get a ProgramFailureException with the given error
+   * information from {@link IOException}.
+   *
+   * @param e The IOException to get the error information from.
+   * @return A ProgramFailureException with the given error information, otherwise null.
+   */
+  private static ProgramFailureException getProgramFailureException(IOException e) {
+    Throwable target = e instanceof HttpResponseException ? e : e.getCause();
+    if (target instanceof HttpResponseException) {
+      return getProgramFailureException((HttpResponseException) target);
+    }
+    return null;
+  }
+}

--- a/src/main/java/io/cdap/plugin/gcp/common/GCPUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCPUtils.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.gcp.common;
 
+import com.google.api.client.http.HttpResponseException;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.ExternalAccountCredentials;
@@ -35,6 +36,10 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import com.google.gson.reflect.TypeToken;
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorCategory.ErrorCategoryEnum;
+import io.cdap.cdap.api.exception.ErrorUtils;
+import io.cdap.cdap.api.exception.ProgramFailureException;
 import io.cdap.plugin.gcp.gcs.GCSPath;
 import io.cdap.plugin.gcp.gcs.ServiceAccountAccessTokenProvider;
 import org.apache.hadoop.conf.Configuration;
@@ -79,7 +84,7 @@ public class GCPUtils {
                                                                    "https://www.googleapis.com/auth/bigquery");
   public static final String FQN_RESERVED_CHARACTERS_PATTERN = ".*[.:` \t\n].*";
   public static final int MILLISECONDS_MULTIPLIER = 1000;
-
+  public static final String WRAPPED_OUTPUTFORMAT_CLASSNAME = "wrapped.outputformat.classname";
   /**
    * Load a service account from the local file system.
    *

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/DelegatingGCSOutputCommitter.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/DelegatingGCSOutputCommitter.java
@@ -65,7 +65,9 @@ public class DelegatingGCSOutputCommitter extends OutputCommitter {
                                                 taskAttemptContext.getConfiguration(), tableName));
 
     //Wrap output committer into the GCS Output Committer.
-    GCSOutputCommitter gcsOutputCommitter = new GCSOutputCommitter(outputFormat.getOutputCommitter(taskAttemptContext));
+    ForwardingOutputCommitter gcsOutputCommitter =
+        new ForwardingOutputCommitter(
+            new GCSOutputCommitter(outputFormat.getOutputCommitter(taskAttemptContext)));
 
     gcsOutputCommitter.setupJob(taskAttemptContext);
     gcsOutputCommitter.setupTask(taskAttemptContext);

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/DelegatingGCSOutputUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/DelegatingGCSOutputUtils.java
@@ -17,6 +17,10 @@
 package io.cdap.plugin.gcp.gcs.sink;
 
 import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorCategory.ErrorCategoryEnum;
+import io.cdap.cdap.api.exception.ErrorType;
+import io.cdap.cdap.api.exception.ErrorUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.OutputFormat;
@@ -36,7 +40,9 @@ public class DelegatingGCSOutputUtils {
         (Class<OutputFormat<NullWritable, StructuredRecord>>) hConf.getClassByName(delegateClassName);
       return delegateClass.newInstance();
     } catch (Exception e) {
-      throw new IOException("Unable to instantiate output format for class " + delegateClassName, e);
+      throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategoryEnum.PLUGIN),
+        String.format("Unable to instantiate output format for class '%s'.", delegateClassName),
+        e.getMessage(), ErrorType.SYSTEM, false, e);
     }
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/ForwardingOutputCommitter.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/ForwardingOutputCommitter.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.gcp.gcs.sink;
+
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorCategory.ErrorCategoryEnum;
+import io.cdap.cdap.api.exception.ErrorType;
+import io.cdap.cdap.api.exception.ErrorUtils;
+import io.cdap.plugin.gcp.common.ExceptionUtils;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.OutputFormat;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import java.io.IOException;
+
+/**
+ * ForwardingOutputCommitter which delegates all operations to another OutputCommitter.
+ * <p>
+ * This is used to wrap the OutputCommitter of the delegate format and
+ * throw {@link io.cdap.cdap.api.exception.ProgramFailureException} from IOException.</p>
+ */
+public class ForwardingOutputCommitter extends OutputCommitter {
+  private final OutputCommitter delegate;
+
+  public ForwardingOutputCommitter(OutputCommitter delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void setupJob(JobContext jobContext) throws IOException {
+    ExceptionUtils.invokeWithProgramFailureHandling(() -> delegate.setupJob(jobContext));
+  }
+
+  @Override
+  public void setupTask(TaskAttemptContext taskAttemptContext) throws IOException {
+    ExceptionUtils.invokeWithProgramFailureHandling(() -> delegate.setupTask(taskAttemptContext));
+  }
+
+  @Override
+  public boolean needsTaskCommit(TaskAttemptContext taskAttemptContext) throws IOException {
+    return ExceptionUtils.invokeWithProgramFailureHandling(
+      () -> delegate.needsTaskCommit(taskAttemptContext));
+  }
+
+  @Override
+  public void commitTask(TaskAttemptContext taskAttemptContext) throws IOException {
+    ExceptionUtils.invokeWithProgramFailureHandling(() -> delegate.commitTask(taskAttemptContext));
+  }
+
+  @Override
+  public void abortTask(TaskAttemptContext taskAttemptContext) throws IOException {
+    ExceptionUtils.invokeWithProgramFailureHandling(() -> delegate.abortTask(taskAttemptContext));
+  }
+
+  @SuppressWarnings("rawtypes")
+  public void addGCSOutputCommitterFromOutputFormat(OutputFormat outputFormat, String tableName)
+    throws InterruptedException, IOException {
+    if (delegate instanceof DelegatingGCSOutputCommitter) {
+      ExceptionUtils.invokeWithProgramFailureAndInterruptionHandling(() ->
+        ((DelegatingGCSOutputCommitter) delegate).addGCSOutputCommitterFromOutputFormat(
+          outputFormat, tableName));
+    } else {
+      throw ErrorUtils.getProgramFailureException(
+        new ErrorCategory(ErrorCategoryEnum.PLUGIN),
+        String.format("Operation is not supported in the output committer: '%s'.",
+          delegate.getClass().getName()), null, ErrorType.SYSTEM, false, null
+      );
+    }
+  }
+}

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/ForwardingOutputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/ForwardingOutputFormat.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.gcp.gcs.sink;
+
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorCategory.ErrorCategoryEnum;
+import io.cdap.cdap.api.exception.ErrorType;
+import io.cdap.cdap.api.exception.ErrorUtils;
+import io.cdap.plugin.gcp.common.ExceptionUtils;
+import io.cdap.plugin.gcp.common.GCPUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.OutputFormat;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.util.ReflectionUtils;
+import java.io.IOException;
+
+/**
+ * ForwardingOutputFormat which delegates all operations to another OutputFormat.
+ * <p>
+ * This is used to wrap the delegate output format and
+ * throw {@link io.cdap.cdap.api.exception.ProgramFailureException} from IOException.</p>
+ */
+public class ForwardingOutputFormat extends OutputFormat<NullWritable, StructuredRecord> {
+  private OutputFormat delegate;
+
+  private OutputFormat getDelegateFormatInstance(Configuration configuration) {
+    if (delegate != null) {
+      return delegate;
+    }
+
+    String delegateClassName = configuration.get(
+      GCPUtils.WRAPPED_OUTPUTFORMAT_CLASSNAME);
+    try {
+      delegate = (OutputFormat) ReflectionUtils
+        .newInstance(configuration.getClassByName(delegateClassName), configuration);
+      return delegate;
+    } catch (ClassNotFoundException e) {
+      throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategoryEnum.PLUGIN),
+        String.format("Unable to instantiate output format for class '%s'.", delegateClassName),
+        e.getMessage(), ErrorType.SYSTEM, false, e);
+    }
+  }
+
+  @Override
+  public RecordWriter<NullWritable, StructuredRecord> getRecordWriter (
+    TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
+    return ExceptionUtils.invokeWithProgramFailureAndInterruptionHandling(
+      () -> getDelegateFormatInstance(
+        taskAttemptContext.getConfiguration()).getRecordWriter(taskAttemptContext));
+  }
+
+  @Override
+  public void checkOutputSpecs (JobContext jobContext) throws IOException, InterruptedException {
+    ExceptionUtils.invokeWithProgramFailureAndInterruptionHandling(
+      () -> getDelegateFormatInstance(jobContext.getConfiguration()).checkOutputSpecs(jobContext));
+  }
+
+  @Override
+  public OutputCommitter getOutputCommitter (TaskAttemptContext taskAttemptContext)
+    throws IOException, InterruptedException {
+    return ExceptionUtils.invokeWithProgramFailureAndInterruptionHandling(
+      () -> getDelegateFormatInstance(
+        taskAttemptContext.getConfiguration()).getOutputCommitter(taskAttemptContext));
+  }
+}

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/ForwardingRecordWriter.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/ForwardingRecordWriter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.gcp.gcs.sink;
+
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.plugin.gcp.common.ExceptionUtils;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import java.io.IOException;
+
+/**
+ * ForwardingRecordWriter which delegates all operations to another RecordWriter.
+ * <p>
+ * This is used to wrap the RecordWriter of the delegate format and
+ * throw {@link io.cdap.cdap.api.exception.ProgramFailureException} from IOException.</p>
+ */
+public class ForwardingRecordWriter extends RecordWriter<NullWritable, StructuredRecord> {
+  private final RecordWriter delegate;
+
+  /**
+   * Constructor for ForwardingRecordWriter.
+   * @param delegate the delegate RecordWriter
+   */
+  public ForwardingRecordWriter(RecordWriter delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void write (NullWritable nullWritable, StructuredRecord structuredRecord)
+    throws IOException, InterruptedException {
+    ExceptionUtils.invokeWithProgramFailureAndInterruptionHandling(
+      () -> delegate.write(nullWritable, structuredRecord));
+  }
+
+  @Override
+  public void close (TaskAttemptContext taskAttemptContext)
+    throws IOException, InterruptedException {
+    ExceptionUtils.invokeWithProgramFailureAndInterruptionHandling(
+      () -> delegate.close(taskAttemptContext));
+  }
+}

--- a/src/test/java/io/cdap/plugin/gcp/dataplex/sink/DataPlexOutputFormatProviderTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/dataplex/sink/DataPlexOutputFormatProviderTest.java
@@ -18,6 +18,7 @@ package io.cdap.plugin.gcp.dataplex.sink;
 
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.exception.ProgramFailureException;
 import io.cdap.cdap.etl.api.validation.FormatContext;
 import io.cdap.cdap.etl.api.validation.ValidatingOutputFormat;
 import io.cdap.plugin.gcp.dataplex.common.util.DataplexConstants;
@@ -238,7 +239,7 @@ public class DataPlexOutputFormatProviderTest {
     configuration.set("mapred.bq.output.gcs.fileformat", "AVRO");
     configuration.set(DELEGATE_OUTPUTFORMAT_CLASSNAME, "class");
     when(mockContext.getConfiguration()).thenReturn(configuration);
-    Assert.assertThrows(IOException.class, () -> {
+    Assert.assertThrows(ProgramFailureException.class, () -> {
       dataplexOutputFormat.getRecordWriter(mockContext);
     });
   }

--- a/src/test/java/io/cdap/plugin/gcp/gcs/sink/GCSOutputformatProviderTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/gcs/sink/GCSOutputformatProviderTest.java
@@ -25,8 +25,9 @@ public class GCSOutputformatProviderTest {
   @Test
   public void testRecordWriter() throws IOException, InterruptedException {
     RecordWriter mockWriter = Mockito.mock(RecordWriter.class);
-    GCSOutputFormatProvider.GCSRecordWriter recordWriterToTest = new GCSOutputFormatProvider.GCSRecordWriter(
-      mockWriter);
+    ForwardingRecordWriter recordWriterToTest =
+      new ForwardingRecordWriter(new GCSOutputFormatProvider.GCSRecordWriter(
+      mockWriter));
     NullWritable mockWritable = Mockito.mock(NullWritable.class);
     StructuredRecord mockRecord = Mockito.mock(StructuredRecord.class);
     for (int i = 0; i < 5; i++) {

--- a/src/test/java/io/cdap/plugin/gcp/gcs/sink/TestDelegatingGCSOutputCommitter.java
+++ b/src/test/java/io/cdap/plugin/gcp/gcs/sink/TestDelegatingGCSOutputCommitter.java
@@ -87,8 +87,10 @@ public class TestDelegatingGCSOutputCommitter {
   private void writeOutput(TaskAttemptContext context, DelegatingGCSOutputCommitter committer) throws IOException,
     InterruptedException {
     NullWritable nullWritable = NullWritable.get();
-    DelegatingGCSRecordWriter delegatingGCSRecordWriter = new DelegatingGCSRecordWriter(context, key1,
-                                                                                        committer);
+    ForwardingRecordWriter delegatingGCSRecordWriter = new ForwardingRecordWriter(
+      new DelegatingGCSRecordWriter(context, key1,
+      new ForwardingOutputCommitter(committer),
+      new DelegatingGCSOutputFormat()));
     try {
       delegatingGCSRecordWriter.write(nullWritable, record1);
       delegatingGCSRecordWriter.write(nullWritable, record2);


### PR DESCRIPTION
Program Failure Exception Class: [reference](https://github.com/cdapio/cdap/blob/develop/cdap-api-common/src/main/java/io/cdap/cdap/api/exception/ProgramFailureException.java)

Tested in CDAP Sandbox:

GCS Batch SInk:

```
2024-09-27 08:46:57,006 - ERROR [SparkRunner-phase-1:i.c.c.i.a.r.ProgramControllerServiceAdapter@98] - Spark Program 'phase-1' failed.
java.util.concurrent.ExecutionException: io.cdap.cdap.api.exception.ProgramFailureException: xxxxx.iam.gserviceaccount.com does not have storage.objects.get access to the Google Cloud Storage object. Permission 'storage.objects.get' denied on resource (or it may not exist).
	at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:357)
	at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1908)
	at io.cdap.cdap.app.runtime.spark.submit.AbstractSparkJobFuture.get(AbstractSparkJobFuture.java:119)
	at io.cdap.cdap.app.runtime.spark.SparkRuntimeService.run(SparkRuntimeService.java:444)
	at com.google.common.util.concurrent.AbstractExecutionThreadService$1$1.run(AbstractExecutionThreadService.java:52)
	at io.cdap.cdap.app.runtime.spark.SparkRuntimeService.lambda$null$2(SparkRuntimeService.java:525)
	at java.lang.Thread.run(Thread.java:750)
Caused by: io.cdap.cdap.api.exception.ProgramFailureException: xxxxx.iam.gserviceaccount.com does not have storage.objects.get access to the Google Cloud Storage object. Permission 'storage.objects.get' denied on resource (or it may not exist).
	at io.cdap.cdap.api.exception.ProgramFailureException$Builder.build(ProgramFailureException.java:186)
	at io.cdap.cdap.api.exception.ErrorUtils.getProgramFailureException(ErrorUtils.java:161)
	at io.cdap.plugin.gcp.common.ExceptionUtils.getProgramFailureException(ExceptionUtils.java:135)
	at io.cdap.plugin.gcp.common.ExceptionUtils.getProgramFailureException(ExceptionUtils.java:150)
	at io.cdap.plugin.gcp.common.ExceptionUtils.invokeWithProgramFailureAndInterruptionHandling(ExceptionUtils.java:64)
	at io.cdap.plugin.gcp.gcs.sink.ForwardingOutputFormat.checkOutputSpecs(ForwardingOutputFormat.java:73)
	at io.cdap.cdap.etl.batch.DelegatingOutputFormat.checkOutputSpecs(DelegatingOutputFormat.java:46)
	at org.apache.spark.internal.io.HadoopMapReduceWriteConfigUtil.assertConf(SparkHadoopWriter.scala:403)
	at org.apache.spark.internal.io.SparkHadoopWriter$.write(SparkHadoopWriter.scala:71)
	at org.apache.spark.rdd.PairRDDFunctions.$anonfun$saveAsNewAPIHadoopDataset$1(PairRDDFunctions.scala:1078)
```

GCS Multi Sink:
```
2024-09-27 10:41:32,695 - ERROR [SparkRunner-phase-1:i.c.c.i.a.r.ProgramControllerServiceAdapter@98] - Spark Program 'phase-1' failed.
java.util.concurrent.ExecutionException: io.cdap.cdap.api.exception.ProgramFailureException: 403 Forbidden
POST https://storage.googleapis.com/upload/storage/v1/b/cdf_example/o?ifGenerationMatch=0&uploadType=multipart
{
  "error": {
    "code": 403,
    "message": "xxxxx.iam.gserviceaccount.com does not have storage.objects.create access to the Google Cloud Storage object. Permission 'storage.objects.create' denied on resource (or it may not exist).",
    "errors": [
      {
        "message": "xxxxxx.iam.gserviceaccount.com does not have storage.objects.create access to the Google Cloud Storage object. Permission 'storage.objects.create' denied on resource (or it may not exist).",
        "domain": "global",
        "reason": "forbidden"
      }
    ]
  }
}

	at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:357)
	at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1908)
	at io.cdap.cdap.app.runtime.spark.submit.AbstractSparkJobFuture.get(AbstractSparkJobFuture.java:119)
	at io.cdap.cdap.app.runtime.spark.SparkRuntimeService.run(SparkRuntimeService.java:444)
	at com.google.common.util.concurrent.AbstractExecutionThreadService$1$1.run(AbstractExecutionThreadService.java:52)
	at io.cdap.cdap.app.runtime.spark.SparkRuntimeService.lambda$null$2(SparkRuntimeService.java:525)
	at java.lang.Thread.run(Thread.java:750)
Caused by: io.cdap.cdap.api.exception.ProgramFailureException: 403 Forbidden
POST https://storage.googleapis.com/upload/storage/v1/b/cdf_example/o?ifGenerationMatch=0&uploadType=multipart
{
  "error": {
    "code": 403,
    "message": "xxxxx.iam.gserviceaccount.com does not have storage.objects.create access to the Google Cloud Storage object. Permission 'storage.objects.create' denied on resource (or it may not exist).",
    "errors": [
      {
        "message": "xxxxx.iam.gserviceaccount.com does not have storage.objects.create access to the Google Cloud Storage object. Permission 'storage.objects.create' denied on resource (or it may not exist).",
        "domain": "global",
        "reason": "forbidden"
      }
    ]
  }
}

	at io.cdap.cdap.api.exception.ProgramFailureException$Builder.build(ProgramFailureException.java:186)
	at io.cdap.cdap.api.exception.ErrorUtils.getProgramFailureException(ErrorUtils.java:161)
	at io.cdap.plugin.gcp.common.ExceptionUtils.getProgramFailureException(ExceptionUtils.java:139)
	at io.cdap.plugin.gcp.common.ExceptionUtils.getProgramFailureException(ExceptionUtils.java:153)
	at io.cdap.plugin.gcp.common.ExceptionUtils.invokeWithProgramFailureHandling(ExceptionUtils.java:70)
	at io.cdap.plugin.gcp.gcs.sink.ForwardingOutputCommitter.setupJob(ForwardingOutputCommitter.java:45)
	at io.cdap.cdap.etl.spark.io.TrackingOutputCommitter.setupJob(TrackingOutputCommitter.java:40)
```