### PR TITLE
[PLUGIN-1818] ErrorDetailsProvider - BigQuery Source/Sink plugin

### DIFF
--- a/src/e2e-test/resources/errorMessage.properties
+++ b/src/e2e-test/resources/errorMessage.properties
@@ -28,8 +28,8 @@ errorMessageInvalidBucketName=Invalid bucket name in path
 errorMessageInvalidFormat=Input has multi-level structure that cannot be represented appropriately as csv. \
   Consider using json, avro or parquet to write data.
 errorMessageMultipleFileWithFirstRowAsHeaderDisabled=Spark program 'phase-1' failed with error: Found a row with 6 fields when the schema only contains 4 fields. Check that the schema contains the right number of fields.. Please check the system logs for more details.
-errorMessageMultipleFileWithFirstRowAsHeaderEnabled=Year of Jupyter
-errorMessageMultipleFileWithoutClearDefaultSchema=Found a row with 4 fields when the schema only contains 2 fields
+errorMessageMultipleFileWithFirstRowAsHeaderEnabled=Spark program 'phase-1' failed with error:
+errorMessageMultipleFileWithoutClearDefaultSchema=Spark program 'phase-1' failed with error: Found a row with 4 fields when the schema only contains 2 fields.
 errorMessageInvalidSourcePath=Invalid bucket name in path 'abc@'. Bucket name should
 errorMessageInvalidDestPath=Invalid bucket name in path 'abc@'. Bucket name should
 errorMessageInvalidEncryptionKey=CryptoKeyName.parse: formattedString not in valid format: Parameter "abc@" must be

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/common/BigQueryErrorDetailsProvider.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/common/BigQueryErrorDetailsProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.gcp.bigquery.common;
+
+import io.cdap.plugin.gcp.common.GCPErrorDetailsProvider;
+
+/**
+ * A custom ErrorDetailsProvider for BigQuery plugins.
+ */
+public class BigQueryErrorDetailsProvider extends GCPErrorDetailsProvider {
+
+  @Override
+  protected String getExternalDocumentationLink() {
+    return "https://cloud.google.com/bigquery/docs/error-messages";
+  }
+}

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryRecordToJson.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryRecordToJson.java
@@ -189,7 +189,7 @@ public final class BigQueryRecordToJson {
           } else if (jsonString.startsWith("[") && jsonString.endsWith("]")) {
             writeJsonArrayToWriter(gson.fromJson(jsonString, JsonArray.class), writer);
           } else {
-            throw new IllegalStateException(String.format("Expected value of Field '%s' to be a valid JSON " +
+            throw new IllegalArgumentException(String.format("Expected value of Field '%s' to be a valid JSON " +
                     "object or array.", name));
           }
           break;

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySourceUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySourceUtils.java
@@ -25,6 +25,9 @@ import com.google.cloud.hadoop.io.bigquery.BigQueryConfiguration;
 import com.google.cloud.kms.v1.CryptoKeyName;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorType;
+import io.cdap.cdap.api.exception.ErrorUtils;
 import io.cdap.plugin.gcp.bigquery.connector.BigQueryConnectorConfig;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryConstants;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;
@@ -93,10 +96,12 @@ public class BigQuerySourceUtils {
           // Ignore this and move on, since all that matters is that the bucket exists.
           return bucket;
         }
-        throw new IOException(String.format("Unable to create Cloud Storage bucket '%s' in the same " +
+        String errorMessage = String.format("Unable to create Cloud Storage bucket '%s' in the same " +
                                               "location ('%s') as BigQuery dataset '%s'. " + "Please use a bucket " +
                                               "that is in the same location as the dataset.",
-                                            bucket, dataset.getLocation(), dataset.getDatasetId().getDataset()), e);
+                                            bucket, dataset.getLocation(), dataset.getDatasetId().getDataset());
+        throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN),
+          errorMessage, e.getMessage(), ErrorType.USER, true, e);
       }
     }
 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/PartitionedBigQueryInputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/PartitionedBigQueryInputFormat.java
@@ -37,6 +37,9 @@ import com.google.cloud.hadoop.util.HadoopConfigurationProperty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorType;
+import io.cdap.cdap.api.exception.ErrorUtils;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryConstants;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;
 import io.cdap.plugin.gcp.common.GCPUtils;
@@ -110,7 +113,8 @@ public class PartitionedBigQueryInputFormat extends AbstractBigQueryInputFormat<
     try {
       bigQueryHelper = getBigQueryHelper(configuration);
     } catch (GeneralSecurityException gse) {
-      throw new IOException("Failed to create BigQuery client", gse);
+      throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN),
+        "Failed to create BigQuery client", gse.getMessage(), ErrorType.UNKNOWN, true, gse);
     }
 
     List<HadoopConfigurationProperty<?>> hadoopConfigurationProperties = new ArrayList<>(

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/BigQueryRecordToJsonTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/BigQueryRecordToJsonTest.java
@@ -477,9 +477,9 @@ public class BigQueryRecordToJsonTest {
 
   /**
    * Empty JSON string is not a valid JSON string and should throw an exception.
-   * @throws IOException
+   * @throws IllegalArgumentException
    */
-  @Test(expected = IllegalStateException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void testEmptyJsonString() throws IOException {
     Schema recordSchema = Schema.recordOf(
             "record",


### PR DESCRIPTION
## ErrorDetailsProvider - BigQuery Source/Sink plugin

Jira : [PLUGIN-1818](https://cdap.atlassian.net/browse/PLUGIN-1818)

### Description

Adding error details provider on bigquery.

<details>
  <summary>CDAP Error logs</summary>
  
  - Test Case (Input invalid Json)

  ```   
  2024-11-13 11:19:00,929 - ERROR [Executor task launch worker for task 0.0 in stage 0.0 (TID 0):o.a.s.u.Utils@98] - Aborting task
io.cdap.cdap.api.exception.WrappedStageException: Stage 'BigQuery' encountered : io.cdap.cdap.api.exception.ProgramFailureException: Error occurred in the phase: 'Writing'. Error message: Expected value of Field 'raw' to be a valid JSON object or array.
	at io.cdap.cdap.etl.common.ErrorDetails.handleException(ErrorDetails.java:77)
	at io.cdap.cdap.etl.spark.io.StageTrackingRecordWriter.write(StageTrackingRecordWriter.java:57)
	at org.apache.spark.internal.io.HadoopMapReduceWriteConfigUtil.write(SparkHadoopWriter.scala:368)
	at org.apache.spark.internal.io.SparkHadoopWriter$.$anonfun$executeTask$1(SparkHadoopWriter.scala:138)
	at org.apache.spark.util.Utils$.tryWithSafeFinallyAndFailureCallbacks(Utils.scala:1538)
	at org.apache.spark.internal.io.SparkHadoopWriter$.executeTask(SparkHadoopWriter.scala:135)
	at org.apache.spark.internal.io.SparkHadoopWriter$.$anonfun$write$1(SparkHadoopWriter.scala:88)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:136)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:548)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1504)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:551)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
Caused by: io.cdap.cdap.api.exception.ProgramFailureException: Error occurred in the phase: 'Writing'. Error message: Expected value of Field 'raw' to be a valid JSON object or array.
	at io.cdap.cdap.api.exception.ProgramFailureException$Builder.build(ProgramFailureException.java:186)
	at io.cdap.cdap.api.exception.ErrorUtils.getProgramFailureException(ErrorUtils.java:161)
	at io.cdap.plugin.gcp.common.GCPErrorDetailsProvider.getProgramFailureException(GCPErrorDetailsProvider.java:133)
	at io.cdap.plugin.gcp.common.GCPErrorDetailsProvider.getExceptionDetails(GCPErrorDetailsProvider.java:60)
	at io.cdap.cdap.etl.common.ErrorDetails.handleException(ErrorDetails.java:75)
	... 14 common frames omitted
Caused by: java.lang.IllegalStateException: Expected value of Field 'raw' to be a valid JSON object or array.
	at io.cdap.plugin.gcp.bigquery.sink.BigQueryRecordToJson.writeSimpleTypes(BigQueryRecordToJson.java:192)
	at io.cdap.plugin.gcp.bigquery.sink.BigQueryRecordToJson.write(BigQueryRecordToJson.java:96)
	at io.cdap.plugin.gcp.bigquery.sink.BigQueryRecordToJson.write(BigQueryRecordToJson.java:71)
	at io.cdap.plugin.gcp.bigquery.sink.BigQueryJsonConverter.transform(BigQueryJsonConverter.java:51)
	at io.cdap.plugin.gcp.bigquery.sink.BigQueryJsonConverter.transform(BigQueryJsonConverter.java:32)
	at io.cdap.plugin.gcp.bigquery.sink.BigQueryRecordWriter.write(BigQueryRecordWriter.java:62)
	at io.cdap.plugin.gcp.bigquery.sink.BigQueryRecordWriter.write(BigQueryRecordWriter.java:33)
	at io.cdap.cdap.etl.spark.io.TrackingRecordWriter.write(TrackingRecordWriter.java:41)
	at io.cdap.cdap.etl.spark.io.StageTrackingRecordWriter.write(StageTrackingRecordWriter.java:55)
	... 13 common frames omitted
	Suppressed: java.io.IOException: Incomplete document
		at com.google.gson.internal.bind.JsonTreeWriter.close(JsonTreeWriter.java:196)
		at io.cdap.plugin.gcp.bigquery.sink.BigQueryJsonConverter.transform(BigQueryJsonConverter.java:56)
		... 18 common frames omitted

  ```
</details>

### Code change

- Added `BigQueryErrorDetailsProvider.java`
- Modified `AbstractBigQuerySink.java`
- Modified `BigQueryOutputFormat.java`
- Modified `BigQueryRecordToJson.java`
- Modified `BigQuerySinkUtils.java`
- Modified `BigQueryAvroToStructuredTransformer.java`
- Modified `BigQuerySource.java`
- Modified `BigQuerySourceUtils.java`
- Modified `PartitionedBigQueryInputFormat.java`
- Modified `GCPErrorDetailsProvider.java`

### Unit Tests

- Modified `BigQueryRecordToJsonTest.java`

[PLUGIN-1818]: https://cdap.atlassian.net/browse/PLUGIN-1818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ