### PR TITLE
[Security Vulnerability] CVE-2024-47561: Upgrade org.apache.avro:avro to version 1.11.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
   <properties>
     <jee.version>7</jee.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <avro.version>1.11.0</avro.version>
+    <avro.version>1.11.4</avro.version>
     <bigquery.connector.hadoop3.version>hadoop3-1.2.0</bigquery.connector.hadoop3.version>
     <commons.codec.version>1.4</commons.codec.version>
     <cdap.version>6.11.0</cdap.version>


### PR DESCRIPTION
context: [CVE-2024-47561](https://nvd.nist.gov/vuln/detail/CVE-2024-47561)

Similar hydrator-plugins PR : https://github.com/cdapio/hydrator-plugins/pull/1893

#### Testing 

- CDAP E2E Tests

- Unit Tests

- Sanity check on cdap-sandbox