### PR TITLE
[🍒][PLUGIN-1842] Error Management catch known errors [GCSBucketCreate]

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/common/GCPErrorDetailsProviderUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCPErrorDetailsProviderUtil.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.gcp.common;
+
+
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpResponseException;
+import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorCodeType;
+import io.cdap.cdap.api.exception.ErrorType;
+import io.cdap.cdap.api.exception.ErrorUtils;
+import io.cdap.cdap.api.exception.ProgramFailureException;
+import io.cdap.cdap.etl.api.exception.ErrorContext;
+
+import java.io.IOException;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * Common functions for GCP error details provider related functionalities.
+ */
+public final class GCPErrorDetailsProviderUtil {
+
+  /**
+   * Get a ProgramFailureException with the given error
+   * information from {@link HttpResponseException}.
+   *
+   * @param e The HttpResponseException to get the error information from.
+   * @return A ProgramFailureException with the given error information.
+   */
+  public static ProgramFailureException getProgramFailureException(HttpResponseException e, String externalDocUrl,
+                                                                   @Nullable ErrorContext errorContext) {
+    Integer statusCode = e.getStatusCode();
+    ErrorUtils.ActionErrorPair pair = ErrorUtils.getActionErrorByStatusCode(statusCode);
+    String errorReason = String.format("%s %s. %s", e.getStatusCode(), e.getStatusMessage(),
+      pair.getCorrectiveAction());
+    String errorMessage = e.getMessage();
+    String externalDocumentationLink = null;
+    if (e instanceof GoogleJsonResponseException) {
+      errorMessage = getErrorMessage((GoogleJsonResponseException) e);
+      externalDocumentationLink = externalDocUrl;
+      if (!Strings.isNullOrEmpty(externalDocumentationLink)) {
+        if (!errorReason.endsWith(".")) {
+          errorReason = errorReason + ".";
+        }
+        errorReason = String.format("%s For more details, see %s", errorReason, externalDocumentationLink);
+      }
+    }
+    return ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN), errorReason,
+      errorContext != null ?
+        String.format(GCPErrorDetailsProvider.ERROR_MESSAGE_FORMAT, errorContext.getPhase(), e.getClass().getName(),
+          errorMessage) : String.format("%s: %s", e.getClass().getName(), errorMessage), pair.getErrorType(), true,
+      ErrorCodeType.HTTP, statusCode.toString(), externalDocumentationLink, e);
+  }
+
+  public static ProgramFailureException getHttpResponseExceptionDetailsFromChain(Exception e, String errorReason,
+                                                                                 ErrorType errorType,
+                                                                                 boolean dependency,
+                                                                                 String externalDocUrl) {
+    List<Throwable> causalChain = Throwables.getCausalChain(e);
+    for (Throwable t : causalChain) {
+      if (t instanceof ProgramFailureException) {
+        // Avoid double wrap
+        return (ProgramFailureException) t;
+      }
+      if (t instanceof HttpResponseException) {
+        return getProgramFailureException((HttpResponseException) t, externalDocUrl, null);
+      }
+    }
+    // If no HttpResponseException found in the causal chain, return generic program failure exception
+    return ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN), errorReason,
+      String.format("%s %s: %s", errorReason, e.getClass().getName(), e.getMessage()), errorType, dependency, e);
+  }
+
+  private static String getErrorMessage(GoogleJsonResponseException exception) {
+    if (!Strings.isNullOrEmpty(exception.getMessage())) {
+      return exception.getMessage();
+    }
+    if (exception.getDetails() != null) {
+      try {
+        return exception.getDetails().toPrettyString();
+      } catch (IOException e) {
+        return exception.getDetails().toString();
+      }
+    }
+    return exception.getMessage();
+  }
+}


### PR DESCRIPTION
🍒 [cherrypick]

### Commits :
 - bdd55f310c373d89b732930874fb2a2dec933a62

### PR:
 - #1488 [ Reviewer @itsankit-google ]
 
---

## Error Management catch known errors

Jira : [PLUGIN-1842](https://cdap.atlassian.net/browse/PLUGIN-1842)

### Description

- Remove unused imports
- Error Management catch known errors

### Code change

- Modified `GCSBucketCreate.java`

### Tests

 - Test Case (Try to create a bucket with no write access on it)
  
<details>
  <summary>Raw Logs</summary>

  ```   
2025-01-13 15:38:06,370 - ERROR [WorkflowDriver:i.c.c.i.a.r.w.WorkflowProgramController@90] - Workflow service 'workflow.default.GCS_BCREATE_TEST_RUN.DataPipelineWorkflow.3e5879da-d196-11ef-a658-000000579539' failed.
io.cdap.cdap.api.exception.WrappedStageException: Stage 'GCS Create' encountered : io.cdap.cdap.api.exception.ProgramFailureException: Unable to access or create bucket this_is_not_my_bucket. Ensure you entered the correct bucket path and have permissions for it. e2e-integration-tests@cdf-entcon.iam.gserviceaccount.com does not have storage.buckets.get access to the Google Cloud Storage bucket. Permission 'storage.buckets.get' denied on resource (or it may not exist).
	at io.cdap.cdap.etl.common.plugin.ExceptionWrappingCaller.call(ExceptionWrappingCaller.java:64)
	at io.cdap.cdap.etl.common.plugin.WrappedAction.run(WrappedAction.java:48)
	at io.cdap.cdap.etl.batch.customaction.PipelineAction.run(PipelineAction.java:91)
	at io.cdap.cdap.internal.app.runtime.AbstractContext.execute(AbstractContext.java:608)
	at io.cdap.cdap.internal.app.runtime.workflow.CustomActionExecutor.execute(CustomActionExecutor.java:90)
	at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.executeCustomAction(WorkflowDriver.java:449)
	at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.executeNode(WorkflowDriver.java:489)
	at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.executeAll(WorkflowDriver.java:669)
	at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.run(WorkflowDriver.java:653)
	at com.google.common.util.concurrent.AbstractExecutionThreadService$1$1.run(AbstractExecutionThreadService.java:52)
	at java.lang.Thread.run(Thread.java:750)
Caused by: io.cdap.cdap.api.exception.ProgramFailureException: Unable to access or create bucket this_is_not_my_bucket. Ensure you entered the correct bucket path and have permissions for it. e2e-integration-tests@cdf-entcon.iam.gserviceaccount.com does not have storage.buckets.get access to the Google Cloud Storage bucket. Permission 'storage.buckets.get' denied on resource (or it may not exist).
	at io.cdap.cdap.api.exception.ProgramFailureException$Builder.build(ProgramFailureException.java:236)
	at io.cdap.cdap.api.exception.ErrorUtils.getProgramFailureException(ErrorUtils.java:161)
	at io.cdap.plugin.gcp.gcs.actions.GCSBucketCreate.run(GCSBucketCreate.java:143)
	at io.cdap.cdap.etl.common.plugin.WrappedAction.lambda$run$1(WrappedAction.java:49)
	at io.cdap.cdap.etl.common.plugin.Caller$1.call(Caller.java:30)
	at io.cdap.cdap.etl.common.plugin.ExceptionWrappingCaller.call(ExceptionWrappingCaller.java:62)
	... 10 common frames omitted
Caused by: com.google.cloud.storage.StorageException: e2e-integration-tests@cdf-entcon.iam.gserviceaccount.com does not have storage.buckets.get access to the Google Cloud Storage bucket. Permission 'storage.buckets.get' denied on resource (or it may not exist).
	at com.google.cloud.storage.spi.v1.HttpStorageRpc.translate(HttpStorageRpc.java:233)
	at com.google.cloud.storage.spi.v1.HttpStorageRpc.get(HttpStorageRpc.java:425)
	at com.google.cloud.storage.StorageImpl.lambda$get$4(StorageImpl.java:264)
	at com.google.api.gax.retrying.DirectRetryingExecutor.submit(DirectRetryingExecutor.java:105)
	at com.google.cloud.RetryHelper.run(RetryHelper.java:76)
	at com.google.cloud.RetryHelper.runWithRetries(RetryHelper.java:50)
	at com.google.cloud.storage.Retrying.run(Retrying.java:51)
	at com.google.cloud.storage.StorageImpl.run(StorageImpl.java:1374)
	at com.google.cloud.storage.StorageImpl.get(StorageImpl.java:263)
	at io.cdap.plugin.gcp.gcs.actions.GCSBucketCreate.run(GCSBucketCreate.java:137)
	... 13 common frames omitted
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 403 Forbidden
GET https://storage.googleapis.com/storage/v1/b/this_is_not_my_bucket?projection=full
{
  "code" : 403,
  "errors" : [ {
    "domain" : "global",
    "message" : "e2e-integration-tests@cdf-entcon.iam.gserviceaccount.com does not have storage.buckets.get access to the Google Cloud Storage bucket. Permission 'storage.buckets.get' denied on resource (or it may not exist).",
    "reason" : "forbidden"
  } ],
  "message" : "e2e-integration-tests@cdf-entcon.iam.gserviceaccount.com does not have storage.buckets.get access to the Google Cloud Storage bucket. Permission 'storage.buckets.get' denied on resource (or it may not exist)."
}
	at com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:146)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:118)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:37)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest$1.interceptResponse(AbstractGoogleClientRequest.java:428)
	at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1111)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:514)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:455)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.execute(AbstractGoogleClientRequest.java:565)
	at com.google.cloud.storage.spi.v1.HttpStorageRpc.get(HttpStorageRpc.java:422)
	... 21 common frames omitted

  ```
</details>

<details>
  <summary>POST v3/namespaces/{namespace-id}/apps/{app-id}/workflows/DataPipelineWorkflow/runs/{run-id}/classify</summary>

  ```json
[
  {
    "stageName": "GCS Create",
    "errorCategory": "Plugin-'GCS Create'",
    "errorReason": "Unable to access or create bucket this_is_not_my_bucket. Ensure you entered the correct bucket path and have permissions for it.",
    "errorMessage": "Unable to access or create bucket this_is_not_my_bucket. Ensure you entered the correct bucket path and have permissions for it. e2e-integration-tests@cdf-entcon.iam.gserviceaccount.com does not have storage.buckets.get access to the Google Cloud Storage bucket. Permission 'storage.buckets.get' denied on resource (or it may not exist).",
    "errorType": "USER",
    "dependency": "true"
  }
]
```
</details>

![image](https://github.com/user-attachments/assets/cb7bedc7-43cc-4c91-b182-db0b63bf8f77)
![image](https://github.com/user-attachments/assets/2dce5010-adbc-4532-887c-b6a6c8d44ce5)



[PLUGIN-1842]: https://cdap.atlassian.net/browse/PLUGIN-1842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ