### PR TITLE
[PLUGIN-1807] Implement error details provider to get more information about exceptions from GCP plugins

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/common/GCPErrorDetailsProvider.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCPErrorDetailsProvider.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.gcp.common;
+
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpResponseException;
+import com.google.common.base.Throwables;
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorCategory.ErrorCategoryEnum;
+import io.cdap.cdap.api.exception.ErrorUtils;
+import io.cdap.cdap.api.exception.ProgramFailureException;
+import io.cdap.cdap.etl.api.exception.ErrorContext;
+import io.cdap.cdap.etl.api.exception.ErrorDetailsProvider;
+
+import java.util.List;
+
+/**
+ * A custom ErrorDetailsProvider for GCP plugins.
+ */
+public class GCPErrorDetailsProvider implements ErrorDetailsProvider {
+
+  /**
+   * Get a ProgramFailureException with the given error
+   * information from generic exceptions like {@link java.io.IOException}.
+   *
+   * @param e The Throwable to get the error information from.
+   * @return A ProgramFailureException with the given error information, otherwise null.
+   */
+  @Override
+  public ProgramFailureException getExceptionDetails(Exception e, ErrorContext errorContext) {
+    List<Throwable> causalChain = Throwables.getCausalChain(e);
+    for (Throwable t : causalChain) {
+      if (t instanceof ProgramFailureException) {
+        // if causal chain already has program failure exception, return null to avoid double wrap.
+        return null;
+      }
+      if (t instanceof HttpResponseException) {
+        return getProgramFailureException((HttpResponseException) t, errorContext);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Get a ProgramFailureException with the given error
+   * information from {@link HttpResponseException}.
+   *
+   * @param e The HttpResponseException to get the error information from.
+   * @return A ProgramFailureException with the given error information.
+   */
+  private ProgramFailureException getProgramFailureException(HttpResponseException e,
+    ErrorContext errorContext) {
+    Integer statusCode = e.getStatusCode();
+    ErrorUtils.ActionErrorPair pair = ErrorUtils.getActionErrorByStatusCode(statusCode);
+    String errorReason = String.format("%s %s %s", e.getStatusCode(), e.getStatusMessage(),
+      pair.getCorrectiveAction());
+    String errorMessageFormat = "Error occurred in the phase: '%s'. Error message: %s";
+
+    String errorMessage = e.getMessage();
+    if (e instanceof GoogleJsonResponseException) {
+      GoogleJsonResponseException exception = (GoogleJsonResponseException) e;
+      errorMessage = exception.getDetails() != null ? exception.getDetails().getMessage() :
+        exception.getMessage();
+    }
+
+    return ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategoryEnum.PLUGIN),
+      errorReason, String.format(errorMessageFormat, errorContext.getPhase(), errorMessage),
+      pair.getErrorType(), true, e);
+  }
+}

--- a/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSMultiBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSMultiBatchSink.java
@@ -41,10 +41,12 @@ import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.cdap.etl.api.connector.Connector;
+import io.cdap.cdap.etl.api.exception.ErrorDetailsProviderSpec;
 import io.cdap.cdap.etl.api.validation.ValidatingOutputFormat;
 import io.cdap.plugin.common.batch.sink.SinkOutputFormatProvider;
 import io.cdap.plugin.format.FileFormat;
 import io.cdap.plugin.gcp.common.CmekUtils;
+import io.cdap.plugin.gcp.common.GCPErrorDetailsProvider;
 import io.cdap.plugin.gcp.common.GCPUtils;
 import io.cdap.plugin.gcp.gcs.connector.GCSConnector;
 import org.apache.hadoop.io.NullWritable;
@@ -129,33 +131,52 @@ public class GCSMultiBatchSink extends BatchSink<StructuredRecord, NullWritable,
     config.validate(collector, context.getArguments().asMap());
     collector.getOrThrowException();
 
-    Map<String, String> baseProperties = GCPUtils.getFileSystemProperties(config.connection,
-                                                                          config.getPath(), new HashMap<>());
     Map<String, String> argumentCopy = new HashMap<>(context.getArguments().asMap());
 
     CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(config.cmekKey, context.getArguments().asMap(), collector);
     collector.getOrThrowException();
+
     Boolean isServiceAccountFilePath = config.connection.isServiceAccountFilePath();
     if (isServiceAccountFilePath == null) {
-      context.getFailureCollector().addFailure("Service account type is undefined.",
+      collector.addFailure("Service account type is undefined.",
                                                "Must be `filePath` or `JSON`");
-      context.getFailureCollector().getOrThrowException();
-      return;
-    }
-    Credentials credentials = config.connection.getServiceAccount() == null ?
-      null : GCPUtils.loadServiceAccountCredentials(config.connection.getServiceAccount(), isServiceAccountFilePath);
-    Storage storage = GCPUtils.getStorage(config.connection.getProject(), credentials);
-    try {
-      if (storage.get(config.getBucket()) == null) {
-        GCPUtils.createBucket(storage, config.getBucket(), config.getLocation(), cmekKeyName);
-      }
-    } catch (StorageException e) {
-      // Add more descriptive error message
-      throw new RuntimeException(
-        String.format("Unable to access or create bucket %s. ", config.getBucket())
-          + "Ensure you entered the correct bucket path and have permissions for it.", e);
+      collector.getOrThrowException();
     }
 
+    Credentials credentials = null;
+    try {
+      credentials = config.connection.getServiceAccount() == null ?
+        null : GCPUtils.loadServiceAccountCredentials(config.connection.getServiceAccount(),
+        isServiceAccountFilePath);
+    } catch (Exception e) {
+      String errorReason = "Unable to load service account credentials.";
+      collector.addFailure(String.format("%s %s", errorReason, e.getMessage()), null)
+        .withStacktrace(e.getStackTrace());
+      collector.getOrThrowException();
+    }
+
+    String bucketName = config.getBucket(collector);
+    Storage storage = GCPUtils.getStorage(config.connection.getProject(), credentials);
+    String errorReasonFormat = "Error code: %s, Unable to read or access GCS bucket.";
+    String correctiveAction = "Ensure you entered the correct bucket path and "
+      + "have permissions for it.";
+    try {
+      if (storage.get(bucketName) == null) {
+        GCPUtils.createBucket(storage, bucketName, config.getLocation(), cmekKeyName);
+      }
+    } catch (StorageException e) {
+      String errorReason = String.format(errorReasonFormat, e.getCode());
+      collector.addFailure(String.format("%s %s", errorReason, e.getMessage()), correctiveAction)
+        .withStacktrace(e.getStackTrace());
+      collector.getOrThrowException();
+    }
+
+    // set error details provider
+    context.setErrorDetailsProvider(
+      new ErrorDetailsProviderSpec(GCPErrorDetailsProvider.class.getName()));
+
+    Map<String, String> baseProperties = GCPUtils.getFileSystemProperties(config.connection,
+      config.getPath(), new HashMap<>());
     if (config.getAllowFlexibleSchema()) {
       //Configure MultiSink with support for flexible schemas.
       configureSchemalessMultiSink(context, baseProperties, argumentCopy);

--- a/src/main/java/io/cdap/plugin/gcp/gcs/source/TinkDecryptor.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/source/TinkDecryptor.java
@@ -24,6 +24,10 @@ import com.google.crypto.tink.KmsClients;
 import com.google.crypto.tink.StreamingAead;
 import com.google.crypto.tink.config.TinkConfig;
 import com.google.crypto.tink.integration.gcpkms.GcpKmsClient;
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorCategory.ErrorCategoryEnum;
+import io.cdap.cdap.api.exception.ErrorType;
+import io.cdap.cdap.api.exception.ErrorUtils;
 import io.cdap.plugin.gcp.crypto.Decryptor;
 import io.cdap.plugin.gcp.crypto.FSInputSeekableByteChannel;
 import org.apache.hadoop.conf.Configurable;
@@ -66,20 +70,22 @@ public class TinkDecryptor implements Decryptor, Configurable {
   @Override
   public SeekableByteChannel open(FileSystem fs, Path path, int bufferSize) throws IOException {
     DecryptInfo decryptInfo = getDecryptInfo(fs, path);
+    Path metadataPath = new Path(path.getParent(), path.getName() + metadataSuffix);
     if (decryptInfo == null) {
-      throw new IllegalArgumentException("Missing encryption metadata for file '" + path
-                                           + "'. Expected metadata path is '"
-                                           + new Path(path.getParent(), path.getName() + metadataSuffix) + "'");
+      throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategoryEnum.PLUGIN),
+        String.format("Missing encryption metadata for file '%s'. "
+          + "Expected metadata path is '%s'.", path, metadataPath), null,
+        ErrorType.USER, false, null);
     }
 
     try {
       StreamingAead streamingAead = decryptInfo.getKeysetHandle().getPrimitive(StreamingAead.class);
       return streamingAead.newSeekableDecryptingChannel(new FSInputSeekableByteChannel(fs, path, bufferSize),
                                                         decryptInfo.getAad());
-    } catch (IOException e) {
-      throw e;
     } catch (Exception e) {
-      throw new IOException(e);
+      throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategoryEnum.PLUGIN),
+        String.format("Unable to decrypt the file '%s' using encryption metadata file '%s'.",
+          path, metadataPath), e.getMessage(), ErrorType.UNKNOWN, false, e);
     }
   }
 
@@ -88,7 +94,9 @@ public class TinkDecryptor implements Decryptor, Configurable {
     this.configuration = configuration;
     this.metadataSuffix = configuration.get(METADATA_SUFFIX);
     if (metadataSuffix == null) {
-      throw new IllegalArgumentException("Missing configuration '" + METADATA_SUFFIX + "'");
+      throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategoryEnum.PLUGIN),
+        String.format("Missing configuration '%s'.", METADATA_SUFFIX), null,
+        ErrorType.USER, false, null);
     }
   }
 
@@ -112,7 +120,13 @@ public class TinkDecryptor implements Decryptor, Configurable {
     }
 
     // Create the DecryptInfo
-    return getDecryptInfo(metadata);
+    try {
+      return getDecryptInfo(metadata);
+    } catch (Exception e) {
+      throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategoryEnum.PLUGIN),
+        String.format("Unable to decrypt the file '%s' using encryption metadata file '%s'.",
+          path, metadataPath), e.getMessage(), ErrorType.UNKNOWN, false, e);
+    }
   }
 
   static DecryptInfo getDecryptInfo(JSONObject metadata) throws IOException {


### PR DESCRIPTION
Tested in CDAP Sandbox:

#### GCS Source
```
Caused by: io.cdap.cdap.api.exception.WrappedStageException: Stage 'NYT Best Sellers Raw Data' encountered : io.cdap.cdap.api.exception.ProgramFailureException: Error occurred in the phase: 'Splitting'. Error message: xxxxx.iam.gserviceaccount.com does not have storage.objects.list access to the Google Cloud Storage bucket. Permission 'storage.objects.list' denied on resource (or it may not exist).
	at io.cdap.cdap.etl.common.ErrorDetails.handleException(ExceptionUtils.java:77)
	at io.cdap.cdap.etl.spark.io.StageTrackingInputFormat.getSplits(StageTrackingInputFormat.java:55)
	at org.apache.spark.rdd.NewHadoopRDD.getPartitions(NewHadoopRDD.scala:136)
	..................................
Caused by: io.cdap.cdap.api.exception.ProgramFailureException: Error occurred in the phase: 'Splitting'. Error message: xxxxxx.iam.gserviceaccount.com does not have storage.objects.list access to the Google Cloud Storage bucket. Permission 'storage.objects.list' denied on resource (or it may not exist).
	at io.cdap.cdap.api.exception.ProgramFailureException$Builder.build(ProgramFailureException.java:186)
	at io.cdap.cdap.api.exception.ErrorUtils.getProgramFailureException(ErrorUtils.java:161)
	at io.cdap.plugin.gcp.common.GCPErrorDetailsProvider.getProgramFailureException(GCPErrorDetailsProvider.java:80)
	at io.cdap.plugin.gcp.common.GCPErrorDetailsProvider.getExceptionDetails(GCPErrorDetailsProvider.java:52)
	at io.cdap.cdap.etl.common.ErrorDetails.handleException(ExceptionUtils.java:75)
	... 66 common frames omitted
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 403 Forbidden
GET https://storage.googleapis.com/storage/v1/b/cdf_example/o?delimiter=/&fields=items(bucket,name,size,updated),prefixes,nextPageToken&includeTrailingDelimiter=true&maxResults=5000
{
  "code" : 403,
  "errors" : [ {
    "domain" : "global",
    "message" : "xxxxxx.iam.gserviceaccount.com does not have storage.objects.list access to the Google Cloud Storage bucket. Permission 'storage.objects.list' denied on resource (or it may not exist).",
    "reason" : "forbidden"
  } ],
  "message" : "xxxxx.iam.gserviceaccount.com does not have storage.objects.list access to the Google Cloud Storage bucket. Permission 'storage.objects.list' denied on resource (or it may not exist)."
}
	at com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:146)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:118)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:37)
```
#### GCS Sink
```
Caused by: io.cdap.cdap.api.exception.WrappedStageException: Stage 'GCS2' encountered : io.cdap.cdap.api.exception.ProgramFailureException: Error occurred in the phase: 'Validating Output Specs'. Error message: xxxxx.iam.gserviceaccount.com does not have storage.objects.get access to the Google Cloud Storage object. Permission 'storage.objects.get' denied on resource (or it may not exist).
	at io.cdap.cdap.etl.common.ExceptionUtils.handleException(ExceptionUtils.java:77)
	at io.cdap.cdap.etl.spark.io.StageTrackingOutputFormat.checkOutputSpecs(StageTrackingOutputFormat.java:67)
	at io.cdap.cdap.etl.common.output.MultiOutputFormat.checkOutputSpecs(MultiOutputFormat.java:114)
	.......................................
Caused by: io.cdap.cdap.api.exception.ProgramFailureException: Error occurred in the phase: 'Validating Output Specs'. Error message: xxxxxxxx.iam.gserviceaccount.com does not have storage.objects.get access to the Google Cloud Storage object. Permission 'storage.objects.get' denied on resource (or it may not exist).
	at io.cdap.cdap.api.exception.ProgramFailureException$Builder.build(ProgramFailureException.java:186)
	at io.cdap.cdap.api.exception.ErrorUtils.getProgramFailureException(ErrorUtils.java:161)
	at io.cdap.plugin.gcp.common.GCPErrorDetailsProvider.getProgramFailureException(GCPErrorDetailsProvider.java:80)
	at io.cdap.plugin.gcp.common.GCPErrorDetailsProvider.getExceptionDetails(GCPErrorDetailsProvider.java:52)
	at io.cdap.cdap.etl.common.ErrorDetails.handleException(ExceptionUtils.java:75)
	... 47 common frames omitted
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 403 Forbidden
GET https://storage.googleapis.com/storage/v1/b/cdf_example/o/2024-10-15-08-53?fields=bucket,name,timeCreated,updated,generation,metageneration,size,contentType,contentEncoding,md5Hash,crc32c,metadata
{
  "code" : 403,
  "errors" : [ {
    "domain" : "global",
    "message" : "xxxxxx.iam.gserviceaccount.com does not have storage.objects.get access to the Google Cloud Storage object. Permission 'storage.objects.get' denied on resource (or it may not exist).",
    "reason" : "forbidden"
  } ],
  "message" : "xxxxxxxxx.iam.gserviceaccount.com does not have storage.objects.get access to the Google Cloud Storage object. Permission 'storage.objects.get' denied on resource (or it may not exist)."
}
	at com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:146)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:118)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:37)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest$1.interceptResponse(AbstractGoogleClientRequest.java:428)
	at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1111)
```
#### GCS Multi Sink
```
Caused by: io.cdap.cdap.api.exception.WrappedStageException: Stage 'GCS Multi File' encountered : io.cdap.cdap.api.exception.ProgramFailureException: Error occurred in the phase: 'Committing'. Error message: xxxxx.iam.gserviceaccount.com does not have storage.objects.get access to the Google Cloud Storage object. Permission 'storage.objects.get' denied on resource (or it may not exist).
	at io.cdap.cdap.etl.common.ExceptionUtils.handleException(ExceptionUtils.java:77)
	at io.cdap.cdap.etl.spark.io.StageTrackingOutputCommitter.setupJob(StageTrackingOutputCommitter.java:57)
	at org.apache.spark.internal.io.HadoopMapReduceCommitProtocol.setupJob(HadoopMapReduceCommitProtocol.scala:188)
	...............
Caused by: io.cdap.cdap.api.exception.ProgramFailureException: Error occurred in the phase: 'Committing'. Error message: xxxxxx.iam.gserviceaccount.com does not have storage.objects.get access to the Google Cloud Storage object. Permission 'storage.objects.get' denied on resource (or it may not exist).
	at io.cdap.cdap.api.exception.ProgramFailureException$Builder.build(ProgramFailureException.java:186)
	at io.cdap.cdap.api.exception.ErrorUtils.getProgramFailureException(ErrorUtils.java:161)
	at io.cdap.plugin.gcp.common.GCPErrorDetailsProvider.getProgramFailureException(GCPErrorDetailsProvider.java:80)
	at io.cdap.plugin.gcp.common.GCPErrorDetailsProvider.getExceptionDetails(GCPErrorDetailsProvider.java:52)
	at io.cdap.cdap.etl.common.ErrorDetails.handleException(ExceptionUtils.java:75)
	... 47 common frames omitted
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: null
	at com.google.cloud.hadoop.gcsio.GoogleCloudStorageExceptions.createJsonResponseException(GoogleCloudStorageExceptions.java:89)
	at com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl$9.onFailure(GoogleCloudStorageImpl.java:1944)
	at com.google.cloud.hadoop.gcsio.BatchHelper.execute(BatchHelper.java:199)
	at com.google.cloud.hadoop.gcsio.BatchHelper.lambda$queue$0(BatchHelper.java:178)
	
````