### PR TITLE
[🍒][PLUGIN-1866] Add Http readTimeout BQ Source/Sink

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/action/BigQueryArgumentSetterConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/action/BigQueryArgumentSetterConfig.java
@@ -183,7 +183,7 @@ public final class BigQueryArgumentSetterConfig extends AbstractBigQueryActionCo
 
   public QueryJobConfiguration getQueryJobConfiguration(FailureCollector collector) {
     Table sourceTable = BigQueryUtil.getBigQueryTable(getDatasetProject(), dataset, table, getServiceAccount(),
-                                                      isServiceAccountFilePath(), collector);
+                                                      isServiceAccountFilePath(), collector, null);
 
     if (sourceTable == null) {
       // Table does not exist

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/action/BigQueryExecute.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/action/BigQueryExecute.java
@@ -45,7 +45,6 @@ import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.exception.ErrorCategory;
-import io.cdap.cdap.api.exception.ErrorCodeType;
 import io.cdap.cdap.api.exception.ErrorType;
 import io.cdap.cdap.api.exception.ErrorUtils;
 import io.cdap.cdap.etl.api.FailureCollector;
@@ -364,7 +363,6 @@ public final class BigQueryExecute extends AbstractBigQueryAction {
     public static final int DEFAULT_MAX_RETRY_COUNT = 5;
     // Sn = a * (1 - r^n) / (r - 1)
     public static final long DEFULT_MAX_RETRY_DURATION_SECONDS = 63L;
-    public static final int DEFAULT_READ_TIMEOUT = 120;
     public static final Set<String> VALID_WRITE_PREFERENCES = Arrays.stream(JobInfo.WriteDisposition.values())
         .map(Enum::name).collect(Collectors.toSet());
 
@@ -581,7 +579,7 @@ public final class BigQueryExecute extends AbstractBigQueryAction {
     }
 
     public int getReadTimeout() {
-      return readTimeout == null ? DEFAULT_READ_TIMEOUT : readTimeout;
+      return readTimeout == null ? GCPUtils.BQ_DEFAULT_READ_TIMEOUT_SECONDS : readTimeout;
     }
 
     @Override

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
@@ -103,7 +103,7 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, S
     DatasetId datasetId = DatasetId.of(config.getDatasetProject(), config.getDataset());
     Dataset dataset;
     try {
-      bigQuery = GCPUtils.getBigQuery(project, credentials, null);
+      bigQuery = GCPUtils.getBigQuery(project, credentials, config.getReadTimeout());
       dataset = bigQuery.getDataset(datasetId);
     } catch (Exception e) {
       throw GCPErrorDetailsProviderUtil.getHttpResponseExceptionDetailsFromChain(e,

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
@@ -33,6 +33,7 @@ import io.cdap.plugin.gcp.bigquery.connector.BigQueryConnectorConfig;
 import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;
 import io.cdap.plugin.gcp.common.CmekUtils;
 
+import io.cdap.plugin.gcp.common.GCPUtils;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -54,6 +55,7 @@ public abstract class AbstractBigQuerySinkConfig extends BigQueryBaseConfig {
   protected static final String NAME_UPDATE_SCHEMA = "allowSchemaRelaxation";
   private static final String SCHEME = "gs://";
   protected static final String NAME_JSON_STRING_FIELDS = "jsonStringFields";
+  private static final String NAME_READ_TIMEOUT = "readTimeout";
 
   @Name(Constants.Reference.REFERENCE_NAME)
   @Nullable
@@ -99,6 +101,16 @@ public abstract class AbstractBigQuerySinkConfig extends BigQueryBaseConfig {
   @Description("Fields in input schema that should be treated as JSON strings. " +
           "The schema of these fields should be of type STRING.")
   protected String jsonStringFields;
+
+  @Name(NAME_READ_TIMEOUT)
+  @Nullable
+  @Macro
+  @Description("Timeout in seconds to read data from an established HTTP connection (Default value is 120).")
+  private Integer readTimeout;
+
+  public int getReadTimeout() {
+    return readTimeout == null ? GCPUtils.BQ_DEFAULT_READ_TIMEOUT_SECONDS : readTimeout;
+  }
 
   public AbstractBigQuerySinkConfig(BigQueryConnectorConfig connection, String dataset, String cmekKey, String bucket) {
     super(connection, dataset, cmekKey, bucket);

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSink.java
@@ -128,7 +128,7 @@ public class BigQueryMultiSink extends AbstractBigQuerySink {
 
         Table table = BigQueryUtil.getBigQueryTable(
           config.getDatasetProject(), config.getDataset(), tableName, config.getServiceAccount(),
-          config.isServiceAccountFilePath(), collector);
+          config.isServiceAccountFilePath(), collector, config.getReadTimeout());
 
         Schema tableSchema = configuredSchema;
         if (table != null) {

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryMultiSinkConfig.java
@@ -20,6 +20,7 @@ import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.plugin.gcp.bigquery.connector.BigQueryConnectorConfig;
+import io.cdap.plugin.gcp.common.GCPUtils;
 
 import javax.annotation.Nullable;
 
@@ -30,6 +31,7 @@ public class BigQueryMultiSinkConfig extends AbstractBigQuerySinkConfig {
 
   private static final String SPLIT_FIELD_DEFAULT = "tablename";
   private static final String NAME_ALLOW_FLEXIBLE_SCHEMA = "allowFlexibleSchema";
+  private static final String NAME_READ_TIMEOUT = "readTimeout";
 
   @Macro
   @Nullable

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -138,7 +138,7 @@ public final class BigQuerySink extends AbstractBigQuerySink {
     configureBigQuerySink();
     Table table = BigQueryUtil.getBigQueryTable(config.getDatasetProject(), config.getDataset(), config.getTable(),
             config.getServiceAccount(), config.isServiceAccountFilePath(),
-            collector);
+            collector, config.getReadTimeout());
     initOutput(context, bigQuery, config.getReferenceName(),
                BigQueryUtil.getFQN(config.getDatasetProject(), config.getDataset(), config.getTable()),
                config.getTable(), outputSchema, bucket, collector, null, table);
@@ -343,10 +343,8 @@ public final class BigQuerySink extends AbstractBigQuerySink {
    */
   private void configureTable(Schema schema) {
     AbstractBigQuerySinkConfig config = getConfig();
-    Table table = BigQueryUtil.getBigQueryTable(config.getDatasetProject(), config.getDataset(),
-                                                config.getTable(),
-                                                config.getServiceAccount(),
-                                                config.isServiceAccountFilePath());
+    Table table = BigQueryUtil.getBigQueryTable(config.getDatasetProject(), config.getDataset(), config.getTable(),
+        config.getServiceAccount(), config.isServiceAccountFilePath(), null, config.getReadTimeout());
     baseConfiguration.setBoolean(BigQueryConstants.CONFIG_DESTINATION_TABLE_EXISTS, table != null);
     List<String> tableFieldsNames = null;
     if (table != null) {
@@ -372,7 +370,7 @@ public final class BigQuerySink extends AbstractBigQuerySink {
     String tableName = config.getTable();
     Table table = BigQueryUtil.getBigQueryTable(config.getDatasetProject(), config.getDataset(), tableName,
                                                 config.getServiceAccount(), config.isServiceAccountFilePath(),
-                                                collector);
+                                                collector, config.getReadTimeout());
 
     if (table != null && !config.containsMacro(AbstractBigQuerySinkConfig.NAME_UPDATE_SCHEMA)) {
       // if table already exists, validate schema against underlying bigquery table

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
@@ -24,7 +24,6 @@ import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.kms.v1.CryptoKeyName;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
@@ -41,7 +40,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -419,7 +417,7 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
     }
 
     Table table = BigQueryUtil.getBigQueryTable(project, dataset, tableName, serviceAccount,
-                                                isServiceAccountFilePath(), collector);
+        isServiceAccountFilePath(), collector, getReadTimeout());
     if (table != null) {
       StandardTableDefinition tableDefinition = table.getDefinition();
       TimePartitioning timePartitioning = tableDefinition.getTimePartitioning();

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySource.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySource.java
@@ -40,7 +40,6 @@ import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.lib.KeyValue;
 import io.cdap.cdap.api.exception.ErrorType;
-import io.cdap.cdap.api.exception.ProgramFailureException;
 import io.cdap.cdap.etl.api.Emitter;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
@@ -50,7 +49,6 @@ import io.cdap.cdap.etl.api.batch.BatchSource;
 import io.cdap.cdap.etl.api.batch.BatchSourceContext;
 import io.cdap.cdap.etl.api.connector.Connector;
 import io.cdap.cdap.etl.api.engine.sql.SQLEngineInput;
-import io.cdap.cdap.etl.api.exception.ErrorContext;
 import io.cdap.cdap.etl.api.exception.ErrorDetailsProviderSpec;
 import io.cdap.cdap.etl.api.validation.ValidationFailure;
 import io.cdap.plugin.common.Asset;
@@ -262,6 +260,7 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
     if (config.getViewMaterializationDataset() != null) {
       configuration.set(BigQueryConstants.CONFIG_VIEW_MATERIALIZATION_DATASET, config.getViewMaterializationDataset());
     }
+    configuration.set(BigQueryConstants.CONFIG_BQ_HTTP_READ_TIMEOUT, String.valueOf(config.getReadTimeout()));
   }
 
   public Schema getSchema(FailureCollector collector) {
@@ -310,7 +309,7 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
     String project = config.getDatasetProject();
 
     Table table = BigQueryUtil.getBigQueryTable(project, dataset, tableName, serviceAccount,
-                                                config.isServiceAccountFilePath(), collector);
+        config.isServiceAccountFilePath(), collector, config.getReadTimeout());
     if (table == null) {
       // Table does not exist
       collector.addFailure(String.format("BigQuery table '%s:%s.%s' does not exist.", project, dataset, tableName),
@@ -343,7 +342,7 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
     String dataset = config.getDataset();
     String tableName = config.getTable();
     Table sourceTable = BigQueryUtil.getBigQueryTable(project, dataset, tableName, config.getServiceAccount(),
-                                                      config.isServiceAccountFilePath(), collector);
+        config.isServiceAccountFilePath(), collector, config.getReadTimeout());
     if (sourceTable == null) {
       return;
     }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySourceConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySourceConfig.java
@@ -58,6 +58,7 @@ public final class BigQuerySourceConfig extends BigQueryBaseConfig {
   private static final String VALID_DATE_FORMAT = "yyyy-MM-dd";
   private static final String SCHEME = "gs://";
   private static final String WHERE = "WHERE";
+  private static final String NAME_READ_TIMEOUT = "readTimeout";
   public static final Set<Schema.Type> SUPPORTED_TYPES =
     ImmutableSet.of(Schema.Type.LONG, Schema.Type.STRING, Schema.Type.DOUBLE, Schema.Type.BOOLEAN, Schema.Type.BYTES,
                     Schema.Type.ARRAY, Schema.Type.RECORD);
@@ -131,6 +132,12 @@ public final class BigQuerySourceConfig extends BigQueryBaseConfig {
     + "Defaults to the same dataset in which the table is located.")
   private String viewMaterializationDataset;
 
+  @Name(NAME_READ_TIMEOUT)
+  @Nullable
+  @Macro
+  @Description("Timeout in seconds to read data from an established HTTP connection (Default value is 120).")
+  private Integer readTimeout;
+
   public String getTable() {
     return table;
   }
@@ -140,6 +147,10 @@ public final class BigQuerySourceConfig extends BigQueryBaseConfig {
       return ServiceOptions.getDefaultProjectId();
     }
     return connection.getDatasetProject();
+  }
+
+  public int getReadTimeout() {
+    return readTimeout == null ? GCPUtils.BQ_DEFAULT_READ_TIMEOUT_SECONDS : readTimeout;
   }
 
   public void validate(FailureCollector collector) {
@@ -238,7 +249,7 @@ public final class BigQuerySourceConfig extends BigQueryBaseConfig {
   public Type getSourceTableType() {
     Table sourceTable =
       BigQueryUtil.getBigQueryTable(getDatasetProject(), getDataset(), table, getServiceAccount(),
-                                    isServiceAccountFilePath());
+                                    isServiceAccountFilePath(), null, getReadTimeout());
     return sourceTable != null ? sourceTable.getDefinition().getType() : null;
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/PartitionedBigQueryInputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/PartitionedBigQueryInputFormat.java
@@ -132,9 +132,11 @@ public class PartitionedBigQueryInputFormat extends AbstractBigQueryInputFormat<
     String partitionFromDate = configuration.get(BigQueryConstants.CONFIG_PARTITION_FROM_DATE, null);
     String partitionToDate = configuration.get(BigQueryConstants.CONFIG_PARTITION_TO_DATE, null);
     String filter = configuration.get(BigQueryConstants.CONFIG_FILTER, null);
+    Integer readTimeout = configuration.getInt(BigQueryConstants.CONFIG_BQ_HTTP_READ_TIMEOUT,
+        GCPUtils.BQ_DEFAULT_READ_TIMEOUT_SECONDS);
 
     com.google.cloud.bigquery.Table bigQueryTable = BigQueryUtil.getBigQueryTable(
-      datasetProjectId, datasetId, tableName, serviceAccount, isServiceAccountFilePath);
+      datasetProjectId, datasetId, tableName, serviceAccount, isServiceAccountFilePath, null, readTimeout);
     Type type = Objects.requireNonNull(bigQueryTable).getDefinition().getType();
 
     String query;
@@ -171,9 +173,9 @@ public class PartitionedBigQueryInputFormat extends AbstractBigQueryInputFormat<
       return null;
     }
     String queryTemplate = "select * from `%s` where %s";
-    com.google.cloud.bigquery.Table sourceTable = BigQueryUtil.getBigQueryTable(datasetProject, dataset, table,
-                                                                                serviceAccount,
-                                                                                isServiceAccountFilePath);
+    com.google.cloud.bigquery.Table sourceTable =
+      BigQueryUtil.getBigQueryTable(datasetProject, dataset, table, serviceAccount, isServiceAccountFilePath, null,
+        null);
     StandardTableDefinition tableDefinition = Objects.requireNonNull(sourceTable).getDefinition();
     TimePartitioning timePartitioning = tableDefinition.getTimePartitioning();
     if (timePartitioning == null && filter == null) {

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
@@ -49,4 +49,5 @@ public interface BigQueryConstants {
   String CDAP_BQ_SINK_OUTPUT_SCHEMA = "cdap.bq.sink.output.schema";
   String BQ_FQN_PREFIX = "bigquery";
   String CONFIG_JOB_LABEL_KEY_VALUE = "cdap.bq.sink.job.label.key.value";
+  String CONFIG_BQ_HTTP_READ_TIMEOUT = "cdap.bq.job.http.read.timeout";
 }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
@@ -39,7 +39,6 @@ import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.validation.InvalidConfigPropertyException;
 import io.cdap.cdap.etl.api.validation.InvalidStageException;
 import io.cdap.cdap.etl.api.validation.ValidationFailure;
-import io.cdap.plugin.gcp.bigquery.sink.AbstractBigQuerySinkConfig;
 import io.cdap.plugin.gcp.bigquery.sink.BigQuerySink;
 import io.cdap.plugin.gcp.bigquery.source.BigQuerySource;
 import io.cdap.plugin.gcp.bigquery.source.BigQuerySourceConfig;
@@ -572,94 +571,49 @@ public final class BigQueryUtil {
   /**
    * Get BigQuery table.
    *
-   * @param datasetProject           project where dataset is in
-   * @param datasetId                BigQuery dataset ID
-   * @param tableName                BigQuery table name
-   * @param serviceAccount           service account file path or JSON content
-   * @param isServiceAccountFilePath indicator for whether service account is file or json
-   * @return BigQuery table
-   */
-  @Nullable
-  public static Table getBigQueryTable(String datasetProject, String datasetId, String tableName,
-                                       @Nullable String serviceAccount, boolean isServiceAccountFilePath) {
-    TableId tableId = TableId.of(datasetProject, datasetId, tableName);
-
-    com.google.auth.Credentials credentials = null;
-    if (serviceAccount != null) {
-      try {
-        credentials = GCPUtils.loadServiceAccountCredentials(serviceAccount, isServiceAccountFilePath);
-      } catch (IOException e) {
-        throw new InvalidConfigPropertyException(
-          String.format("Unable to load credentials from %s", isServiceAccountFilePath ? serviceAccount : " JSON."),
-          "serviceFilePath");
-      }
-    }
-    BigQuery bigQuery = GCPUtils.getBigQuery(datasetProject, credentials, null);
-
-    Table table;
-    try {
-      table = bigQuery.getTable(tableId);
-    } catch (BigQueryException e) {
-      throw new InvalidStageException("Unable to get details about the BigQuery table: " + e.getMessage(), e);
-    }
-
-    return table;
-  }
-
-  /**
-   * Get BigQuery table.
-   *
-   * @param projectId          BigQuery project ID
-   * @param datasetId          BigQuery dataset ID
-   * @param tableName          BigQuery table name
-   * @param serviceAccountPath service account file path
-   * @param collector          failure collector
-   * @return BigQuery table
-   */
-  @Nullable
-  public static Table getBigQueryTable(String projectId, String datasetId, String tableName,
-                                       @Nullable String serviceAccountPath, FailureCollector collector) {
-    return getBigQueryTable(projectId, datasetId, tableName, serviceAccountPath, true, collector);
-  }
-
-  /**
-   * Get BigQuery table.
-   *
    * @param projectId                BigQuery project ID
    * @param dataset                  BigQuery dataset name
    * @param tableName                BigQuery table name
    * @param serviceAccount           service account file path or JSON content
    * @param isServiceAccountFilePath indicator for whether service account is file or json
    * @param collector                failure collector
+   * @param readTimeoutSeconds       http read time out in seconds
    * @return BigQuery table
    */
   public static Table getBigQueryTable(String projectId, String dataset, String tableName,
                                        @Nullable String serviceAccount, @Nullable Boolean isServiceAccountFilePath,
-                                       FailureCollector collector) {
+                                       @Nullable FailureCollector collector, @Nullable Integer readTimeoutSeconds) {
     TableId tableId = TableId.of(projectId, dataset, tableName);
     com.google.auth.Credentials credentials = null;
     if (serviceAccount != null) {
       try {
         credentials = GCPUtils.loadServiceAccountCredentials(serviceAccount, isServiceAccountFilePath);
       } catch (IOException e) {
-        collector.addFailure(String.format("Unable to load credentials from %s.",
-                                           isServiceAccountFilePath ? serviceAccount : "provided JSON key"),
-                             "Ensure the service account file is available on the local filesystem.")
-          .withConfigProperty(GCPConfig.NAME_SERVICE_ACCOUNT_FILE_PATH);
-        throw collector.getOrThrowException();
+        if (collector != null) {
+          collector.addFailure(String.format("Unable to load credentials from %s.",
+                isServiceAccountFilePath ? serviceAccount : "provided JSON key"),
+              "Ensure the service account file is available on the local filesystem.")
+            .withConfigProperty(GCPConfig.NAME_SERVICE_ACCOUNT_FILE_PATH);
+          throw collector.getOrThrowException();
+        }
+        throw new InvalidConfigPropertyException(
+          String.format("Unable to load credentials from %s", isServiceAccountFilePath ? serviceAccount : " JSON."),
+          "serviceFilePath");
       }
     }
-    BigQuery bigQuery = GCPUtils.getBigQuery(projectId, credentials, null);
+    BigQuery bigQuery = GCPUtils.getBigQuery(projectId, credentials, readTimeoutSeconds);
 
-    Table table = null;
+    Table table;
     try {
       table = bigQuery.getTable(tableId);
     } catch (BigQueryException e) {
-      collector.addFailure("Unable to get details about the BigQuery table: " + e.getMessage(), null)
-        .withConfigProperty(BigQuerySourceConfig.NAME_TABLE);
-      throw collector.getOrThrowException();
+      if (collector != null) {
+        collector.addFailure("Unable to get details about the BigQuery table: " + e.getMessage(), null)
+          .withConfigProperty(BigQuerySourceConfig.NAME_TABLE);
+        throw collector.getOrThrowException();
+      }
+      throw new InvalidStageException("Unable to get details about the BigQuery table: " + e.getMessage(), e);
     }
-
     return table;
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/common/GCPUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCPUtils.java
@@ -35,9 +35,12 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import com.google.gson.reflect.TypeToken;
+import io.cdap.plugin.gcp.bigquery.util.BigQueryUtil;
 import io.cdap.plugin.gcp.gcs.GCSPath;
 import io.cdap.plugin.gcp.gcs.ServiceAccountAccessTokenProvider;
 import org.apache.hadoop.conf.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.threeten.bp.Duration;
 
 import java.io.ByteArrayInputStream;
@@ -62,6 +65,8 @@ import javax.annotation.Nullable;
  * GCP utility class to get service account credentials
  */
 public class GCPUtils {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GCPUtils.class);
   public static final String FS_GS_PROJECT_ID = "fs.gs.project.id";
   private static final Gson GSON = new Gson();
   private static final Type SCOPES_TYPE = new TypeToken<List<String>>() { }.getType();
@@ -82,6 +87,7 @@ public class GCPUtils {
   public static final String GCS_SUPPORTED_DOC_URL = "https://cloud.google.com/storage/docs/json_api/v1/status-codes";
   public static final String BQ_SUPPORTED_DOC_URL = "https://cloud.google.com/bigquery/docs/error-messages";
   public static final String PUBSUB_SUPPORTED_DOC_URL = "https://cloud.google.com/pubsub/docs/reference/error-codes";
+  public static final int BQ_DEFAULT_READ_TIMEOUT_SECONDS = 120;
 
   /**
    * Load a service account from the local file system.
@@ -259,6 +265,7 @@ public class GCPUtils {
     }
 
     if (readTimeout != null) {
+      LOG.debug("Setting read timeout to {} seconds.", readTimeout);
       bigqueryBuilder.setTransportOptions(HttpTransportOptions.newBuilder()
           .setReadTimeout(readTimeout * MILLISECONDS_MULTIPLIER).build());
     }

--- a/src/main/java/io/cdap/plugin/gcp/dataplex/sink/DataplexBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/dataplex/sink/DataplexBatchSink.java
@@ -355,7 +355,7 @@ public final class DataplexBatchSink extends BatchSink<StructuredRecord, Object,
       config.getTable(),
       config.getServiceAccount(),
       config.isServiceAccountFilePath(),
-      collector);
+      collector, null);
     baseConfiguration.setBoolean(BigQueryConstants.CONFIG_DESTINATION_TABLE_EXISTS, table != null);
     List<String> tableFieldsNames = null;
     if (table != null) {

--- a/src/main/java/io/cdap/plugin/gcp/dataplex/sink/config/DataplexBatchSinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/dataplex/sink/config/DataplexBatchSinkConfig.java
@@ -556,7 +556,7 @@ public class DataplexBatchSinkConfig extends DataplexBaseConfig {
     String tableName = this.getTable();
     Table table = BigQueryUtil.getBigQueryTable(this.tryGetProject(), dataset, tableName,
       connection.getServiceAccount(), connection.isServiceAccountFilePath(),
-      collector);
+      collector, null);
 
     if (table != null && !this.containsMacro(NAME_UPDATE_SCHEMA)) {
       // if table already exists, validate schema against underlying bigquery table
@@ -586,7 +586,7 @@ public class DataplexBatchSinkConfig extends DataplexBaseConfig {
     }
 
     Table table = BigQueryUtil.getBigQueryTable(project, dataset, tableName, serviceAccount,
-      isServiceAccountFilePath(), collector);
+      isServiceAccountFilePath(), collector, null);
     if (table != null) {
       StandardTableDefinition tableDefinition = table.getDefinition();
       TimePartitioning timePartitioning = tableDefinition.getTimePartitioning();

--- a/src/main/java/io/cdap/plugin/gcp/dataplex/source/config/DataplexBatchSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/dataplex/source/config/DataplexBatchSourceConfig.java
@@ -210,7 +210,7 @@ public class DataplexBatchSourceConfig extends DataplexBaseConfig {
   public void validateBigQueryDataset(FailureCollector collector, String project, String dataset, String tableName) {
     BigQueryUtil.validateTable(tableName, NAME_ENTITY, collector);
     Table sourceTable = BigQueryUtil.getBigQueryTable(project, dataset, tableName, this.getServiceAccount(),
-      this.isServiceAccountFilePath(), collector);
+      this.isServiceAccountFilePath(), collector, null);
     if (sourceTable == null) {
       return;
     }
@@ -270,7 +270,8 @@ public class DataplexBatchSourceConfig extends DataplexBaseConfig {
   public TableDefinition.Type getSourceTableType(String datasetProject, String dataSet,
                                                  String tableId) {
     Table sourceTable =
-      BigQueryUtil.getBigQueryTable(datasetProject, dataSet, tableId, getServiceAccount(), isServiceAccountFilePath());
+      BigQueryUtil.getBigQueryTable(datasetProject, dataSet, tableId, getServiceAccount(), isServiceAccountFilePath(),
+        null, null);
     return sourceTable != null ? sourceTable.getDefinition().getType() : null;
   }
 

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/action/BigQueryExecuteTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/action/BigQueryExecuteTest.java
@@ -31,6 +31,7 @@ import io.cdap.cdap.etl.api.StageMetrics;
 import io.cdap.cdap.etl.api.action.ActionContext;
 
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
+import io.cdap.plugin.gcp.common.GCPUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -134,7 +135,7 @@ public class BigQueryExecuteTest {
             BigQueryExecute.Config.DEFULT_MAX_RETRY_DURATION_SECONDS,
             BigQueryExecute.Config.DEFAULT_MAX_RETRY_COUNT,
             BigQueryExecute.Config.DEFAULT_RETRY_MULTIPLIER,
-            BigQueryExecute.Config.DEFAULT_READ_TIMEOUT);
+            GCPUtils.BQ_DEFAULT_READ_TIMEOUT_SECONDS);
     Assert.assertEquals(0, failureCollector.getValidationFailures().size());
   }
 
@@ -144,7 +145,7 @@ public class BigQueryExecuteTest {
             BigQueryExecute.Config.DEFULT_MAX_RETRY_DURATION_SECONDS,
             BigQueryExecute.Config.DEFAULT_MAX_RETRY_COUNT,
             BigQueryExecute.Config.DEFAULT_RETRY_MULTIPLIER,
-            BigQueryExecute.Config.DEFAULT_READ_TIMEOUT);
+            GCPUtils.BQ_DEFAULT_READ_TIMEOUT_SECONDS);
     Assert.assertEquals(1, failureCollector.getValidationFailures().size());
     Assert.assertEquals("Initial retry duration must be greater than 0.",
             failureCollector.getValidationFailures().get(0).getMessage());
@@ -156,7 +157,7 @@ public class BigQueryExecuteTest {
             BigQueryExecute.Config.DEFAULT_INITIAL_RETRY_DURATION_SECONDS, -1L,
             BigQueryExecute.Config.DEFAULT_MAX_RETRY_COUNT,
             BigQueryExecute.Config.DEFAULT_RETRY_MULTIPLIER,
-            BigQueryExecute.Config.DEFAULT_READ_TIMEOUT);
+            GCPUtils.BQ_DEFAULT_READ_TIMEOUT_SECONDS);
     Assert.assertEquals(2, failureCollector.getValidationFailures().size());
     Assert.assertEquals("Max retry duration must be greater than 0.",
             failureCollector.getValidationFailures().get(0).getMessage());
@@ -170,7 +171,7 @@ public class BigQueryExecuteTest {
             BigQueryExecute.Config.DEFAULT_INITIAL_RETRY_DURATION_SECONDS,
             BigQueryExecute.Config.DEFULT_MAX_RETRY_DURATION_SECONDS,
             BigQueryExecute.Config.DEFAULT_MAX_RETRY_COUNT, -1.0,
-            BigQueryExecute.Config.DEFAULT_READ_TIMEOUT);
+            GCPUtils.BQ_DEFAULT_READ_TIMEOUT_SECONDS);
     Assert.assertEquals(1, failureCollector.getValidationFailures().size());
     Assert.assertEquals("Retry multiplier must be strictly greater than 1.",
             failureCollector.getValidationFailures().get(0).getMessage());
@@ -182,7 +183,7 @@ public class BigQueryExecuteTest {
             BigQueryExecute.Config.DEFAULT_INITIAL_RETRY_DURATION_SECONDS,
             BigQueryExecute.Config.DEFULT_MAX_RETRY_DURATION_SECONDS, -1,
             BigQueryExecute.Config.DEFAULT_RETRY_MULTIPLIER,
-            BigQueryExecute.Config.DEFAULT_READ_TIMEOUT);
+            GCPUtils.BQ_DEFAULT_READ_TIMEOUT_SECONDS);
     Assert.assertEquals(1, failureCollector.getValidationFailures().size());
     Assert.assertEquals("Max retry count must be greater than 0.",
             failureCollector.getValidationFailures().get(0).getMessage());
@@ -194,7 +195,7 @@ public class BigQueryExecuteTest {
             BigQueryExecute.Config.DEFAULT_INITIAL_RETRY_DURATION_SECONDS,
             BigQueryExecute.Config.DEFULT_MAX_RETRY_DURATION_SECONDS,
             BigQueryExecute.Config.DEFAULT_MAX_RETRY_COUNT, 1.0,
-            BigQueryExecute.Config.DEFAULT_READ_TIMEOUT);
+            GCPUtils.BQ_DEFAULT_READ_TIMEOUT_SECONDS);
     Assert.assertEquals(1, failureCollector.getValidationFailures().size());
     Assert.assertEquals("Retry multiplier must be strictly greater than 1.",
             failureCollector.getValidationFailures().get(0).getMessage());
@@ -205,7 +206,7 @@ public class BigQueryExecuteTest {
     config.validateRetryConfiguration(failureCollector, 10L, 5L,
             BigQueryExecute.Config.DEFAULT_MAX_RETRY_COUNT,
             BigQueryExecute.Config.DEFAULT_RETRY_MULTIPLIER,
-            BigQueryExecute.Config.DEFAULT_READ_TIMEOUT);
+            GCPUtils.BQ_DEFAULT_READ_TIMEOUT_SECONDS);
     Assert.assertEquals(1, failureCollector.getValidationFailures().size());
     Assert.assertEquals("Max retry duration must be greater than initial retry duration.",
             failureCollector.getValidationFailures().get(0).getMessage());

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/source/PartitionedBigQueryInputFormatTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/source/PartitionedBigQueryInputFormatTest.java
@@ -27,8 +27,6 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.Objects;
-
 /**
  *  Unit Tests for generateQuery methods
  */
@@ -65,8 +63,8 @@ public class PartitionedBigQueryInputFormatTest {
     Table t = PowerMockito.mock(Table.class);
     StandardTableDefinition tableDefinition = PowerMockito.mock(StandardTableDefinition.class);
     PowerMockito.when(BigQueryUtil.getBigQueryTable(ArgumentMatchers.anyString(), ArgumentMatchers.anyString(),
-                                                    ArgumentMatchers.anyString(), ArgumentMatchers.any(),
-                                                    ArgumentMatchers.anyBoolean())).thenReturn(t);
+        ArgumentMatchers.anyString(), ArgumentMatchers.any(), ArgumentMatchers.anyBoolean(), ArgumentMatchers.any(),
+        ArgumentMatchers.any())).thenReturn(t);
     PowerMockito.when(t.getDefinition()).thenReturn(tableDefinition);
     String generatedQuery = partitionedBigQueryInputFormat.generateQuery(null, null, filter, datasetProject,
                                                                          datasetProject, dataset, table, null, true);

--- a/src/test/java/io/cdap/plugin/gcp/dataplex/sink/config/DataplexBatchSinkConfigTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/dataplex/sink/config/DataplexBatchSinkConfigTest.java
@@ -1170,7 +1170,7 @@ public class DataplexBatchSinkConfigTest {
     Mockito.when(tableDefinition.getTimePartitioning()).thenReturn(timePartitioning);
     Mockito.when(timePartitioning.getField()).thenReturn("field");
     Mockito.when(BigQueryUtil.getBigQueryTable(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
-        Mockito.anyString(), Mockito.anyBoolean(), Mockito.any())).
+        Mockito.anyString(), Mockito.anyBoolean(), Mockito.any(), Mockito.any())).
       thenReturn(table);
     Asset asset = mock(Asset.class);
     Asset.ResourceSpec assetResourceSpec = mock(Asset.ResourceSpec.class);
@@ -1222,7 +1222,7 @@ public class DataplexBatchSinkConfigTest {
     Mockito.when(tableDefinition.getTimePartitioning()).thenReturn(timePartitioning);
     Mockito.when(timePartitioning.getField()).thenReturn("field");
     Mockito.when(BigQueryUtil.getBigQueryTable(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
-        Mockito.anyString(), Mockito.anyBoolean(), Mockito.any())).
+        Mockito.anyString(), Mockito.anyBoolean(), Mockito.any(), Mockito.any())).
       thenReturn(table);
     Asset asset = mock(Asset.class);
     Asset.ResourceSpec assetResourceSpec = mock(Asset.ResourceSpec.class);
@@ -1277,7 +1277,7 @@ public class DataplexBatchSinkConfigTest {
     Mockito.when(tableDefinition.getRangePartitioning()).thenReturn(rangePartitioning);
     Mockito.when(rangePartitioning.getField()).thenReturn("rangeField");
     Mockito.when(BigQueryUtil.getBigQueryTable(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
-        Mockito.anyString(), Mockito.anyBoolean(), Mockito.any())).
+        Mockito.anyString(), Mockito.anyBoolean(), Mockito.any(), Mockito.any())).
       thenReturn(table);
     Asset asset = mock(Asset.class);
     Asset.ResourceSpec assetResourceSpec = mock(Asset.ResourceSpec.class);
@@ -1331,7 +1331,7 @@ public class DataplexBatchSinkConfigTest {
     Mockito.when(tableDefinition.getRangePartitioning()).thenReturn(rangePartitioning);
     Mockito.when(rangePartitioning.getField()).thenReturn("rangeField");
     Mockito.when(BigQueryUtil.getBigQueryTable(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
-        Mockito.anyString(), Mockito.anyBoolean(), Mockito.any())).
+        Mockito.anyString(), Mockito.anyBoolean(), Mockito.any(), Mockito.any())).
       thenReturn(table);
     Asset asset = mock(Asset.class);
     Asset.ResourceSpec assetResourceSpec = mock(Asset.ResourceSpec.class);

--- a/src/test/java/io/cdap/plugin/gcp/dataplex/sink/config/DataplexBatchSinkTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/dataplex/sink/config/DataplexBatchSinkTest.java
@@ -264,7 +264,7 @@ public class DataplexBatchSinkTest {
     Mockito.when(timePartitioning.getField()).thenReturn("field");
     Mockito.when(
       BigQueryUtil.getBigQueryTable(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
-        Mockito.anyBoolean(), Mockito.any())).thenReturn(table);
+        Mockito.anyBoolean(), Mockito.any(), Mockito.any())).thenReturn(table);
     Asset asset = mock(Asset.class);
     Asset.ResourceSpec assetResourceSpec = mock(Asset.ResourceSpec.class);
     // Assigning the values in DataplexBatchSinkConfig class

--- a/src/test/java/io/cdap/plugin/gcp/dataplex/source/DataplexBatchSourceTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/dataplex/source/DataplexBatchSourceTest.java
@@ -248,7 +248,7 @@ public class DataplexBatchSourceTest {
     Mockito.when(entity.getDataPath()).thenReturn("project/dataset/table");
     Mockito.when(BigQueryUtil.getBigQueryTable(Mockito.anyString(), Mockito.anyString(),
       Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean(),
-      Mockito.any())).thenReturn(table);
+      Mockito.any(), Mockito.any())).thenReturn(table);
     PowerMockito.mockStatic(BigQueryUtil.class);
     Configuration configuration = Mockito.mock(Configuration.class);
     BigQuery bigQuery = Mockito.mock(BigQuery.class);
@@ -342,7 +342,7 @@ public class DataplexBatchSourceTest {
     Mockito.when(entity.getDataPath()).thenReturn("project/dataset/table");
     Mockito.when(BigQueryUtil.getBigQueryTable(Mockito.anyString(), Mockito.anyString(),
       Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean(),
-      Mockito.any())).thenReturn(table);
+      Mockito.any(), Mockito.any())).thenReturn(table);
     PowerMockito.mockStatic(BigQueryUtil.class);
     Configuration configuration = Mockito.mock(Configuration.class);
     String tableName = "cdap.bq.source.temporary.table.name";

--- a/src/test/java/io/cdap/plugin/gcp/dataplex/source/config/DataplexBatchSourceConfigTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/dataplex/source/config/DataplexBatchSourceConfigTest.java
@@ -387,7 +387,7 @@ public class DataplexBatchSourceConfigTest {
     PowerMockito.mockStatic(BigQueryUtil.class);
     Mockito.when(BigQueryUtil.getBigQueryTable("project", "datasets", "tablename",
       "service", true,
-      mockFailureCollector)).thenReturn(table);
+      mockFailureCollector, null)).thenReturn(table);
     Mockito.doReturn(credentials).when(dataplexBatchSourceConfig).getCredentials(mockFailureCollector);
     Mockito.doReturn(credentials).when(dataplexBatchSourceConfig).getCredentials(mockFailureCollector);
     dataplexBatchSourceConfig.validateBigQueryDataset(mockFailureCollector, "project",

--- a/widgets/BigQueryMultiTable-batchsink.json
+++ b/widgets/BigQueryMultiTable-batchsink.json
@@ -205,6 +205,15 @@
               }
             ]
           }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Read Timeout",
+          "name": "readTimeout",
+          "widget-attributes": {
+            "default": "120",
+            "minimum": "0"
+          }
         }
       ]
     },

--- a/widgets/BigQueryTable-batchsink.json
+++ b/widgets/BigQueryTable-batchsink.json
@@ -236,6 +236,15 @@
             },
             "default": "false"
           }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Read Timeout",
+          "name": "readTimeout",
+          "widget-attributes": {
+            "default": "120",
+            "minimum": "0"
+          }
         }
       ]
     },

--- a/widgets/BigQueryTable-batchsource.json
+++ b/widgets/BigQueryTable-batchsource.json
@@ -166,6 +166,15 @@
           "widget-attributes": {
             "placeholder": "projects/<gcp-project-id>/locations/<key-location>/keyRings/<key-ring-name>/cryptoKeys/<key-name>"
           }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Read Timeout",
+          "name": "readTimeout",
+          "widget-attributes": {
+            "default": "120",
+            "minimum": "0"
+          }
         }
       ]
     },


### PR DESCRIPTION
🍒 [cherrypick]

### Commits :
 - 8ec75177efc832ed7631654fbd6586ba102ead70
 - 2b4884f4ca0ed7af62e0a5822b71f75303f4cc3e

### PR:
 - #1527 [ Reviewer @itsankit-google ]
 - #1525 [ Reviewer @itsankit-google ]
 
 ---
 
 # Code Cleanup BigQueryUtils
 
 JIRA: [PLUGIN-1866](https://cdap.atlassian.net/browse/PLUGIN-1866)

Code Cleanup

- Remove duplicated functions `getBigQueryTable` and combine in one.
- Add read Timeout to  function signature in `getBigQueryTable`
- Fix Unit Tests

Splitting the code cleanup PR to help Review process of the original PR : https://github.com/data-integrations/google-cloud/pull/1525 (WIP)

[PLUGIN-1866]: https://cdap.atlassian.net/browse/PLUGIN-1866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

# Add Http readTimeout BQ Source/Sink

Code Restructure PR is raised separately to help with review: https://github.com/data-integrations/google-cloud/pull/1527
The changes are present in this PR as well as a separate commit !

https://cdap.atlassian.net/browse/PLUGIN-1866

## Tests

- BQ Source 
![image](https://github.com/user-attachments/assets/48393808-644d-4ceb-9849-5ad634b638ff)

<img width="1110" alt="image" src="https://github.com/user-attachments/assets/dd6e19cb-6815-4d02-8fe4-7add4df5a0de" />



- BQ Sink
![image](https://github.com/user-attachments/assets/46c0dce2-f78b-4006-b167-6e333c185c38)

<img width="1110" alt="image" src="https://github.com/user-attachments/assets/5ee4ef9c-d298-49c6-bb58-60b70fc30c2f" />


- BQ Multi Sink
![image](https://github.com/user-attachments/assets/490fce91-f339-49a2-812c-8858846cb5ea)

<img width="1104" alt="image" src="https://github.com/user-attachments/assets/b160629e-fb04-4285-a903-3a584fe8c39d" />
