### PR TITLE
Bump google-cloud plugin version to 0.23.4-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>google-cloud</artifactId>
-  <version>0.23.3</version>
+  <version>0.23.4-SNAPSHOT</version>
   <name>Google Cloud Plugins</name>
   <packaging>jar</packaging>
   <description>Plugins for Google Big Query</description>


### PR DESCRIPTION
Bump google-cloud plugin version to 0.23.4-SNAPSHOT