### PR TITLE
PLUGIN-1438: Added support for destination table write preference in BQ Execute Plugin

### DIFF
--- a/docs/BigQueryExecute-action.md
+++ b/docs/BigQueryExecute-action.md
@@ -62,6 +62,11 @@ cache that will be flushed whenever tables in the query are modified.
 It is only applicable when users choose to store the query results in a BigQuery table.
 More information can be found [here](https://cloud.google.com/data-fusion/docs/how-to/customer-managed-encryption-keys)
 
+**Destination Table Write Preference**: Provides the following options as write preferences for the destination table:
+* **Write if Empty**: Only write if the table is empty
+* **Append to Table**: Add results to existing data. Schema should match.
+* **Overwrite Table**: Replace all existing data. Schema will also be overriden.
+
 **Row As Arguments**: Row as arguments. For example, if the query is 'select min(id) as min_id, max(id) as max_id from my_dataset.my_table',
 an arguments for 'min_id' and 'max_id' will be set based on the query results. Plugins further down the pipeline can then
 reference these values with macros ${min_id} and ${max_id}.

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/action/BigQueryExecuteTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/action/BigQueryExecuteTest.java
@@ -25,6 +25,7 @@ import com.google.cloud.bigquery.JobStatistics;
 import com.google.cloud.bigquery.JobStatus;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.TableResult;
+import com.google.common.collect.ImmutableSet;
 import io.cdap.cdap.api.metrics.Metrics;
 import io.cdap.cdap.etl.api.StageMetrics;
 import io.cdap.cdap.etl.api.action.ActionContext;
@@ -37,6 +38,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import java.util.Set;
 
 public class BigQueryExecuteTest {
   @Mock
@@ -224,6 +226,25 @@ public class BigQueryExecuteTest {
     Assert.assertEquals(1, failureCollector.getValidationFailures().size());
     Assert.assertEquals("Read timeout must be greater than 0.",
             failureCollector.getValidationFailures().get(0).getMessage());
+  }
+
+  @Test
+  public void testValidateWritePreferenceWithInvalidValue() {
+    config.validateWritePreference(failureCollector, "INVALID_PREFERENCE");
+
+    // Assert validation failure
+    Assert.assertEquals(1, failureCollector.getValidationFailures().size());
+    Assert.assertEquals(
+        String.format("Invalid write preference 'INVALID_PREFERENCE'. Allowed values are '%s'.",
+            config.VALID_WRITE_PREFERENCES.toString()
+        ),
+        failureCollector.getValidationFailures().get(0).getMessage()
+    );
+  }
+
+  @Test
+  public void testDefaultWritePreference() {
+    Assert.assertEquals(JobInfo.WriteDisposition.WRITE_EMPTY.name(), config.getWritePreference());
   }
 
 }

--- a/widgets/BigQueryExecute-action.json
+++ b/widgets/BigQueryExecute-action.json
@@ -151,6 +151,29 @@
           }
         },
         {
+          "widget-type": "radio-group",
+          "label": "Destination Table Write Preference",
+          "name": "writePreference",
+          "widget-attributes": {
+            "layout": "vertical",
+            "default": "WRITE_EMPTY",
+            "options": [
+              {
+                "id": "WRITE_EMPTY",
+                "label": "Write if Empty"
+              },
+              {
+                "id": "WRITE_APPEND",
+                "label": "Append to Table"
+              },
+              {
+                "id": "WRITE_TRUNCATE",
+                "label": "Overwrite Table"
+              }
+            ]
+          }
+        },
+        {
           "name": "rowAsArguments",
           "label": "Row As Arguments",
           "widget-type": "toggle",
@@ -313,6 +336,10 @@
         {
           "type": "property",
           "name": "cmekKey"
+        },
+        {
+          "type": "property",
+          "name": "writePreference"
         }
       ]
     }


### PR DESCRIPTION
### Added support for destination table write preference in BQ Execute Plugin

Jira : [PLUGIN-1438](https://cdap.atlassian.net/browse/PLUGIN-1438)

### Description

This update introduces the ability for users to select a destination table write preference when storing results in BigQuery. Users can now choose from the following options:

- Write If Empty: Write to the table only if it is empty. If the table contains data, the operation will fail.
- Append To Table: Append results to an existing table, preserving its schema.
- Overwrite Table: Overwrite the existing table, replacing both the data and schema.

### UI Field

- Modified `BigQueryExecute-action.json`

### Docs

- Modified `BigQueryExecute-action.md`

### Code change

- Modified `BigQueryExecute.java`

### Unit Tests

- Modified `BigQueryExecuteTest.java`

### Tested
![image](https://github.com/user-attachments/assets/5bb7ba82-f36e-4a4d-80ef-69feeb76158a)

[PLUGIN-1438]: https://cdap.atlassian.net/browse/PLUGIN-1438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ