### PR TITLE
[PLUGIN-1931] Add necessary condition to prevent query job when appropriate parameters are empty

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/PartitionedBigQueryInputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/PartitionedBigQueryInputFormat.java
@@ -182,6 +182,12 @@ public class PartitionedBigQueryInputFormat extends AbstractBigQueryInputFormat<
       String datasetProject, String dataset, String table, String limit, String orderBy,
       Boolean isPartitionFilterRequired, StandardTableDefinition tableDefinition) {
 
+    if (Strings.isNullOrEmpty(filter) && Strings.isNullOrEmpty(orderBy) && Strings.isNullOrEmpty(
+        limit)
+        && Strings.isNullOrEmpty(partitionFromDate) && Strings.isNullOrEmpty(partitionToDate)) {
+      return null;
+    }
+
     RangePartitioning rangePartitioning = tableDefinition.getRangePartitioning();
     TimePartitioning timePartitioning = tableDefinition.getTimePartitioning();
     StringBuilder condition = new StringBuilder();

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/source/PartitionedBigQueryInputFormatTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/source/PartitionedBigQueryInputFormatTest.java
@@ -34,13 +34,15 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PartitionedBigQueryInputFormatTest {
+
   private static final String TEST_PROJECT = "test-project";
   private static final String TEST_DATASET = "test-dataset";
   private static final String TEST_TABLE = "test-table";
   private static final String TEST_FILTER = "age > 10";
   private static final String TEST_LIMIT = "100";
   private static final String TEST_ORDER_BY = "name asc";
-  private static final String TEST_TABLE_SPEC = String.format("%s.%s.%s", TEST_PROJECT, TEST_DATASET, TEST_TABLE);
+  private static final String TEST_TABLE_SPEC = String.format("%s.%s.%s", TEST_PROJECT,
+      TEST_DATASET, TEST_TABLE);
   private static final String TEST_FROM_DATE = "2025-01-01";
   private static final String TEST_TO_DATE = "2025-01-02";
   private static final String TEST_PARTITION_CONDITION =
@@ -125,17 +127,6 @@ public class PartitionedBigQueryInputFormatTest {
   }
 
   @Test
-  public void testGenerateQuery_NoOptions() {
-    String expectedQuery = String.format("select * from %s", TEST_TABLE_SPEC);
-
-    String generatedQuery = format.generateQuery(null, null,
-        null, TEST_PROJECT, TEST_DATASET, TEST_TABLE,
-        null, null,
-        false, mockTableDefinition);
-    Assert.assertEquals(expectedQuery, generatedQuery);
-  }
-
-  @Test
   public void testGenerateQuery_AllOptions() {
     String expectedQuery = String.format("select * from %s where %s order by %s limit %s",
         TEST_TABLE_SPEC, TEST_FILTER, TEST_ORDER_BY, TEST_LIMIT);
@@ -160,38 +151,6 @@ public class PartitionedBigQueryInputFormatTest {
         TEST_PROJECT, TEST_DATASET, TEST_TABLE,
         null, null,
         false, mockTableDefinition);
-    Assert.assertEquals(expectedQuery, generatedQuery);
-  }
-
-
-  @Test
-  public void testGenerateQuery_TimePartitionRequiredNoDates() {
-    when(mockTableDefinition.getTimePartitioning()).thenReturn(mockTimePartitioning);
-    when(mockTimePartitioning.getField()).thenReturn(null);
-
-    String expectedQuery = String.format("select * from %s where %s",
-        TEST_TABLE_SPEC, TEST_DEFAULT_TIME_CONDITION);
-
-    String generatedQuery = format.generateQuery(null, null,
-        null, TEST_PROJECT, TEST_DATASET, TEST_TABLE,
-        null, null,
-        true, mockTableDefinition);
-    Assert.assertEquals(expectedQuery, generatedQuery);
-  }
-
-  @Test
-  public void testGenerateQuery_RangePartitionRequiredNoDates() {
-    when(mockTableDefinition.getTimePartitioning()).thenReturn(null);
-    when(mockTableDefinition.getRangePartitioning()).thenReturn(mockRangePartitioning);
-    when(mockRangePartitioning.getField()).thenReturn("range_col");
-
-    String expectedQuery = String.format("select * from %s where %s",
-        TEST_TABLE_SPEC, TEST_DEFAULT_RANGE_CONDITION);
-
-    String generatedQuery = format.generateQuery(null, null, null,
-        TEST_PROJECT, TEST_DATASET, TEST_TABLE,
-        null, null,
-        true, mockTableDefinition);
     Assert.assertEquals(expectedQuery, generatedQuery);
   }
 
@@ -229,21 +188,6 @@ public class PartitionedBigQueryInputFormatTest {
   }
 
   @Test
-  public void testGenerateQuery_TimeUnitPartitionRequiredNoDates() {
-    when(mockTableDefinition.getTimePartitioning()).thenReturn(mockTimePartitioning);
-    when(mockTimePartitioning.getField()).thenReturn(TEST_TIME_UNIT_COL);
-
-    String expectedQuery = String.format("select * from %s where %s",
-        TEST_TABLE_SPEC, TEST_DEFAULT_TIME_UNIT_CONDITION);
-
-    String generatedQuery = format.generateQuery(null, null, null,
-        TEST_PROJECT, TEST_DATASET, TEST_TABLE,
-        null, null,
-        true, mockTableDefinition);
-    Assert.assertEquals(expectedQuery, generatedQuery);
-  }
-
-  @Test
   public void testGenerateQuery_TimePartitionFilterNotRequiredWithDates() {
     when(mockTableDefinition.getTimePartitioning()).thenReturn(mockTimePartitioning);
     when(mockTimePartitioning.getField()).thenReturn(null);
@@ -260,11 +204,48 @@ public class PartitionedBigQueryInputFormatTest {
   }
 
   @Test
-  public void testGenerateQuery_TimePartitionFilterNotRequiredNoDates() {
-    when(mockTableDefinition.getTimePartitioning()).thenReturn(mockTimePartitioning);
+  public void testGenerateQuery_NoOptions_ShouldReturnNull() {
+    String generatedQuery = format.generateQuery(null, null,
+        null, TEST_PROJECT, TEST_DATASET, TEST_TABLE,
+        null, null,
+        false, mockTableDefinition);
+    Assert.assertNull("Query should be null if no filters or options are set.", generatedQuery);
+  }
 
-    String expectedQuery = String.format("select * from %s", TEST_TABLE_SPEC);
-    String generatedQuery = format.generateQuery(null, null, null,
+  @Test
+  public void testGenerateQuery_WithLimitOnly_ShouldAssertQuery() {
+    String expectedQuery = String.format("select * from %s limit %s", TEST_TABLE_SPEC,
+        TEST_LIMIT);
+
+    String generatedQuery = format.generateQuery(null, null,
+        null, TEST_PROJECT, TEST_DATASET, TEST_TABLE,
+        TEST_LIMIT, null,
+        false, mockTableDefinition);
+    Assert.assertEquals(expectedQuery, generatedQuery);
+  }
+
+  @Test
+  public void testGenerateQuery_WithOrderByOnly_ShouldAssertQuery() {
+    String expectedQuery = String.format("select * from %s order by %s", TEST_TABLE_SPEC,
+        TEST_ORDER_BY);
+
+    String generatedQuery = format.generateQuery(null, null,
+        null, TEST_PROJECT, TEST_DATASET, TEST_TABLE,
+        null, TEST_ORDER_BY,
+        false, mockTableDefinition);
+    Assert.assertEquals(expectedQuery, generatedQuery);
+  }
+
+  @Test
+  public void testGenerateQuery_TimePartitionNotRequired_WithDates_ShouldAssertQuery() {
+    when(mockTableDefinition.getTimePartitioning()).thenReturn(mockTimePartitioning);
+    when(mockTimePartitioning.getField()).thenReturn(null);
+
+    String expectedQuery = String.format("select * from %s where (%s)",
+        TEST_TABLE_SPEC,
+        TEST_PARTITION_CONDITION);
+
+    String generatedQuery = format.generateQuery(TEST_FROM_DATE, TEST_TO_DATE, null,
         TEST_PROJECT, TEST_DATASET, TEST_TABLE,
         null, null,
         false, mockTableDefinition);
@@ -272,15 +253,77 @@ public class PartitionedBigQueryInputFormatTest {
   }
 
   @Test
-  public void testGenerateQuery_RangePartitionFilterNotRequired() {
-    when(mockTableDefinition.getRangePartitioning()).thenReturn(mockRangePartitioning);
+  public void testGenerateQuery_TimePartitionRequired_WithFilterOnly_ShouldAssertQuery() {
+    when(mockTableDefinition.getTimePartitioning()).thenReturn(mockTimePartitioning);
+    when(mockTimePartitioning.getField()).thenReturn(null);
 
-    String expectedQuery = String.format("select * from %s", TEST_TABLE_SPEC);
+    String expectedQuery = String.format("select * from %s where %s and (%s)",
+        TEST_TABLE_SPEC, TEST_DEFAULT_TIME_CONDITION, TEST_FILTER);
+
+    String generatedQuery = format.generateQuery(null, null,
+        TEST_FILTER, TEST_PROJECT, TEST_DATASET, TEST_TABLE,
+        null, null,
+        true, mockTableDefinition);
+    Assert.assertEquals(expectedQuery, generatedQuery);
+  }
+
+  @Test
+  public void testGenerateQuery_RangePartitionRequiredAndFilter() {
+    when(mockTableDefinition.getRangePartitioning()).thenReturn(mockRangePartitioning);
+    when(mockRangePartitioning.getField()).thenReturn("range_col");
+
+    String expectedQuery = String.format("select * from %s where %s and (%s)",
+        TEST_TABLE_SPEC, TEST_DEFAULT_RANGE_CONDITION, TEST_FILTER);
+
+    String generatedQuery = format.generateQuery(null, null, TEST_FILTER,
+        TEST_PROJECT, TEST_DATASET, TEST_TABLE,
+        null, null,
+        true, mockTableDefinition);
+    Assert.assertEquals(expectedQuery, generatedQuery);
+  }
+
+  @Test
+  public void testGenerateQuery_RangePartitionRequiredWithLimit() {
+    when(mockTableDefinition.getRangePartitioning()).thenReturn(mockRangePartitioning);
+    when(mockRangePartitioning.getField()).thenReturn("range_col");
+
+    String expectedQuery = String.format("select * from %s where %s limit %s",
+        TEST_TABLE_SPEC, TEST_DEFAULT_RANGE_CONDITION, TEST_LIMIT);
 
     String generatedQuery = format.generateQuery(null, null, null,
         TEST_PROJECT, TEST_DATASET, TEST_TABLE,
+        TEST_LIMIT, null,
+        true, mockTableDefinition);
+    Assert.assertEquals(expectedQuery, generatedQuery);
+  }
+
+  @Test
+  public void testGenerateQuery_TimeUnitPartitionRequiredAndFilter() {
+    when(mockTableDefinition.getTimePartitioning()).thenReturn(mockTimePartitioning);
+    when(mockTimePartitioning.getField()).thenReturn(TEST_TIME_UNIT_COL);
+
+    String expectedQuery = String.format("select * from %s where %s and (%s)",
+        TEST_TABLE_SPEC, TEST_DEFAULT_TIME_UNIT_CONDITION, TEST_FILTER);
+
+    String generatedQuery = format.generateQuery(null, null, TEST_FILTER,
+        TEST_PROJECT, TEST_DATASET, TEST_TABLE,
         null, null,
-        false, mockTableDefinition);
+        true, mockTableDefinition);
+    Assert.assertEquals(expectedQuery, generatedQuery);
+  }
+
+  @Test
+  public void testGenerateQuery_TimeUnitPartitionRequiredWithLimit() {
+    when(mockTableDefinition.getTimePartitioning()).thenReturn(mockTimePartitioning);
+    when(mockTimePartitioning.getField()).thenReturn(TEST_TIME_UNIT_COL);
+
+    String expectedQuery = String.format("select * from %s where %s limit %s",
+        TEST_TABLE_SPEC, TEST_DEFAULT_TIME_UNIT_CONDITION, TEST_LIMIT);
+
+    String generatedQuery = format.generateQuery(null, null, null,
+        TEST_PROJECT, TEST_DATASET, TEST_TABLE,
+        TEST_LIMIT, null,
+        true, mockTableDefinition);
     Assert.assertEquals(expectedQuery, generatedQuery);
   }
 }


### PR DESCRIPTION
In previous version, if a user provided no filters, no limits, and no partition dates, the code would still execute the full logic, only to determine at the end that the query should default to reading the source table directly (select * from "table") and creates a temporary table. But in such cases, there is no need to create a temporary table. Hence, added this check.

Testing:
1. Created a pipeline with BQ source plugin using a table having required partitioning filter as true. Provided no filter, partitioning inputs, limit or order by clauses. The preview/deployment run is successful.
2. Created a pipeline with BQ source plugin using a table having required partitioning filter as true. Provided filter, but no partitioning inputs, limit or order by clauses. The preview/deployment run is successful.
3. Created a pipeline with BQ source plugin using a table having required partitioning filter as false. Provided no filter, partitioning inputs, limit or order by clauses. The preview/deployment run is successful.
4. Created a pipeline with BQ source plugin using a table having required partitioning filter as false. Provided filter, limit but no partitioning inputs, order by clauses. The preview/deployment run is successful.  