### PR TITLE
[PLUGIN-1814] Log output path

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
@@ -160,7 +160,7 @@ public class BigQueryOutputFormat extends ForwardingBigQueryFileOutputFormat<Str
 
     // Get the output path.
     Path outputPath = BigQueryOutputConfiguration.getGcsOutputPath(conf);
-    LOG.info("Using output path '%s'.", outputPath);
+    LOG.info("Using output path '{}'.", outputPath);
 
     // Error if the output path already exists.
     FileSystem outputFileSystem = outputPath.getFileSystem(conf);


### PR DESCRIPTION
##  Log output path

Jira : [PLUGIN-1814](https://cdap.atlassian.net/browse/PLUGIN-1814)

### Description

`%s` is a c style placeholder, using `{}` should display the correct path

### Code change

- Modified `BigQueryOutputFormat.java`


[PLUGIN-1814]: https://cdap.atlassian.net/browse/PLUGIN-1814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ