### PR TITLE
[🍒][PLUGIN-1945] Skip bucket creation if exist (copy/move action)

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/gcs/StorageClient.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/StorageClient.java
@@ -146,6 +146,18 @@ public class StorageClient {
    * @param cmekKeyName  the name of the cmek key
    */
   public void createBucketIfNotExists(GCSPath path, @Nullable String location, @Nullable CryptoKeyName cmekKeyName) {
+    // Skip bucket creation if bucket already exists.
+    try {
+      if (storage.get(path.getBucket()) != null) {
+        LOG.trace("Bucket {} already exists, skipping creation.", path.getBucket());
+        return;
+      }
+    } catch (StorageException e) {
+      // do not throw error if unable to access bucket for backward compatibility.
+      LOG.warn("Getting unexpected error code {}: {} when checking if bucket {} exists. Attempting to create bucket.",
+          e.getCode(), e.getMessage(), path.getBucket(), e);
+    }
+    // Fallback to bucket creations when get returns null or throws exception.
     try {
       GCPUtils.createBucket(storage, path.getBucket(), location, cmekKeyName);
       LOG.info("Bucket {} has been created successfully", path.getBucket());
@@ -157,7 +169,7 @@ public class StorageClient {
                  e.getMessage(), path.getUri());
       } else {
         String errorReason =
-          String.format("Unable to create bucket %s. Ensure you entered the correct bucket path and " +
+          String.format("Unable to create or get bucket %s. Ensure you entered the correct bucket path and " +
             "have permissions for it.", path.getBucket());
         throw GCPErrorDetailsProviderUtil.getHttpResponseExceptionDetailsFromChain(e, errorReason, ErrorType.UNKNOWN,
           true, GCPUtils.GCS_SUPPORTED_DOC_URL);


### PR DESCRIPTION
cherry-pick for [6.11]

commit : e1b76afdc0716e91d6ef5d82f1f5881eccc4bb47 (this the merge commit)
pull request : #1596

---

## Skip bucket creation if exist (copy/move action)

Jira : [PLUGIN-1945](https://cdap.atlassian.net/browse/PLUGIN-1945)

### Description

if the user does not have `storage.buckets.create` the flow fails with 403 error, bucket creation should be skipped if the bucket already exists.

---

### Code change

- Modified `StorageClient.java`

[PLUGIN-1945]: https://cdap.atlassian.net/browse/PLUGIN-1945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ