### PR TITLE
[PLUGIN-1948] Fix ClassCastException in BigQuery source plugin for table definition

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/PartitionedBigQueryInputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/PartitionedBigQueryInputFormat.java
@@ -24,6 +24,7 @@ import com.google.api.services.bigquery.model.Table;
 import com.google.api.services.bigquery.model.TableReference;
 import com.google.cloud.bigquery.RangePartitioning;
 import com.google.cloud.bigquery.StandardTableDefinition;
+import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.TableDefinition.Type;
 import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.hadoop.io.bigquery.AbstractBigQueryInputFormat;
@@ -146,7 +147,7 @@ public class PartitionedBigQueryInputFormat extends AbstractBigQueryInputFormat<
         readTimeout);
     Type type = Objects.requireNonNull(bigQueryTable).getDefinition().getType();
     Boolean isPartitionFilterRequired = bigQueryTable.getRequirePartitionFilter();
-    StandardTableDefinition tableDefinition = Objects.requireNonNull(bigQueryTable).getDefinition();
+    TableDefinition tableDefinition = Objects.requireNonNull(bigQueryTable).getDefinition();
 
     String query;
     if (type == Type.VIEW || type == Type.MATERIALIZED_VIEW || type == Type.EXTERNAL) {
@@ -156,7 +157,7 @@ public class PartitionedBigQueryInputFormat extends AbstractBigQueryInputFormat<
       query = generateQuery(partitionFromDate, partitionToDate, filter, datasetProjectId,
           datasetId,
           tableName, limit, orderBy,
-          isPartitionFilterRequired, tableDefinition);
+          isPartitionFilterRequired, (StandardTableDefinition) tableDefinition);
     }
 
     if (query != null) {


### PR DESCRIPTION
When fetching table metadata, the plugin incorrectly assumes all BigQuery tables are standard tables and attempts to cast the TableDefinition directly to a StandardTableDefinition - [link](https://github.com/data-integrations/google-cloud/blob/develop/src/main/java/io/cdap/plugin/gcp/bigquery/source/PartitionedBigQueryInputFormat.java#L149).

The pipeline crashes with the following error:
```
java.lang.ClassCastException: class com.google.cloud.bigquery.AutoValue_MaterializedViewDefinition cannot be cast to class com.google.cloud.bigquery.StandardTableDefinition
```

This PR fixes this issue.

**Testing**

- Created a pipeline with BQ source and added materializing view as the table. Successfully ran the preview and pipeline deployment.

Also tested the below to verify non materializing view (standard table) scenarios:
- Created a pipeline with BQ source and added range-partitioning table with & without required paritioning filter as true. Successfully ran the preview and pipeline deployment.
- Created a pipeline with BQ source and added ingestion partitioning table with required paritioning filter as true. Successfully ran the preview and pipeline deployment.