### PR TITLE
Enhance error handling in DelegatingMultiSinkOutputCommitter

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/DelegatingMultiSinkOutputCommitter.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/DelegatingMultiSinkOutputCommitter.java
@@ -23,6 +23,8 @@ import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.JobStatus;
 import org.apache.hadoop.mapreduce.OutputCommitter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -35,6 +37,7 @@ import java.util.Map;
  * Delegated instances are supplied along with a schema, which is used to configure the commit operation.
  */
 public class DelegatingMultiSinkOutputCommitter extends OutputCommitter {
+  private static final Logger LOG = LoggerFactory.getLogger(DelegatingMultiSinkOutputCommitter.class);
   private final Map<String, OutputCommitter> committerMap;
   private final Map<String, Schema> schemaMap;
   private final String projectName;
@@ -99,18 +102,28 @@ public class DelegatingMultiSinkOutputCommitter extends OutputCommitter {
   @Override
   public void commitTask(TaskAttemptContext taskAttemptContext) throws IOException {
     for (String tableName : committerMap.keySet()) {
-      configureContext(taskAttemptContext, tableName);
-
-      committerMap.get(tableName).commitTask(taskAttemptContext);
+      try {
+        configureContext(taskAttemptContext, tableName);
+        committerMap.get(tableName).commitTask(taskAttemptContext);
+      } catch (IOException e) {
+        LOG.warn("BigQuery multi-sink table '{}' failed during task commit. Reason: {}",
+                 tableName, getFailureReason(e), e);
+        throw e;
+      }
     }
   }
 
   @Override
   public void commitJob(JobContext jobContext) throws IOException {
     for (String tableName : committerMap.keySet()) {
-      configureContext(jobContext, tableName);
-
-      committerMap.get(tableName).commitJob(jobContext);
+      try {
+        configureContext(jobContext, tableName);
+        committerMap.get(tableName).commitJob(jobContext);
+      } catch (IOException e) {
+        LOG.warn("BigQuery multi-sink table '{}' failed during job commit. Reason: {}",
+                 tableName, getFailureReason(e), e);
+        throw e;
+      }
     }
   }
 
@@ -167,5 +180,13 @@ public class DelegatingMultiSinkOutputCommitter extends OutputCommitter {
                                                tableName,
                                                gcsPath,
                                                fields);
+  }
+
+  private String getFailureReason(IOException exception) {
+    Throwable rootCause = exception;
+    while (rootCause.getCause() != null) {
+      rootCause = rootCause.getCause();
+    }
+    return rootCause.getMessage() == null ? exception.getMessage() : rootCause.getMessage();
   }
 }


### PR DESCRIPTION
This pull request improves error handling and logging in the `DelegatingMultiSinkOutputCommitter` class for BigQuery multi-sink operations. The main focus is to provide more informative log messages when task or job commits fail, making it easier to diagnose issues.

**Enhanced error handling and logging:**

* Added a `Logger` instance (`LOG`) using SLF4J to the `DelegatingMultiSinkOutputCommitter` class for logging warnings. [[1]](diffhunk://#diff-9915e9b2c1184584ecab1075a66cb1d39aa98b84cd786dce71237dc1a9e9acc0R26-R27) [[2]](diffhunk://#diff-9915e9b2c1184584ecab1075a66cb1d39aa98b84cd786dce71237dc1a9e9acc0R40)
* Wrapped `commitTask` and `commitJob` calls in try-catch blocks to log warnings with detailed failure reasons when an `IOException` occurs, then re-throw the exception.
* Introduced a private `getFailureReason` helper method to extract the root cause message from an `IOException` for clearer log output.