### PR TITLE
E2e build fixes for github actions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1252,6 +1252,7 @@
           <execution>
             <goals>
               <goal>integration-test</goal>
+              <goal>verify</goal>
             </goals>
           </execution>
         </executions>

--- a/src/e2e-test/java/io/cdap/plugin/bigquery/runners/multitablerunner/TestRunner.java
+++ b/src/e2e-test/java/io/cdap/plugin/bigquery/runners/multitablerunner/TestRunner.java
@@ -31,7 +31,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/bigquerymultitable-sink",
     "json:target/cucumber-reports/cucumber-bigquerymultitable-sink.json",
-    "junit:target/cucumber-reports/cucumber-bigquerymultitable-sink.xml"}
+    "junit:target/cucumber-reports/cucumber-bigquerymultitable-sink.xml"},
+  strict = true
 )
 public class TestRunner {
 }

--- a/src/e2e-test/java/io/cdap/plugin/bigquery/runners/multitablerunner/TestRunnerRequired.java
+++ b/src/e2e-test/java/io/cdap/plugin/bigquery/runners/multitablerunner/TestRunnerRequired.java
@@ -31,7 +31,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/bigquerymultitable-sink-required",
     "json:target/cucumber-reports/cucumber-bigquerymultitable-sink-required.json",
-    "junit:target/cucumber-reports/cucumber-bigquerymultitable-sink-required.xml"}
+    "junit:target/cucumber-reports/cucumber-bigquerymultitable-sink-required.xml"},
+  strict = true
 )
 public class TestRunnerRequired {
 }

--- a/src/e2e-test/java/io/cdap/plugin/bigquery/runners/sinkrunner/TestRunner.java
+++ b/src/e2e-test/java/io/cdap/plugin/bigquery/runners/sinkrunner/TestRunner.java
@@ -32,7 +32,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/bigquery-sink",
     "json:target/cucumber-reports/cucumber-bigquery-sink.json",
-    "junit:target/cucumber-reports/cucumber-bigquery-sink.xml"}
+    "junit:target/cucumber-reports/cucumber-bigquery-sink.xml"},
+  strict = true
 )
 public class TestRunner {
 }

--- a/src/e2e-test/java/io/cdap/plugin/bigquery/runners/sinkrunner/TestRunnerRequired.java
+++ b/src/e2e-test/java/io/cdap/plugin/bigquery/runners/sinkrunner/TestRunnerRequired.java
@@ -32,7 +32,8 @@ import org.junit.runner.RunWith;
   //TODO: Enable test once issue is fixed https://cdap.atlassian.net/browse/CDAP-20830
   plugin = {"pretty", "html:target/cucumber-html-report/bigquery-sink-required",
     "json:target/cucumber-reports/cucumber-bigquery-sink-required.json",
-    "junit:target/cucumber-reports/cucumber-bigquery-sink-required.xml"}
+    "junit:target/cucumber-reports/cucumber-bigquery-sink-required.xml"},
+  strict = true
 )
 public class TestRunnerRequired {
 }

--- a/src/e2e-test/java/io/cdap/plugin/bigquery/runners/sourcerunner/TestRunner.java
+++ b/src/e2e-test/java/io/cdap/plugin/bigquery/runners/sourcerunner/TestRunner.java
@@ -31,7 +31,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/bigquery-source",
     "json:target/cucumber-reports/cucumber-bigquery-source.json",
-    "junit:target/cucumber-reports/cucumber-bigquery-source.xml"}
+    "junit:target/cucumber-reports/cucumber-bigquery-source.xml"},
+  strict = true
 )
 public class TestRunner {
 }

--- a/src/e2e-test/java/io/cdap/plugin/bigquery/runners/sourcerunner/TestRunnerRequired.java
+++ b/src/e2e-test/java/io/cdap/plugin/bigquery/runners/sourcerunner/TestRunnerRequired.java
@@ -31,7 +31,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/bigquery-source-required",
     "json:target/cucumber-reports/cucumber-bigquery-source-required.json",
-    "junit:target/cucumber-reports/cucumber-bigquery-source-required.xml"}
+    "junit:target/cucumber-reports/cucumber-bigquery-source-required.xml"},
+  strict = true
 )
 public class TestRunnerRequired {
 }

--- a/src/e2e-test/java/io/cdap/plugin/bigqueryexecute/runner/TestRunner.java
+++ b/src/e2e-test/java/io/cdap/plugin/bigqueryexecute/runner/TestRunner.java
@@ -31,7 +31,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/bqExecute",
     "json:target/cucumber-reports/cucumber-bqExecute.json",
-    "junit:target/cucumber-reports/cucumber-bqExecute.xml"}
+    "junit:target/cucumber-reports/cucumber-bqExecute.xml"},
+  strict = true
 )
 public class TestRunner {
 }

--- a/src/e2e-test/java/io/cdap/plugin/bigqueryexecute/runner/TestRunnerRequired.java
+++ b/src/e2e-test/java/io/cdap/plugin/bigqueryexecute/runner/TestRunnerRequired.java
@@ -31,7 +31,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/bqExecute-required",
     "json:target/cucumber-reports/cucumber-bqExecute-required.json",
-    "junit:target/cucumber-reports/cucumber-bqExecute-required.xml"}
+    "junit:target/cucumber-reports/cucumber-bqExecute-required.xml"},
+  strict = true
 )
 public class TestRunnerRequired {
 }

--- a/src/e2e-test/java/io/cdap/plugin/bigtable/runners/TestRunner.java
+++ b/src/e2e-test/java/io/cdap/plugin/bigtable/runners/TestRunner.java
@@ -31,7 +31,8 @@ import org.junit.runner.RunWith;
         monochrome = true,
         plugin = {"pretty", "html:target/cucumber-html-report/bigtable",
                 "json:target/cucumber-reports/cucumber-bigtable.json",
-                "junit:target/cucumber-reports/cucumber-bigtable.xml"}
+                "junit:target/cucumber-reports/cucumber-bigtable.xml"},
+        strict = true
 )
 public class TestRunner {
 }

--- a/src/e2e-test/java/io/cdap/plugin/bigtable/runners/TestRunnerRequired.java
+++ b/src/e2e-test/java/io/cdap/plugin/bigtable/runners/TestRunnerRequired.java
@@ -30,7 +30,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/bigtable-required",
     "json:target/cucumber-reports/cucumber-bigtable-required.json",
-    "junit:target/cucumber-reports/cucumber-bigtable-required.xml"}
+    "junit:target/cucumber-reports/cucumber-bigtable-required.xml"},
+  strict = true
 )
 
 public class TestRunnerRequired {

--- a/src/e2e-test/java/io/cdap/plugin/common/runners/cmekrunner/TestRunner.java
+++ b/src/e2e-test/java/io/cdap/plugin/common/runners/cmekrunner/TestRunner.java
@@ -27,11 +27,12 @@ import org.junit.runner.RunWith;
   features = {"src/e2e-test/features"},
   glue = {"io.cdap.plugin.gcs.stepsdesign", "io.cdap.plugin.bigquery.stepsdesign",
     "stepsdesign", "io.cdap.plugin.common.stepsdesign", "io.cdap.plugin.pubsub.stepsdesign",
-          "io.cdap.plugin.gcsmove.stepsdesign"},
+          "io.cdap.plugin.gcsmove.stepsdesign", "io.cdap.plugin.gcscopy.stepsdesign"},
   tags = {"@CMEK"},
   plugin = {"pretty", "html:target/cucumber-html-report/cmek", "json:target/cucumber-reports/cucumber-cmek.json",
     "junit:target/cucumber-reports/cucumber-cmek.xml", "io.cdap.e2e.utils.PropModifier:cmek-config.properties"},
-  monochrome = true
+  monochrome = true,
+  strict = true
 )
 public class TestRunner {
 }

--- a/src/e2e-test/java/io/cdap/plugin/common/runners/cmekrunner/TestRunnerRequired.java
+++ b/src/e2e-test/java/io/cdap/plugin/common/runners/cmekrunner/TestRunnerRequired.java
@@ -27,13 +27,14 @@ import org.junit.runner.RunWith;
   features = {"src/e2e-test/features"},
   glue = {"io.cdap.plugin.gcs.stepsdesign", "io.cdap.plugin.bigquery.stepsdesign",
     "stepsdesign", "io.cdap.plugin.common.stepsdesign", "io.cdap.plugin.pubsub.stepsdesign",
-          "io.cdap.plugin.gcsmove.stepsdesign"},
+          "io.cdap.plugin.gcsmove.stepsdesign", "io.cdap.plugin.gcscopy.stepsdesign"},
   tags = {"@CMEK_Required"},
   plugin = {"pretty", "html:target/cucumber-html-report/cmek-required",
     "json:target/cucumber-reports/cucumber-cmek-required.json",
     "junit:target/cucumber-reports/cucumber-cmek-required.xml",
     "io.cdap.e2e.utils.PropModifier:cmek-config.properties"},
-  monochrome = true
+  monochrome = true,
+  strict = true
 )
 public class TestRunnerRequired {
 }

--- a/src/e2e-test/java/io/cdap/plugin/common/runners/common/TestRunnerRequired.java
+++ b/src/e2e-test/java/io/cdap/plugin/common/runners/common/TestRunnerRequired.java
@@ -28,12 +28,13 @@ import org.junit.runner.RunWith;
   glue = {"io.cdap.plugin.gcs.stepsdesign", "io.cdap.plugin.bigquery.stepsdesign", "stepsdesign",
     "io.cdap.plugin.common.stepsdesign", "io.cdap.plugin.pubsub.stepsdesign",
     "io.cdap.plugin.gcsmove.stepsdesign", "io.cdap.plugin.spanner.stepsdesign",
-    "io.cdap.plugin.gcsdelete.stepsdesign"},
+    "io.cdap.plugin.gcsdelete.stepsdesign", "io.cdap.plugin.gcscopy.stepsdesign"},
   tags = {"@Required"},
   plugin = {"pretty", "html:target/cucumber-html-report/required",
     "json:target/cucumber-reports/cucumber-required.json",
     "junit:target/cucumber-reports/cucumber-required.xml"},
-  monochrome = true
+  monochrome = true,
+  strict = true
 )
 public class TestRunnerRequired {
 }

--- a/src/e2e-test/java/io/cdap/plugin/datastore/runner/TestRunner.java
+++ b/src/e2e-test/java/io/cdap/plugin/datastore/runner/TestRunner.java
@@ -31,7 +31,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/datastore",
     "json:target/cucumber-reports/cucumber-datastore.json",
-    "junit:target/cucumber-reports/cucumber-datastore.xml"}
+    "junit:target/cucumber-reports/cucumber-datastore.xml"},
+  strict = true
 )
 public class TestRunner {
 }

--- a/src/e2e-test/java/io/cdap/plugin/datastore/runner/TestRunnerRequired.java
+++ b/src/e2e-test/java/io/cdap/plugin/datastore/runner/TestRunnerRequired.java
@@ -31,7 +31,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/datastore-required",
     "json:target/cucumber-reports/cucumber-datastore-required.json",
-    "junit:target/cucumber-reports/cucumber-datastore-required.xml"}
+    "junit:target/cucumber-reports/cucumber-datastore-required.xml"},
+  strict = true
 )
 
 public class TestRunnerRequired {

--- a/src/e2e-test/java/io/cdap/plugin/gcs/runners/sinkrunner/TestRunner.java
+++ b/src/e2e-test/java/io/cdap/plugin/gcs/runners/sinkrunner/TestRunner.java
@@ -31,7 +31,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/gcs-sink",
     "json:target/cucumber-reports/cucumber-gcs-sink.json",
-    "junit:target/cucumber-reports/cucumber-gcs-sink.xml"}
+    "junit:target/cucumber-reports/cucumber-gcs-sink.xml"},
+  strict = true
 )
 public class TestRunner {
 }

--- a/src/e2e-test/java/io/cdap/plugin/gcs/runners/sinkrunner/TestRunnerRequired.java
+++ b/src/e2e-test/java/io/cdap/plugin/gcs/runners/sinkrunner/TestRunnerRequired.java
@@ -31,7 +31,8 @@ import org.junit.runner.RunWith;
         monochrome = true,
         plugin = {"pretty", "html:target/cucumber-html-report/gcs-sink",
                 "json:target/cucumber-reports/cucumber-gcs-sink.json",
-                "junit:target/cucumber-reports/cucumber-gcs-sink.xml"}
+                "junit:target/cucumber-reports/cucumber-gcs-sink.xml"},
+        strict = true
 )
 public class TestRunnerRequired {
 }

--- a/src/e2e-test/java/io/cdap/plugin/gcs/runners/sourcerunner/TestRunner.java
+++ b/src/e2e-test/java/io/cdap/plugin/gcs/runners/sourcerunner/TestRunner.java
@@ -34,7 +34,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/gcs-source",
     "json:target/cucumber-reports/cucumber-gcs-source.json",
-    "junit:target/cucumber-reports/cucumber-gcs-source.xml"}
+    "junit:target/cucumber-reports/cucumber-gcs-source.xml"},
+  strict = true
 )
 public class TestRunner {
 }

--- a/src/e2e-test/java/io/cdap/plugin/gcs/runners/sourcerunner/TestRunnerRequired.java
+++ b/src/e2e-test/java/io/cdap/plugin/gcs/runners/sourcerunner/TestRunnerRequired.java
@@ -32,7 +32,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/gcs-source-required",
     "json:target/cucumber-reports/cucumber-gcs-source-required.json",
-    "junit:target/cucumber-reports/cucumber-gcs-source-required.xml"}
+    "junit:target/cucumber-reports/cucumber-gcs-source-required.xml"},
+  strict = true
 )
 public class TestRunnerRequired {
 }

--- a/src/e2e-test/java/io/cdap/plugin/gcscopy/runners/TestRunner.java
+++ b/src/e2e-test/java/io/cdap/plugin/gcscopy/runners/TestRunner.java
@@ -31,7 +31,8 @@ import org.junit.runner.RunWith;
     monochrome = true,
     plugin = {"pretty", "html:target/cucumber-html-report/gcscopy-action",
       "json:target/cucumber-reports/cucumber-gcscopy-action.json",
-      "junit:target/cucumber-reports/cucumber-gcscopy-action.xml"}
+      "junit:target/cucumber-reports/cucumber-gcscopy-action.xml"},
+    strict = true
   )
   public class TestRunner {
   }

--- a/src/e2e-test/java/io/cdap/plugin/gcscopy/runners/TestRunnerRequired.java
+++ b/src/e2e-test/java/io/cdap/plugin/gcscopy/runners/TestRunnerRequired.java
@@ -31,7 +31,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/gcscopy-action",
     "json:target/cucumber-reports/cucumber-gcscopy-action.json",
-    "junit:target/cucumber-reports/cucumber-gcscopy-action.xml"}
+    "junit:target/cucumber-reports/cucumber-gcscopy-action.xml"},
+  strict = true
 )
 public class TestRunnerRequired {
 }

--- a/src/e2e-test/java/io/cdap/plugin/gcscreate/runners/TestRunner.java
+++ b/src/e2e-test/java/io/cdap/plugin/gcscreate/runners/TestRunner.java
@@ -31,7 +31,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/gcscreate",
     "json:target/cucumber-reports/cucumber-gcscreate.json",
-    "junit:target/cucumber-reports/cucumber-gcscreate.xml"}
+    "junit:target/cucumber-reports/cucumber-gcscreate.xml"},
+  strict = true
 )
 public class TestRunner {
 }

--- a/src/e2e-test/java/io/cdap/plugin/gcscreate/runners/TestRunnerRequired.java
+++ b/src/e2e-test/java/io/cdap/plugin/gcscreate/runners/TestRunnerRequired.java
@@ -31,7 +31,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/gcscreate-required",
     "json:target/cucumber-reports/cucumber-gcscreate-required.json",
-    "junit:target/cucumber-reports/cucumber-gcscreate-required.xml"}
+    "junit:target/cucumber-reports/cucumber-gcscreate-required.xml"},
+  strict = true
 )
 public class TestRunnerRequired {
 }

--- a/src/e2e-test/java/io/cdap/plugin/gcsdelete/runners/TestRunner.java
+++ b/src/e2e-test/java/io/cdap/plugin/gcsdelete/runners/TestRunner.java
@@ -31,7 +31,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/gcsdelete",
     "json:target/cucumber-reports/cucumber-gcsdelete.json",
-    "junit:target/cucumber-reports/cucumber-gcsdelete.xml"}
+    "junit:target/cucumber-reports/cucumber-gcsdelete.xml"},
+  strict = true
 )
 public class TestRunner {
 }

--- a/src/e2e-test/java/io/cdap/plugin/gcsdelete/runners/TestRunnerRequired.java
+++ b/src/e2e-test/java/io/cdap/plugin/gcsdelete/runners/TestRunnerRequired.java
@@ -31,7 +31,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/gcsdelete-required",
     "json:target/cucumber-reports/cucumber-gcsdelete-required.json",
-    "junit:target/cucumber-reports/cucumber-gcsdelete-required.xml"}
+    "junit:target/cucumber-reports/cucumber-gcsdelete-required.xml"},
+  strict = true
 )
 public class TestRunnerRequired {
 }

--- a/src/e2e-test/java/io/cdap/plugin/gcsmove/runners/TestRunner.java
+++ b/src/e2e-test/java/io/cdap/plugin/gcsmove/runners/TestRunner.java
@@ -31,7 +31,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/gcsmove-action",
     "json:target/cucumber-reports/cucumber-gcsmove-action.json",
-    "junit:target/cucumber-reports/cucumber-gcsmove-action.xml"}
+    "junit:target/cucumber-reports/cucumber-gcsmove-action.xml"},
+  strict = true
 )
 public class TestRunner {
 }

--- a/src/e2e-test/java/io/cdap/plugin/gcsmove/runners/TestRunnerRequired.java
+++ b/src/e2e-test/java/io/cdap/plugin/gcsmove/runners/TestRunnerRequired.java
@@ -31,7 +31,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/gcsmove-action-required",
     "json:target/cucumber-reports/cucumber-gcsmove-action-required.json",
-    "junit:target/cucumber-reports/cucumber-gcsmove-action-required.xml"}
+    "junit:target/cucumber-reports/cucumber-gcsmove-action-required.xml"},
+  strict = true
 )
 public class TestRunnerRequired {
 }

--- a/src/e2e-test/java/io/cdap/plugin/pubsub/runners/sinkrunner/TestRunner.java
+++ b/src/e2e-test/java/io/cdap/plugin/pubsub/runners/sinkrunner/TestRunner.java
@@ -31,7 +31,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/pubsub-sink",
     "json:target/cucumber-reports/cucumber-pubsub-sink.json",
-    "junit:target/cucumber-reports/cucumber-pubsub-sink.xml"}
+    "junit:target/cucumber-reports/cucumber-pubsub-sink.xml"},
+  strict = true
 )
 
 public class TestRunner {

--- a/src/e2e-test/java/io/cdap/plugin/pubsub/runners/sinkrunner/TestRunnerRequired.java
+++ b/src/e2e-test/java/io/cdap/plugin/pubsub/runners/sinkrunner/TestRunnerRequired.java
@@ -31,7 +31,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/pubsub-sink-required",
     "json:target/cucumber-reports/cucumber-pubsub-sink-required.json",
-    "junit:target/cucumber-reports/cucumber-pubsub-sink-required.xml"}
+    "junit:target/cucumber-reports/cucumber-pubsub-sink-required.xml"},
+  strict = true
 )
 
 public class TestRunnerRequired {

--- a/src/e2e-test/java/io/cdap/plugin/spanner/runners/sinkrunner/TestRunner.java
+++ b/src/e2e-test/java/io/cdap/plugin/spanner/runners/sinkrunner/TestRunner.java
@@ -31,7 +31,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/spanner-sink",
     "json:target/cucumber-reports/cucumber-spanner-sink.json",
-    "junit:target/cucumber-reports/cucumber-spanner-sink.xml"}
+    "junit:target/cucumber-reports/cucumber-spanner-sink.xml"},
+  strict = true
 )
 public class TestRunner {
 }

--- a/src/e2e-test/java/io/cdap/plugin/spanner/runners/sourcerunner/TestRunner.java
+++ b/src/e2e-test/java/io/cdap/plugin/spanner/runners/sourcerunner/TestRunner.java
@@ -31,7 +31,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/spanner-source",
     "json:target/cucumber-reports/cucumber-spanner-source.json",
-    "junit:target/cucumber-reports/cucumber-spanner-source.xml"}
+    "junit:target/cucumber-reports/cucumber-spanner-source.xml"},
+  strict = true
 )
 public class TestRunner {
 }

--- a/src/e2e-test/java/io/cdap/plugin/spanner/runners/sourcerunner/TestRunnerRequired.java
+++ b/src/e2e-test/java/io/cdap/plugin/spanner/runners/sourcerunner/TestRunnerRequired.java
@@ -31,7 +31,8 @@ import org.junit.runner.RunWith;
   monochrome = true,
   plugin = {"pretty", "html:target/cucumber-html-report/spanner-source-required",
     "json:target/cucumber-reports/cucumber-spanner-source-required.json",
-    "junit:target/cucumber-reports/cucumber-spanner-source-required.xml"}
+    "junit:target/cucumber-reports/cucumber-spanner-source-required.xml"},
+  strict = true
 )
 public class TestRunnerRequired {
 }


### PR DESCRIPTION
This PR contains changes related  to fix the undefined e2e step fix for github build and adding the verify goal.
Earlier when there was any undefined step in the feature file the build got passed by throwing warnings for undefined step but not failing the build.
<img width="1730" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/417bbe86-2c6d-46d8-91ca-e58d66951229" />
<img width="1366" alt="image" src="https://github.com/user-attachments/assets/d410788f-6479-4955-b477-4b141438813d" />

In order to ensure that the build fails when any undefined step is encountered, a strict command has been added to the runner files.

<img width="1435" alt="image" src="https://github.com/user-attachments/assets/2fb129bb-2ddc-4f77-9f2d-f1a6769ca16c" />
