### PR TITLE
removing another instance of Htrace

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -417,6 +417,10 @@
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.htrace</groupId>
+          <artifactId>htrace-core</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
This is the final htrace

On mvn dependency tree, it's not found in compile scope.