### PR TITLE
Use central publishing plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,17 +55,6 @@
     <url>https://issues.cask.co/browse/CDAP</url>
   </issueManagement>
 
-  <distributionManagement>
-    <repository>
-      <id>sonatype.release</id>
-      <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2</url>
-    </repository>
-    <snapshotRepository>
-      <id>sonatype.snapshots</id>
-      <url>https://central.sonatype.com/repository/maven-snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
-
   <properties>
     <jee.version>7</jee.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -118,16 +107,6 @@
   </dependencyManagement>
 
   <repositories>
-    <repository>
-      <id>sonatype</id>
-      <url>https://ossrh-staging-api.central.sonatype.com/content/groups/public</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
     <repository>
       <id>sonatype-snapshots</id>
       <url>https://central.sonatype.com/repository/maven-snapshots</url>
@@ -1150,29 +1129,15 @@
               </execution>
             </executions>
           </plugin>
-
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-release-plugin</artifactId>
-            <version>2.5.3</version>
-            <configuration>
-              <tag>v${releaseVersion}</tag>
-              <tagNameFormat>v@{project.version}</tagNameFormat>
-              <autoVersionSubmodules>true</autoVersionSubmodules>
-              <!-- releaseProfiles configuration will actually force a Maven profile
-                – the `releases` profile – to become active during the Release process. -->
-              <releaseProfiles>releases</releaseProfiles>
-            </configuration>
-          </plugin>
-
-          <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.14</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.8.0</version>
             <extensions>true</extensions>
             <configuration>
-              <nexusUrl>https://ossrh-staging-api.central.sonatype.com</nexusUrl>
-              <serverId>sonatype.release</serverId>
+              <publishingServerId>sonatype.release</publishingServerId>
+              <autoPublish>false</autoPublish>
+              <ignorePublishedComponents>true</ignorePublishedComponents>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
Migration to central sonatype repo.

* Using the central-publishing-maven-plugin to release the changes.
* Distribution management tag is no longer required with this plugin.
* sonatype repository can be removed since we are pulling from central.
* sonatype-snapshots pointed to https://central.sonatype.com/repository/maven-snapshots. This was done as part of the last PR.