### PR TITLE
[PLUGIN-1948] Handle unsupported BigQuery table types gracefully  in PartitionedBigQueryInputFormat

### DIFF
--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/PartitionedBigQueryInputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/PartitionedBigQueryInputFormat.java
@@ -157,7 +157,7 @@ public class PartitionedBigQueryInputFormat extends AbstractBigQueryInputFormat<
       query = generateQuery(partitionFromDate, partitionToDate, filter, datasetProjectId,
           datasetId,
           tableName, limit, orderBy,
-          isPartitionFilterRequired, (StandardTableDefinition) tableDefinition);
+          isPartitionFilterRequired, tableDefinition);
     }
 
     if (query != null) {
@@ -181,7 +181,7 @@ public class PartitionedBigQueryInputFormat extends AbstractBigQueryInputFormat<
   @VisibleForTesting
   String generateQuery(String partitionFromDate, String partitionToDate, String filter,
       String datasetProject, String dataset, String table, String limit, String orderBy,
-      Boolean isPartitionFilterRequired, StandardTableDefinition tableDefinition) {
+      Boolean isPartitionFilterRequired, TableDefinition tableDef) {
 
     if (Strings.isNullOrEmpty(filter) && Strings.isNullOrEmpty(orderBy) && Strings.isNullOrEmpty(
         limit)
@@ -189,6 +189,13 @@ public class PartitionedBigQueryInputFormat extends AbstractBigQueryInputFormat<
       return null;
     }
 
+    if (!(tableDef instanceof StandardTableDefinition)) {
+      throw new IllegalArgumentException(
+          String.format("Unsupported BigQuery table type for filtering/partitioning: %s. " +
+              "Cannot apply filters, limits, or ordering.", tableDef.getType()));
+    }
+
+    StandardTableDefinition tableDefinition = (StandardTableDefinition) tableDef;
     RangePartitioning rangePartitioning = tableDefinition.getRangePartitioning();
     TimePartitioning timePartitioning = tableDefinition.getTimePartitioning();
     StringBuilder condition = new StringBuilder();


### PR DESCRIPTION
**Problem:**
PR #1607 fixed the initial `ClassCastException` that occurred when incorrectly assuming all BigQuery tables are standard tables. However, the code still blindly casts the `TableDefinition` to a `StandardTableDefinition` inside `processQuery` before passing it to `generateQuery`.

**Solution:**
This follow-up PR refactors `PartitionedBigQueryInputFormat.java` to restore backward compatibility and improve type safety:
1. Removes the unsafe cast in `processQuery` and passes the generic `TableDefinition` to `generateQuery`.
2. Moves the `StandardTableDefinition` cast inside `generateQuery`, after checking if any query modifiers (filters, limits, order by, partitions) are present.
3. If no modifiers are present, it returns `null`, allowing other types like`SNAPSHOT` and `MODEL` tables to be read directly without crashing.
4. If a user does attempt to apply filters/limits/ordering to an unsupported table type, it safely catches the type using `instanceof` and throws a descriptive error instead of a `ClassCastException`.


**Testing**

- Created a pipeline with BQ source, added a Snapshot in table field. Did not add any filtering fields. Ran preview successfully.
- Created a pipeline with BQ source, added a Snapshot in table field. Added "1=1" under filter field. Preview threw expected error:
```
Error occurred in the phase: 'Splitting'. java.lang.IllegalArgumentException: Unsupported BigQuery table type for filtering/partitioning: SNAPSHOT. Cannot apply filters, limits, or ordering.
```
- Created a pipeline with BQ source and added ingestion partitioning table with required partitioning filter as true. Successfully ran the preview with & without filters successfully.
- Created a pipeline with BQ source and added materializing view as the table. Successfully ran the preview with & without filters successfully.
- Created a pipeline with BQ source and added range-partitioning table with & without required partitioning filter as true. Successfully ran the preview with & without filters successfully.