### PR TITLE
OSSRH to central sonatype repo migration.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,11 +58,11 @@
   <distributionManagement>
     <repository>
       <id>sonatype.release</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+      <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2</url>
     </repository>
     <snapshotRepository>
       <id>sonatype.snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <url>https://central.sonatype.com/repository/maven-snapshots</url>
     </snapshotRepository>
   </distributionManagement>
 
@@ -120,7 +120,7 @@
   <repositories>
     <repository>
       <id>sonatype</id>
-      <url>https://oss.sonatype.org/content/groups/public</url>
+      <url>https://ossrh-staging-api.central.sonatype.com/content/groups/public</url>
       <releases>
         <enabled>true</enabled>
       </releases>
@@ -130,7 +130,7 @@
     </repository>
     <repository>
       <id>sonatype-snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <url>https://central.sonatype.com/repository/maven-snapshots</url>
       <releases>
         <enabled>false</enabled>
       </releases>
@@ -1171,7 +1171,7 @@
             <version>1.6.14</version>
             <extensions>true</extensions>
             <configuration>
-              <nexusUrl>https://oss.sonatype.org</nexusUrl>
+              <nexusUrl>https://ossrh-staging-api.central.sonatype.com</nexusUrl>
               <serverId>sonatype.release</serverId>
             </configuration>
           </plugin>


### PR DESCRIPTION
* Updating the releases and snapshot urls. This will allow us to use existing plugins and push to the new central repository.


Tested locally for snapshot push and staging release(only that a deployment is correctly created).  

Failure is expected since it was uploaded locally without gpg signature.
![image](https://github.com/user-attachments/assets/01f057d7-3c32-4ada-948e-8b5ab7ca12fa)
