### PR TITLE
Commenting out verify goal for proper cucumber report generation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>google-cloud</artifactId>
-  <version>0.23.7</version>
+  <version>0.23.8-SNAPSHOT</version>
   <name>Google Cloud Plugins</name>
   <packaging>jar</packaging>
   <description>Plugins for Google Big Query</description>
@@ -1165,7 +1165,8 @@
           <execution>
             <goals>
               <goal>integration-test</goal>
-              <goal>verify</goal>
+              <!-- Commented out verify goal to allow Cucumber reports to generate correctly even when tests fail -->
+              <!-- <goal>verify</goal> -->
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
This change modifies the pom.xml to ensure that Cucumber test reports are generated even when there are test failures.

Currently, the verify goal in the maven-failsafe-plugin configuration causes the build to halt on test failures, which prevents the Cucumber report generation from completing. By commenting out the verify goal, the build will now proceed and generate the reports, which is crucial for debugging failures.
