### PR TITLE
[🍒][PLUGIN-430][PLUGIN-1803][PLUGIN-1805][PLUGIN-1742] GCS/BQ Patch

### DIFF
--- a/docs/BigQueryArgumentSetter-action.md
+++ b/docs/BigQueryArgumentSetter-action.md
@@ -23,8 +23,6 @@
 
  Properties
  ----------
- **Reference Name:** Name used to uniquely identify this source for lineage, annotating metadata, etc.
-
  **Project ID**: Google Cloud Project ID, which uniquely identifies a project.
  It can be found on the Dashboard in the Google Cloud Platform Console. This is the project
  that the BigQuery job will run in. If a temporary bucket needs to be created, the service account

--- a/docs/BigQueryTable-batchsink.md
+++ b/docs/BigQueryTable-batchsink.md
@@ -110,6 +110,17 @@ is ignored if the table already exists.
 **Time Partitioning Type**: Specifies the time partitioning type. Can either be Daily or Hourly or Monthly or Yearly.
 Default is Daily. Ignored when table already exists
 
+> The table below shows the compatibility of different time schema types with various time partitioning types in BigQuery.
+
+| Schema Type / Partion Type  | Hourly  | Daily   | Monthly | Yearly  |
+|-------------------------| ------- | ------- | ------- | ------- |
+| TIMESTAMP_MILLIS        | &check; | &check; | &check; | &check; |
+| TIMESTAMP_MICROS        | &check; | &check; | &check; | &check; |
+| DATETIME                | &check; | &check; | &check; | &check; |
+| DATE                    | &cross; | &check; | &check; | &check; |
+| TIME_MILLIS             | &cross; | &cross; | &cross; | &cross; |
+| TIME_MICROS             | &cross; | &cross; | &cross; | &cross; |
+
 **Range Start**: For integer partitioning, specifies the start of the range. Only used when table doesn’t 
 exist already, and partitioning type is set to Integer.
 * The start value is inclusive.

--- a/docs/GCSArgumentSetter-action.md
+++ b/docs/GCSArgumentSetter-action.md
@@ -37,8 +37,6 @@ must be readable by all users running the job.
 
 Properties
 ----------
-**Reference Name:** Name used to uniquely identify this source for lineage, annotating metadata, etc.
-
 **Project ID**: Google Cloud Project ID, which uniquely identifies a project.
 It can be found on the Dashboard in the Google Cloud Platform Console. This is the project
 that the BigQuery job will run in. If a temporary bucket needs to be created, the service account

--- a/pom.xml
+++ b/pom.xml
@@ -1245,7 +1245,7 @@
         <dependency>
           <groupId>io.cdap.tests.e2e</groupId>
           <artifactId>cdap-e2e-framework</artifactId>
-          <version>0.3.1</version>
+          <version>0.3.2</version>
           <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <bigquery.connector.hadoop2.version>hadoop2-1.2.0</bigquery.connector.hadoop2.version>
     <commons.codec.version>1.4</commons.codec.version>
     <cdap.version>6.9.1</cdap.version>
-    <cdap.plugin.version>2.11.1</cdap.plugin.version>
+    <cdap.plugin.version>2.12.1</cdap.plugin.version>
     <dropwizard.metrics-core.version>3.2.6</dropwizard.metrics-core.version>
     <flogger.system.backend.version>0.7.1</flogger.system.backend.version>
     <gcs.connector.version>hadoop2-2.2.9</gcs.connector.version>

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
@@ -506,23 +506,21 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
 
     boolean isTimestamp = logicalType == LogicalType.TIMESTAMP_MICROS || logicalType == LogicalType.TIMESTAMP_MILLIS;
     boolean isDate = logicalType == LogicalType.DATE;
-    boolean isTimestampOrDate = isTimestamp || isDate;
-
-    // If timePartitioningType is HOUR, then logicalType cannot be DATE Only TIMESTAMP_MICROS and TIMESTAMP_MILLIS
-    if (timePartitioningType == TimePartitioning.Type.HOUR && !isTimestamp) {
-      collector.addFailure(
-                      String.format("Partition column '%s' is of invalid type '%s'.",
+    boolean isDateTime = logicalType == LogicalType.DATETIME;
+    boolean isTimestampOrDateOrDateTime = isTimestamp || isDate || isDateTime;
+    boolean isTimestampOrDateTime = isTimestamp || isDateTime;
+    // TimePartitioningType HOUR is supported by TIMESTAMP_MICROS, TIMESTAMP_MILLIS, DATETIME
+    if (timePartitioningType == TimePartitioning.Type.HOUR && !isTimestampOrDateTime) {
+      collector.addFailure(String.format("Partition column '%s' is of invalid type '%s'.",
                               columnName, fieldSchema.getDisplayName()),
-                      "Partition column must be a timestamp.").withConfigProperty(NAME_PARTITION_BY_FIELD)
-              .withOutputSchemaField(columnName).withInputSchemaField(columnName);
-
-    // For any other timePartitioningType (DAY, MONTH, YEAR) logicalType can be DATE, TIMESTAMP_MICROS, TIMESTAMP_MILLIS
-    } else if (!isTimestampOrDate) {
-      collector.addFailure(
-                      String.format("Partition column '%s' is of invalid type '%s'.",
+                      "Partition column must be of type TIMESTAMP or DATETIME")
+        .withConfigProperty(NAME_PARTITION_BY_FIELD).withOutputSchemaField(columnName).withInputSchemaField(columnName);
+    // TimePartitioningType (DAY, MONTH, YEAR) are supported by TIMESTAMP_MICROS, TIMESTAMP_MILLIS, DATE, DATETIME
+    } else if (!isTimestampOrDateOrDateTime) {
+      collector.addFailure(String.format("Partition column '%s' is of invalid type '%s'.",
                               columnName, fieldSchema.getDisplayName()),
-                      "Partition column must be a date or timestamp.").withConfigProperty(NAME_PARTITION_BY_FIELD)
-              .withOutputSchemaField(columnName).withInputSchemaField(columnName);
+                      "Partition column must be of type TIMESTAMP, DATE or DATETIME")
+        .withConfigProperty(NAME_PARTITION_BY_FIELD).withOutputSchemaField(columnName).withInputSchemaField(columnName);
     }
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/common/GCSEmptyInputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCSEmptyInputFormat.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.plugin.gcp.common;
+
+import io.cdap.plugin.format.input.AbstractEmptyInputFormat;
+
+
+/**
+ * An InputFormat that returns no data.
+ * @param <K> the type of key
+ * @param <V> the type of value
+ */
+public class GCSEmptyInputFormat<K, V> extends AbstractEmptyInputFormat<K, V> {
+  // no-op
+}

--- a/src/main/java/io/cdap/plugin/gcp/gcs/source/GCSSource.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/source/GCSSource.java
@@ -43,6 +43,7 @@ import io.cdap.plugin.format.plugin.AbstractFileSourceConfig;
 import io.cdap.plugin.format.plugin.FileSourceProperties;
 import io.cdap.plugin.gcp.common.GCPConnectorConfig;
 import io.cdap.plugin.gcp.common.GCPUtils;
+import io.cdap.plugin.gcp.common.GCSEmptyInputFormat;
 import io.cdap.plugin.gcp.crypto.EncryptedFileSystem;
 import io.cdap.plugin.gcp.gcs.GCSPath;
 import io.cdap.plugin.gcp.gcs.connector.GCSConnector;
@@ -75,6 +76,11 @@ public class GCSSource extends AbstractFileSource<GCSSource.GCSSourceConfig> {
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     super.configurePipeline(pipelineConfigurer);
+  }
+
+  @Override
+  protected String getEmptyInputFormatClassName() {
+    return GCSEmptyInputFormat.class.getName();
   }
 
   @Override
@@ -266,11 +272,6 @@ public class GCSSource extends AbstractFileSource<GCSSource.GCSSourceConfig> {
     @Nullable
     public Long getMinSplitSize() {
       return minSplitSize;
-    }
-
-    @Override
-    public boolean shouldAllowEmptyInput() {
-      return false;
     }
 
     public boolean isCopyHeader() {

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfigTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfigTest.java
@@ -130,6 +130,34 @@ public class BigQuerySinkConfigTest {
   }
 
   @Test
+  public void testValidateTimePartitioningColumnWithMonthAndDateTime() throws
+    InvocationTargetException, IllegalAccessException {
+
+    String columnName = "partitionFrom";
+    Schema schema = Schema.of(Schema.LogicalType.DATETIME);
+
+    Schema fieldSchema = schema.isNullable() ? schema.getNonNullable() : schema;
+    TimePartitioning.Type timePartitioningType = TimePartitioning.Type.MONTH;
+
+    validateTimePartitioningColumnMethod.invoke(config, columnName, collector, fieldSchema, timePartitioningType);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+  @Test
+  public void testValidateTimePartitioningColumnWithHourAndDateTime() throws
+    InvocationTargetException, IllegalAccessException {
+
+    String columnName = "partitionFrom";
+    Schema schema = Schema.of(Schema.LogicalType.DATETIME);
+
+    Schema fieldSchema = schema.isNullable() ? schema.getNonNullable() : schema;
+    TimePartitioning.Type timePartitioningType = TimePartitioning.Type.HOUR;
+
+    validateTimePartitioningColumnMethod.invoke(config, columnName, collector, fieldSchema, timePartitioningType);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+  @Test
   public void testValidateColumnNameWithValidColumnName() {
     String columnName = "test";
     Schema schema = Schema.recordOf("test", Schema.Field.of(columnName, Schema.of(Schema.Type.STRING)));

--- a/widgets/BigQueryArgumentSetter-action.json
+++ b/widgets/BigQueryArgumentSetter-action.json
@@ -8,14 +8,6 @@
       "label": "Basic",
       "properties": [
         {
-          "widget-type": "textbox",
-          "label": "Reference Name",
-          "name": "referenceName",
-          "widget-attributes" : {
-            "placeholder": "Name used to identify this source for lineage"
-          }
-        },
-        {
           "widget-type": "connection-browser",
           "widget-category": "plugin",
           "widget-attributes": {

--- a/widgets/GCSArgumentSetter-action.json
+++ b/widgets/GCSArgumentSetter-action.json
@@ -9,14 +9,6 @@
       "properties": [
         {
           "widget-type": "textbox",
-          "label": "Reference Name",
-          "name": "referenceName",
-          "widget-attributes": {
-            "placeholder": "Name used to identify this source for lineage"
-          }
-        },
-        {
-          "widget-type": "textbox",
           "label": "Project ID",
           "name": "project",
           "widget-attributes": {


### PR DESCRIPTION
Cherry Pick 

REF PLUGIN-430  : https://github.com/data-integrations/google-cloud/pull/1444
REF PLUGIN-1803 : https://github.com/data-integrations/google-cloud/pull/1431
REF PLUGIN-1805 : https://github.com/data-integrations/google-cloud/pull/1442
REF PLUGIN-1742  : https://github.com/data-integrations/google-cloud/pull/1443

Bump `cdap.plugin.version` to `2.12.1`
Bump `cdap-e2e-frampwrk` to `0.3.2`



---

## Remove unused field :ReferenceName from GCS/BQ argument setter

Jira : [PLUGIN-430](https://cdap.atlassian.net/browse/PLUGIN-430)

### Description

GCS/BQ argument setters have field :ReferenceName: mentioned in the docs and the plugin design file, being a action plugin the field is not used in the code hence it's mention in the docs may cause confusion.

### UI Field

- Modified `BigQueryArgumentSetter-action.json`
- Modified `GCSArgumentSetter-action.json`
  
  > As the field was not used in code removing them from the plugin design does not cause and visual change on plugin UI on the brower.

### Docs

- Modified `BigQueryArgumentSetter-action.md`
- Modified `GCSArgumentSetter-action.md`

### Code change

- No Changes made to source files (.java)

### Unit Tests

- No Changes made to unit tests.

[PLUGIN-430]: https://cdap.atlassian.net/browse/PLUGIN-430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


---


## Add validation for logical type (array/repeated)

Jira : [PLUGIN-1803](https://cdap.atlassian.net/browse/PLUGIN-1803)

### Description

When we have a BQ field with repeated logical type _(say array of dates)_ current validation only works primitive types, and it fails when `BQ.type (=DATE)` is compared with the primitive type `(INT for Date)` causing an invalid mismatch error.

### Code change

- Modified `BigQueryUtil.java`

### Unit Tests

- Modified `BigQueryUtilTest.java`
  -  testValidateFieldSchemaNotMatchesDate 
  - testValidateFieldSchemaMatchesDate
  
  
![image](https://github.com/user-attachments/assets/6c84be73-37f4-4337-b998-8324570f644e)




[PLUGIN-1803]: https://cdap.atlassian.net/browse/PLUGIN-1803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

## Fix TimePartitioningColumn DATETIME validation

Jira : [PLUGIN-1805](https://cdap.atlassian.net/browse/PLUGIN-1805)

### Description

This datetime is a valid time format that can be used as the partion coloumn, this PR adds the column to validate function.


### Compatibility Matrix (with all time types)
- Partition Field Type / Time Partitioning Type

|                       | Hourly  | Daily   | Monthly | Yearly  |
| --------------------- | ------- | ------- | ------- | ------- |
| type_timestamp_millis | &check; | &check; | &check; | &check; |
| type_timestamp_micros | &check; | &check; | &check; | &check; |
| type_datetime         | &check; | &check; | &check; | &check; |
| type_date             | &cross; | &check; | &check; | &check; |
| type_time_millis      | &cross; | &cross; | &cross; | &cross; |
| type_time_micros      | &cross; | &cross; | &cross; | &cross; |

---

### Code change

- Modified `BigQuerySinkConfig.java`

### Docs

- Modified `BigQueryTable-batchsink.md`

![image](https://github.com/user-attachments/assets/5d0eabe8-9dfa-4776-b5bc-50c8260f9618)


### Unit Tests

- Modified `BigQuerySinkConfigTest.java`
	- testValidateTimePartitioningColumnWith`HourAndDateTime`
	- testValidateTimePartitioningColumnWith`MonthAndDateTime`

<img width="497" alt="image" src="https://github.com/user-attachments/assets/1f90d03f-d85e-487a-a9b6-4832f6ef2132">



[PLUGIN-1805]: https://cdap.atlassian.net/browse/PLUGIN-1805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


---


## Add GCSEmptyInputFormat (Allow Empty Input)

Jira : [PLUGIN-1742](https://cdap.atlassian.net/browse/PLUGIN-1742)

### Description

Add `GCSEmptyInputFormat` to allow user to run the pipeline with invalid source if `Allow Empty Input` is set to true.
- The pipeline would fail with an invalid source, when the option is set to false (default behavior)
  - Invalid source refers to a GCS path that does not exist
- This was hard coded to false to avoid the class loading error, which requires to add a separate `EmptyInputFormat`

### Code change

- Added `GCSEmptyInputFormat.java`
- Modified `GCSSource.java`


## Testing

- ( Current Release Version ) with `Allow Empty Input` (True/False)
  -  FAILED with does not exist error
  
  
![image](https://github.com/user-attachments/assets/9589bd94-5e7b-47ce-95d6-0daddbd8a765)

  
<details>
  <summary>📒Error Log</summary>
  
```
2024-09-12 12:35:01,639 - ERROR [SparkRunner-phase-1:i.c.c.i.a.r.ProgramControllerServiceAdapter@100] - Spark program 'phase-1' failed with error: Input path 00000000-e2e-000a5066-c14f-49c7-b68d-fe3b3b0fdf70/gcs_empty_input_test_case/sad_case/fail.csv does not exist. Please check the system logs for more details.
java.io.IOException: Input path 00000000-e2e-000a5066-c14f-49c7-b68d-fe3b3b0fdf70/gcs_empty_input_test_case/sad_case/fail.csv does not exist
	at io.cdap.plugin.format.plugin.AbstractFileSource.prepareRun(AbstractFileSource.java:208)
	at io.cdap.plugin.gcp.gcs.source.GCSSource.prepareRun(GCSSource.java:106)
	at io.cdap.plugin.gcp.gcs.source.GCSSource.prepareRun(GCSSource.java:61)
	at io.cdap.cdap.etl.common.plugin.WrappedBatchSource.lambda$prepareRun$0(WrappedBatchSource.java:53)
	at io.cdap.cdap.etl.common.plugin.Caller$1.call(Caller.java:30)
....
```
</details>

---

- Version with `Allow Empty Input` True (Removing hard coding)
  -  FAILED with class loading 
  
  
![image](https://github.com/user-attachments/assets/57ffef78-8b3d-4083-bfe1-356a7ac32f72)


<details>
  <summary>📒Error Log</summary>
  
```
2024-09-12 12:45:33,599 - ERROR [SparkRunner-phase-1:i.c.c.i.a.r.ProgramControllerServiceAdapter@98] - Spark Program 'phase-1' failed.
java.util.concurrent.ExecutionException: java.io.IOException: Unable to instantiate delegate input format io.cdap.plugin.format.input.EmptyInputFormat
	at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:357)
	at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1908)
	at io.cdap.cdap.app.runtime.spark.submit.AbstractSparkJobFuture.get(AbstractSparkJobFuture.java:119)
	at io.cdap.cdap.app.runtime.spark.SparkRuntimeService.run(SparkRuntimeService.java:444)
	at com.google.common.util.concurrent.AbstractExecutionThreadService$1$1.run(AbstractExecutionThreadService.java:52)
	at io.cdap.cdap.app.runtime.spark.SparkRuntimeService.lambda$null$2(SparkRuntimeService.java:525)
	at java.lang.Thread.run(Thread.java:750)
Caused by: java.io.IOException: Unable to instantiate delegate input format io.cdap.plugin.format.input.EmptyInputFormat
	at io.cdap.cdap.etl.batch.DelegatingInputFormat.getDelegate(DelegatingInputFormat.java:80)
	at io.cdap.cdap.etl.batch.DelegatingInputFormat.getSplits(DelegatingInputFormat.java:45)
	
....
```
</details>

---

- Version with `Allow Empty Input` True (with GCSEmptyInputFormat)
  -  PASSED
   
![image](https://github.com/user-attachments/assets/36a072a0-07bf-43af-b19a-ca6cafec1418)


---

- Config for the runs
![image](https://github.com/user-attachments/assets/c21af0b1-032e-40ff-8d7c-6c9898d1e468)
![image](https://github.com/user-attachments/assets/8d66a267-fa7f-4c87-b25c-2bc5caf7f5d3)



[PLUGIN-1742]: https://cdap.atlassian.net/browse/PLUGIN-1742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ