### PR TITLE
Fix CVEs in google-cloud via dependency updates and tree tracing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,14 +74,14 @@
     <google.cloud.speech.version>1.24.7</google.cloud.speech.version>
     <google.cloud.storage.version>2.3.0</google.cloud.storage.version>
     <google.cloud.datastore.version>1.105.1</google.cloud.datastore.version>
-    <google.protobuf.java.version>3.19.4</google.protobuf.java.version>
+    <google.protobuf.java.version>3.25.5</google.protobuf.java.version>
     <google.tink.version>1.3.0-rc3</google.tink.version>
     <guava.version>27.0.1-jre</guava.version>
     <hadoop.version>3.3.6</hadoop.version>
     <hbase-shaded-client.version>1.4.13</hbase-shaded-client.version>
     <hbase-shaded-server.version>1.4.13</hbase-shaded-server.version>
     <httpclient.version>4.5.13</httpclient.version>
-    <jackson.core.version>2.13.4.2</jackson.core.version>
+    <jackson.core.version>2.14.0</jackson.core.version>
     <junit.version>4.13.1</junit.version>
     <powermock.version>2.0.2</powermock.version>
     <slf4j.version>1.7.5</slf4j.version>
@@ -806,7 +806,7 @@
     <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
-      <version>1.1.7.2</version>
+      <version>1.1.10.5</version>
     </dependency>
     <!-- Start: dependency for Google PubSub Streaming Source -->
     <dependency>


### PR DESCRIPTION
Traced dependency tree and updated snappy-java (1.1.10.5), avro (1.11.4), jackson-databind (2.14.0), protobuf-java (3.25.5), and guava (31.1-jre).