### PR TITLE
[🍒][Plugin-1730] Adding XLS UI elements for gcs file source

### DIFF
--- a/docs/GCSFile-batchsource.md
+++ b/docs/GCSFile-batchsource.md
@@ -33,22 +33,44 @@ You also can use the macro function ${conn(connection-name)}.
 **Project ID:** Google Cloud Project ID, which uniquely identifies a project.
 It can be found on the Dashboard in the Google Cloud Platform Console.
 
+**Service Account Type:** Service account type, file path where the service account is located or the JSON content of 
+the service account.
+
+**Service Account File Path:** Path on the local file system of the service account key. Can be set to 'auto-detect'.
+
+**Service Account JSON:** Contents of the service account JSON file.
+
 **Path:** Path to file(s) to be read. If a directory is specified, terminate the path name with a '/'.
 For example, `gs://<bucket>/path/to/directory/`.
 An asterisk ("\*") can be used as a wildcard to match a filename pattern.
 If no files are found or matched, the pipeline will fail.
 
 **Format:** Format of the data to read.
-The format must be one of 'avro', 'blob', 'csv', 'delimited', 'json', 'parquet', 'text', 'tsv', or the
+The format must be one of 'avro', 'blob', 'csv', 'delimited', 'json', 'parquet', 'text', 'tsv', 'xls', or the
 name of any format plugin that you have deployed to your environment.
 If the format is a macro, only the pre-packaged formats can be used.
 If the format is 'blob', every input file will be read into a separate record.
 The 'blob' format also requires a schema that contains a field named 'body' of type 'bytes'.
 If the format is 'text', the schema must contain a field named 'body' of type 'string'.
 
+**Get Schema:** Auto-detects schema from file.  Supported formats are: avro, parquet, csv, delimited, tsv, blob, text, and xls.
+
+**Sample Size:** The maximum number of rows that will get investigated for automatic data type detection. 
+The default value is 1000. This is only used when the format is 'xls'.
+
+**Override:** A list of columns with the corresponding data types for whom the automatic data type detection gets
+skipped. This is only used when the format is 'xls'.
+
+**Terminate Reading After Empty Row:** Specify whether to stop reading after encountering the first empty row. Defaults to false. When false the reader will read all rows in the sheet. This is only used when the format is 'xls'.
+
+**Select Sheet Using:** Select the sheet by name or number. Default is 'Sheet Number'. This is only used when the format is 'xls'.
+
+**Sheet Value:** The name/number of the sheet to read from. If not specified, the first sheet will be read.
+Sheet Numbers are 0 based, ie first sheet is 0. This is only used when the format is 'xls'.
+
 **Delimiter:** Delimiter to use when the format is 'delimited'. This will be ignored for other formats.
 
-**Use First Row as Header:** Whether to use first row as header. Supported formats are 'text', 'csv', 'tsv', 'delimited'.
+**Use First Row as Header:** Whether to use first row as header. Supported formats are 'text', 'csv', 'tsv', 'delimited', 'xls'.
 
 **Enable Quoted Values:** Whether to treat content between quotes as a value. This value will only be used if the format
 is 'csv', 'tsv' or 'delimited'. For example, if this is set to true, a line that looks like `1, "a, b, c"` will output two fields.

--- a/src/main/java/io/cdap/plugin/gcp/gcs/source/GCSSource.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/source/GCSSource.java
@@ -166,6 +166,9 @@ public class GCSSource extends AbstractFileSource<GCSSource.GCSSourceConfig> {
     private static final String NAME_FILE_SYSTEM_PROPERTIES = "fileSystemProperties";
     private static final String NAME_FILE_REGEX = "fileRegex";
     private static final String NAME_DELIMITER = "delimiter";
+    private static final String NAME_SHEET = "sheet";
+    private static final String NAME_SHEET_VALUE = "sheetValue";
+    private static final String NAME_TERMINATE_IF_EMPTY_ROW = "terminateIfEmptyRow";
 
     private static final String DEFAULT_ENCRYPTED_METADATA_SUFFIX = ".metadata";
 
@@ -219,6 +222,25 @@ public class GCSSource extends AbstractFileSource<GCSSource.GCSSourceConfig> {
     @Nullable
     @Description("The existing connection to use.")
     private GCPConnectorConfig connection;
+
+    @Name(NAME_SHEET)
+    @Macro
+    @Nullable
+    @Description("Select the sheet by name or number. Default is 'Sheet Number'.")
+    private String sheet;
+
+    @Name(NAME_SHEET_VALUE)
+    @Macro
+    @Nullable
+    @Description("The name/number of the sheet to read from. If not specified, the first sheet will be read." +
+            "Sheet Numbers are 0 based, ie first sheet is 0.")
+    private String sheetValue;
+
+    @Name(NAME_TERMINATE_IF_EMPTY_ROW)
+    @Macro
+    @Nullable
+    @Description("Specify whether to stop reading after encountering the first empty row. Defaults to false.")
+    private String terminateIfEmptyRow;
 
     @Override
     public void validate() {

--- a/widgets/GCSFile-batchsource.json
+++ b/widgets/GCSFile-batchsource.json
@@ -187,6 +187,42 @@
               "label": "False"
             }
           }
+        },
+        {
+          "widget-type": "toggle",
+          "label": "Terminate Reading After Empty Row",
+          "name": "terminateIfEmptyRow",
+          "widget-attributes": {
+            "default": "false",
+            "on": {
+              "value": "true",
+              "label": "True"
+            },
+            "off": {
+              "value": "false",
+              "label": "False"
+            }
+          }
+        },
+        {
+          "widget-type": "select",
+          "label": "Select Sheet Using",
+          "name": "sheet",
+          "widget-attributes": {
+            "values": [
+              "Sheet Name",
+              "Sheet Number"
+            ],
+            "default": "Sheet Number"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Sheet Value",
+          "name": "sheetValue",
+          "widget-attributes": {
+            "default": "0"
+          }
         }
       ]
     },
@@ -673,11 +709,44 @@
     {
       "name": "skipHeader",
       "condition": {
-        "expression": "format == 'delimited' || format == 'csv' || format == 'tsv'"
+        "expression": "format == 'delimited' || format == 'csv' || format == 'tsv' || format == 'xls'"
       },
       "show": [
         {
           "name": "skipHeader"
+        }
+      ]
+    },
+    {
+      "name": "sheet",
+      "condition": {
+        "expression": "format == 'xls'"
+      },
+      "show": [
+        {
+          "name": "sheet"
+        }
+      ]
+    },
+    {
+      "name": "sheetValue",
+      "condition": {
+        "expression": "format == 'xls'"
+      },
+      "show": [
+        {
+          "name": "sheetValue"
+        }
+      ]
+    },
+    {
+      "name": "terminateIfEmptyRow",
+      "condition": {
+        "expression": "format == 'xls'"
+      },
+      "show": [
+        {
+          "name": "terminateIfEmptyRow"
         }
       ]
     }


### PR DESCRIPTION
[🍒]

🍒 [cherrypick]

### Commits :
 - a9419a7940a87e2d97982a410f24d80dcb662dab

### PR:
 - #1368 [ Reviewer @itsankit-google ]
 
---

## Adding XLS UI elements for gcs source

Jira : [Plugin-1730](https://cdap.atlassian.net/browse/PLUGIN-1730)

### Description
This PR adds UI element required for XLS Support in `GCS Source`.
Ref : XLS Support PR https://github.com/cdapio/hydrator-plugins/pull/1835

### Added Fields 
- Terminate If Empty Row
- Select Sheet Using
- Sheet Value

A filter is used to show XLS specific values  `Terminate If Empty Row` , `Select Sheet Using`, `Sheet Value` only when format `XLS` is selected.

### Preview
<img width="950" alt="image" src="https://github.com/user-attachments/assets/ef7b0ae7-a4d0-419a-9525-82593b3e4812" />

<img width="1455" alt="image" src="https://github.com/user-attachments/assets/25d4a3e7-f8a1-4745-b389-0a170d98f2ca" />

## Sanity Tests 

### Data Used
[xlsx_bench.xlsx](https://github.com/user-attachments/files/20080031/xlsx_bench.xlsx)

- A xlsx file with 3 sheets
- Sheet 1 (data with headers)
- Sheet 2 (data without headers)
- Sheet 3 (data with headers and an empty line)

#### "Sheet1" [index 0]
![image](https://github.com/user-attachments/assets/2b6fa143-7f10-49ad-9b33-8fd1db80bc2f)

#### "Sheet2" [index 1]
![image](https://github.com/user-attachments/assets/7cff67c1-e6c5-4de1-8a40-71ffe1252b66)

#### "Sheet3" [index 2]
![image](https://github.com/user-attachments/assets/24da1b90-0f88-4c84-ba46-a316fcb551ae)

---

## Test 1 [Read a sheet with headers]

> We will be testing can the plugin read a sheet with headers defined, also skip the first row while reading data.

- Config
  - Turn on "Use First Row as Header" 
![image](https://github.com/user-attachments/assets/d384331c-0ccb-4030-a351-e8e10139f1ad)
- Deploy
![image](https://github.com/user-attachments/assets/a70f9019-81ba-4833-9208-e9d474a0f048)

- Output
![image](https://github.com/user-attachments/assets/a1a24b55-ae0e-4aa7-b4c3-b69fbd07afef)


## Test 2 [Read a sheet using it's name + Read a sheet other than the 1st + Read a sheet without headers]

> We will be testing can the plugin read a sheet using the sheet's name.
> We will be testing if the plugin can read any sheet other than the first one, we will also be testing if the plugin can read sheet without a header.

- Config
  - Set "Select Sheet Using" to "Sheet Name"
  - Add the sheet name
![image](https://github.com/user-attachments/assets/780da8c5-fa3c-4c26-a6ff-98e1f18fc4a8)

- Deploy
![image](https://github.com/user-attachments/assets/520ce677-f3df-4e15-a431-0c01874bfc66)

- Output
![image](https://github.com/user-attachments/assets/e9bbf8a5-740b-4bff-987c-c1f783a56b45)


## Test 3 [Do not stop reading when a row is missing]

> We will be testing if the plugin can keep reading if an empty row is encountered.

- Config
  - Turn off "Terminate Reading After Empty Row" 
![image](https://github.com/user-attachments/assets/37eaa5c1-2efc-4a25-845c-c3226c6e2e59)

- Deploy
![image](https://github.com/user-attachments/assets/43808d51-f560-4e8b-a38b-5ce4757085ff)

- Output
![image](https://github.com/user-attachments/assets/c1c26517-e98a-4b88-aee8-fd6579b883f7)


## Test 4 [Stop reading when a row is missing]

> We will be testing if the plugin can stop reading if an empty row is encountered.

- Config
    - Turn on "Terminate Reading After Empty Row"
![image](https://github.com/user-attachments/assets/42924912-5520-47b2-9348-baa8f0cf766d)

- Deploy
![image](https://github.com/user-attachments/assets/254aff7e-68ae-4513-bd7f-8fb7506e5105)

- Output
![image](https://github.com/user-attachments/assets/bf67e587-3125-4805-b51f-bcee998cf7c6)

