### PR TITLE
[🍒][PLUGIN-1839] Error Management catch known errors [GCSMove]

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/actions/GCSMove.java
@@ -17,10 +17,6 @@
 package io.cdap.plugin.gcp.gcs.actions;
 
 import com.google.cloud.kms.v1.CryptoKeyName;
-import com.google.cloud.storage.Bucket;
-import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
-import com.google.common.base.Strings;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
@@ -30,13 +26,11 @@ import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.action.Action;
 import io.cdap.cdap.etl.api.action.ActionContext;
 import io.cdap.plugin.gcp.common.CmekUtils;
-import io.cdap.plugin.gcp.common.GCPUtils;
 import io.cdap.plugin.gcp.gcs.GCSPath;
 import io.cdap.plugin.gcp.gcs.StorageClient;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -57,7 +51,7 @@ public class GCSMove extends Action {
   }
 
   @Override
-  public void run(ActionContext context) throws IOException {
+  public void run(ActionContext context) {
     FailureCollector collector = context.getFailureCollector();
     config.validate(collector, context.getArguments().asMap());
 


### PR DESCRIPTION
🍒 [cherrypick]

### Commits :
 - 21753e37676c42b9319a88426c699275803eca77

### PR:
 - #1484 [ Reviewer @itsankit-google ]
 
---

## Error Management catch known errors [GCSMove]

Jira : [PLUGIN-1839](https://cdap.atlassian.net/browse/PLUGIN-1839)

### Description

- Remove unused imports
- Error Management catch known errors

### Code change

- Modified `GCSMove.java`

### Test

 - Test Case (File does not exist on path provided)
  
<details>
  <summary>Raw Logs</summary>

  ```   
2025-01-13 13:27:27,904 - ERROR [WorkflowDriver:i.c.c.i.a.r.w.WorkflowProgramController@90] - Workflow service 'workflow.default.GCS_MOVE_TEST_RUN.DataPipelineWorkflow.01c2da42-d184-11ef-83da-000000f326f9' failed.
io.cdap.cdap.api.exception.WrappedStageException: Stage 'GCS Move' encountered : io.cdap.cdap.etl.api.validation.ValidationException: Errors were encountered during validation. Failed to create storage client, unable to load service account credentials. /Users/pusaini/cbin/cred/GCP_invalid.json (No such file or directory)
	at io.cdap.cdap.etl.common.plugin.ExceptionWrappingCaller.call(ExceptionWrappingCaller.java:64)
	at io.cdap.cdap.etl.common.plugin.WrappedAction.run(WrappedAction.java:48)
	at io.cdap.cdap.etl.batch.customaction.PipelineAction.run(PipelineAction.java:91)
	at io.cdap.cdap.internal.app.runtime.AbstractContext.execute(AbstractContext.java:608)
	at io.cdap.cdap.internal.app.runtime.workflow.CustomActionExecutor.execute(CustomActionExecutor.java:90)
	at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.executeCustomAction(WorkflowDriver.java:449)
	at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.executeNode(WorkflowDriver.java:489)
	at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.executeAll(WorkflowDriver.java:669)
	at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.run(WorkflowDriver.java:653)
	at com.google.common.util.concurrent.AbstractExecutionThreadService$1$1.run(AbstractExecutionThreadService.java:52)
	at java.lang.Thread.run(Thread.java:750)
Caused by: io.cdap.cdap.etl.api.validation.ValidationException: Errors were encountered during validation. Failed to create storage client, unable to load service account credentials. /Users/pusaini/cbin/cred/GCP_invalid.json (No such file or directory)
	at io.cdap.cdap.etl.validation.DefaultFailureCollector.getOrThrowException(DefaultFailureCollector.java:78)
	at io.cdap.cdap.etl.validation.LoggingFailureCollector.getOrThrowException(LoggingFailureCollector.java:50)
	at io.cdap.plugin.gcp.gcs.actions.GCSMove.run(GCSMove.java:73)
	at io.cdap.cdap.etl.common.plugin.WrappedAction.lambda$run$1(WrappedAction.java:49)
	at io.cdap.cdap.etl.common.plugin.Caller$1.call(Caller.java:30)
	at io.cdap.cdap.etl.common.plugin.ExceptionWrappingCaller.call(ExceptionWrappingCaller.java:62)
	... 10 common frames omitted
	
  ```
</details>

<details>
  <summary>POST v3/namespaces/{namespace-id}/apps/{app-id}/workflows/DataPipelineWorkflow/runs/{run-id}/classify</summary>

  ```json
[
  {
    "stageName": "GCS Move",
    "errorCategory": "Plugin-'Validation'-'GCS Move'",
    "errorReason": "Stage 'GCS Move' encountered 1 validation failures.",
    "errorMessage": "Stage 'GCS Move' encountered : io.cdap.cdap.etl.api.validation.ValidationException: Errors were encountered during validation. Failed to create storage client, unable to load service account credentials. /Users/pusaini/cbin/cred/GCP_invalid.json (No such file or directory)",
    "errorType": "USER",
    "dependency": "false"
  }
]
  ```
</details>

![image](https://github.com/user-attachments/assets/07442530-3805-403e-a0ba-897cf3f71304)
![image](https://github.com/user-attachments/assets/420693b0-de36-42d0-920f-0f337b0acacb)

[PLUGIN-1839]: https://cdap.atlassian.net/browse/PLUGIN-1839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ