### PR TITLE
Upgrade snappy-java to 1.1.10.5 to fix CVE-2023-34453

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -806,7 +806,7 @@
     <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
-      <version>1.1.7.2</version>
+      <version>1.1.10.5</version>
     </dependency>
     <!-- Start: dependency for Google PubSub Streaming Source -->
     <dependency>


### PR DESCRIPTION
This PR upgrades snappy-java to 1.1.10.5 to remediate CVE-2023-34453. Note: avro is already at version 1.11.4 in develop branch.