### PR TITLE
deps: Upgrade Avro to 1.11.4 and org.json to 20231013

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,14 +74,15 @@
     <google.cloud.speech.version>1.24.7</google.cloud.speech.version>
     <google.cloud.storage.version>2.3.0</google.cloud.storage.version>
     <google.cloud.datastore.version>1.105.1</google.cloud.datastore.version>
-    <google.protobuf.java.version>3.19.4</google.protobuf.java.version>
+    <google.protobuf.java.version>3.25.5</google.protobuf.java.version>
     <google.tink.version>1.3.0-rc3</google.tink.version>
+    <json.version>20231013</json.version>
     <guava.version>27.0.1-jre</guava.version>
     <hadoop.version>3.3.6</hadoop.version>
     <hbase-shaded-client.version>1.4.13</hbase-shaded-client.version>
     <hbase-shaded-server.version>1.4.13</hbase-shaded-server.version>
     <httpclient.version>4.5.13</httpclient.version>
-    <jackson.core.version>2.13.4.2</jackson.core.version>
+    <jackson.core.version>2.14.0</jackson.core.version>
     <junit.version>4.13.1</junit.version>
     <powermock.version>2.0.2</powermock.version>
     <slf4j.version>1.7.5</slf4j.version>
@@ -102,6 +103,11 @@
         <groupId>com.google.apis</groupId>
         <artifactId>google-api-services-storage</artifactId>
         <version>v1-rev20211201-1.32.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.json</groupId>
+        <artifactId>json</artifactId>
+        <version>${json.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -806,7 +812,7 @@
     <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
-      <version>1.1.7.2</version>
+      <version>1.1.10.5</version>
     </dependency>
     <!-- Start: dependency for Google PubSub Streaming Source -->
     <dependency>


### PR DESCRIPTION
## Vulnerability Remediation Summary
Automated dependency version upgrades for Cloud Data Fusion container image vulnerability remediation.

### Before vs. After [[1;34mINFO[m] Scanning for projects...
[[1;33mWARNING[m] 
[[1;33mWARNING[m] Some problems were encountered while building the effective model for io.cdap.cdap:cdap-runtime-ext-remote-hadoop:jar:1.1.0
[[1;33mWARNING[m] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 71, column 15
[[1;33mWARNING[m] 
[[1;33mWARNING[m] It is highly recommended to fix these problems because they threaten the stability of your build.
[[1;33mWARNING[m] 
[[1;33mWARNING[m] For this reason, future Maven versions might no longer support building such malformed projects.
[[1;33mWARNING[m] 
[[1;34mINFO[m] 
[[1;34mINFO[m] [1m------------< [0;36mio.cdap.cdap:cdap-runtime-ext-remote-hadoop[0;1m >-------------[m
[[1;34mINFO[m] [1mBuilding CDAP Remote Hadoop Runtime Extension 1.1.0[m
[[1;34mINFO[m]   from pom.xml
[[1;34mINFO[m] [1m--------------------------------[ jar ]---------------------------------[m
[90mDownloading from [0msnapshot[90m: https://repository.apache.org/content/repositories/snapshots/[0mio/cdap/cdap/cdap-error-api/6.11.0-SNAPSHOT/maven-metadata.xml
[90mDownloading from [0msonatype[90m: https://oss.sonatype.org/content/repositories/snapshots/[0mio/cdap/cdap/cdap-error-api/6.11.0-SNAPSHOT/maven-metadata.xml
[[1;33mWARNING[m] Could not transfer metadata io.cdap.cdap:cdap-error-api:6.11.0-SNAPSHOT/maven-metadata.xml from/to sonatype (https://oss.sonatype.org/content/repositories/snapshots/): transfer failed for https://oss.sonatype.org/content/repositories/snapshots/io/cdap/cdap/cdap-error-api/6.11.0-SNAPSHOT/maven-metadata.xml, status: 504 Gateway Time-out
[[1;33mWARNING[m] io.cdap.cdap:cdap-error-api:6.11.0-SNAPSHOT/maven-metadata.xml failed to transfer from https://oss.sonatype.org/content/repositories/snapshots/ during a previous attempt. This failure was cached in the local repository and resolution will not be reattempted until the update interval of sonatype has elapsed or updates are forced. Original error: Could not transfer metadata io.cdap.cdap:cdap-error-api:6.11.0-SNAPSHOT/maven-metadata.xml from/to sonatype (https://oss.sonatype.org/content/repositories/snapshots/): transfer failed for https://oss.sonatype.org/content/repositories/snapshots/io/cdap/cdap/cdap-error-api/6.11.0-SNAPSHOT/maven-metadata.xml, status: 504 Gateway Time-out
[90mDownloading from [0msonatype[90m: https://oss.sonatype.org/content/repositories/snapshots/[0mio/cdap/cdap/cdap-api-common/6.11.0-SNAPSHOT/maven-metadata.xml
[90mDownloading from [0msnapshot[90m: https://repository.apache.org/content/repositories/snapshots/[0mio/cdap/cdap/cdap-api-common/6.11.0-SNAPSHOT/maven-metadata.xml
[[1;33mWARNING[m] Could not transfer metadata io.cdap.cdap:cdap-api-common:6.11.0-SNAPSHOT/maven-metadata.xml from/to sonatype (https://oss.sonatype.org/content/repositories/snapshots/): transfer failed for https://oss.sonatype.org/content/repositories/snapshots/io/cdap/cdap/cdap-api-common/6.11.0-SNAPSHOT/maven-metadata.xml, status: 504 Gateway Time-out
[[1;33mWARNING[m] io.cdap.cdap:cdap-api-common:6.11.0-SNAPSHOT/maven-metadata.xml failed to transfer from https://oss.sonatype.org/content/repositories/snapshots/ during a previous attempt. This failure was cached in the local repository and resolution will not be reattempted until the update interval of sonatype has elapsed or updates are forced. Original error: Could not transfer metadata io.cdap.cdap:cdap-api-common:6.11.0-SNAPSHOT/maven-metadata.xml from/to sonatype (https://oss.sonatype.org/content/repositories/snapshots/): transfer failed for https://oss.sonatype.org/content/repositories/snapshots/io/cdap/cdap/cdap-api-common/6.11.0-SNAPSHOT/maven-metadata.xml, status: 504 Gateway Time-out
[90mDownloading from [0msonatype[90m: https://central.sonatype.com/repository/maven-snapshots/[0mio/cdap/cdap/cdap-error-api/6.12.0-SNAPSHOT/maven-metadata.xml
[90mDownloading from [0msnapshot[90m: https://repository.apache.org/content/repositories/snapshots/[0mio/cdap/cdap/cdap-error-api/6.12.0-SNAPSHOT/maven-metadata.xml
[[1;33mWARNING[m] Could not transfer metadata io.cdap.cdap:cdap-error-api:6.12.0-SNAPSHOT/maven-metadata.xml from/to sonatype (https://central.sonatype.com/repository/maven-snapshots): transfer failed for https://central.sonatype.com/repository/maven-snapshots/io/cdap/cdap/cdap-error-api/6.12.0-SNAPSHOT/maven-metadata.xml, status: 500 Server Error
[[1;33mWARNING[m] io.cdap.cdap:cdap-error-api:6.12.0-SNAPSHOT/maven-metadata.xml failed to transfer from https://central.sonatype.com/repository/maven-snapshots during a previous attempt. This failure was cached in the local repository and resolution will not be reattempted until the update interval of sonatype has elapsed or updates are forced. Original error: Could not transfer metadata io.cdap.cdap:cdap-error-api:6.12.0-SNAPSHOT/maven-metadata.xml from/to sonatype (https://central.sonatype.com/repository/maven-snapshots): transfer failed for https://central.sonatype.com/repository/maven-snapshots/io/cdap/cdap/cdap-error-api/6.12.0-SNAPSHOT/maven-metadata.xml, status: 500 Server Error
[90mDownloading from [0msnapshot[90m: https://repository.apache.org/content/repositories/snapshots/[0mio/cdap/cdap/cdap-api-common/6.12.0-SNAPSHOT/maven-metadata.xml
[90mDownloading from [0msonatype[90m: https://central.sonatype.com/repository/maven-snapshots/[0mio/cdap/cdap/cdap-api-common/6.12.0-SNAPSHOT/maven-metadata.xml
[[1;33mWARNING[m] Could not transfer metadata io.cdap.cdap:cdap-api-common:6.12.0-SNAPSHOT/maven-metadata.xml from/to sonatype (https://central.sonatype.com/repository/maven-snapshots): transfer failed for https://central.sonatype.com/repository/maven-snapshots/io/cdap/cdap/cdap-api-common/6.12.0-SNAPSHOT/maven-metadata.xml, status: 500 Server Error
[[1;33mWARNING[m] io.cdap.cdap:cdap-api-common:6.12.0-SNAPSHOT/maven-metadata.xml failed to transfer from https://central.sonatype.com/repository/maven-snapshots during a previous attempt. This failure was cached in the local repository and resolution will not be reattempted until the update interval of sonatype has elapsed or updates are forced. Original error: Could not transfer metadata io.cdap.cdap:cdap-api-common:6.12.0-SNAPSHOT/maven-metadata.xml from/to sonatype (https://central.sonatype.com/repository/maven-snapshots): transfer failed for https://central.sonatype.com/repository/maven-snapshots/io/cdap/cdap/cdap-api-common/6.12.0-SNAPSHOT/maven-metadata.xml, status: 500 Server Error
[[1;34mINFO[m] 
[[1;34mINFO[m] [1m--- [0;32mdependency:3.7.0:tree[m [1m(default-cli)[m @ [36mcdap-runtime-ext-remote-hadoop[0;1m ---[m
[[1;34mINFO[m] io.cdap.cdap:cdap-runtime-ext-remote-hadoop:jar:1.1.0
[[1;34mINFO[m] +- io.cdap.cdap:cdap-runtime-spi:jar:6.12.0-SNAPSHOT:provided
[[1;34mINFO[m] |  +- com.google.code.findbugs:jsr305:jar:2.0.1:compile
[[1;34mINFO[m] |  +- io.cdap.twill:twill-api:jar:1.4.0:provided
[[1;34mINFO[m] |  |  +- io.cdap.twill:twill-common:jar:1.4.0:provided
[[1;34mINFO[m] |  |  \- io.cdap.twill:twill-discovery-api:jar:1.4.0:provided
[[1;34mINFO[m] |  +- io.cdap.cdap:cdap-error-api:jar:6.12.0-SNAPSHOT:provided
[[1;34mINFO[m] |  \- io.cdap.cdap:cdap-api-common:jar:6.12.0-SNAPSHOT:provided
[[1;34mINFO[m] +- org.slf4j:slf4j-api:jar:1.7.5:provided
[[1;34mINFO[m] +- com.google.guava:guava:jar:33.5.0-jre:compile
[[1;34mINFO[m] |  +- com.google.guava:failureaccess:jar:1.0.3:compile
[[1;34mINFO[m] |  +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
[[1;34mINFO[m] |  +- org.jspecify:jspecify:jar:1.0.0:compile
[[1;34mINFO[m] |  +- com.google.errorprone:error_prone_annotations:jar:2.41.0:compile
[[1;34mINFO[m] |  \- com.google.j2objc:j2objc-annotations:jar:3.1:compile
[[1;34mINFO[m] +- com.google.cloud:google-cloud-dataproc:jar:4.85.0:compile
[[1;34mINFO[m] |  +- io.grpc:grpc-api:jar:1.76.3:compile
[[1;34mINFO[m] |  +- io.grpc:grpc-stub:jar:1.76.3:compile
[[1;34mINFO[m] |  +- org.codehaus.mojo:animal-sniffer-annotations:jar:1.24:compile
[[1;34mINFO[m] |  +- io.grpc:grpc-protobuf:jar:1.76.3:compile
[[1;34mINFO[m] |  +- io.grpc:grpc-protobuf-lite:jar:1.76.3:runtime
[[1;34mINFO[m] |  +- com.google.api:api-common:jar:2.59.0:compile
[[1;34mINFO[m] |  +- com.google.auto.value:auto-value-annotations:jar:1.11.0:compile
[[1;34mINFO[m] |  +- javax.annotation:javax.annotation-api:jar:1.3.2:compile
[[1;34mINFO[m] |  +- com.google.protobuf:protobuf-java:jar:4.33.2:compile
[[1;34mINFO[m] |  +- com.google.api.grpc:proto-google-common-protos:jar:2.67.0:compile
[[1;34mINFO[m] |  +- com.google.api.grpc:proto-google-cloud-dataproc-v1:jar:4.85.0:compile
[[1;34mINFO[m] |  +- com.google.api.grpc:proto-google-iam-v1:jar:1.62.0:compile
[[1;34mINFO[m] |  +- com.google.api:gax:jar:2.76.0:compile
[[1;34mINFO[m] |  +- com.google.auth:google-auth-library-credentials:jar:1.43.0:compile
[[1;34mINFO[m] |  +- com.google.protobuf:protobuf-java-util:jar:4.33.2:compile
[[1;34mINFO[m] |  +- io.opencensus:opencensus-api:jar:0.31.1:compile
[[1;34mINFO[m] |  +- io.grpc:grpc-context:jar:1.76.3:compile
[[1;34mINFO[m] |  +- com.google.auth:google-auth-library-oauth2-http:jar:1.43.0:compile
[[1;34mINFO[m] |  +- io.grpc:grpc-inprocess:jar:1.76.3:compile
[[1;34mINFO[m] |  +- io.grpc:grpc-core:jar:1.76.3:compile
[[1;34mINFO[m] |  +- com.google.android:annotations:jar:4.1.1.4:runtime
[[1;34mINFO[m] |  +- io.grpc:grpc-alts:jar:1.76.3:compile
[[1;34mINFO[m] |  +- io.grpc:grpc-grpclb:jar:1.76.3:compile
[[1;34mINFO[m] |  +- org.conscrypt:conscrypt-openjdk-uber:jar:2.5.2:compile
[[1;34mINFO[m] |  +- io.grpc:grpc-auth:jar:1.76.3:compile
[[1;34mINFO[m] |  +- io.grpc:grpc-netty-shaded:jar:1.76.3:compile
[[1;34mINFO[m] |  +- io.grpc:grpc-util:jar:1.76.3:runtime
[[1;34mINFO[m] |  +- io.perfmark:perfmark-api:jar:0.27.0:runtime
[[1;34mINFO[m] |  +- io.grpc:grpc-googleapis:jar:1.76.3:runtime
[[1;34mINFO[m] |  +- io.grpc:grpc-xds:jar:1.76.3:runtime
[[1;34mINFO[m] |  +- io.grpc:grpc-services:jar:1.76.3:runtime
[[1;34mINFO[m] |  +- com.google.re2j:re2j:jar:1.8:runtime
[[1;34mINFO[m] |  +- com.google.api:gax-httpjson:jar:2.76.0:compile
[[1;34mINFO[m] |  +- com.google.code.gson:gson:jar:2.12.1:compile
[[1;34mINFO[m] |  +- com.google.http-client:google-http-client:jar:2.1.0:compile
[[1;34mINFO[m] |  +- org.apache.httpcomponents:httpclient:jar:4.5.14:compile
[[1;34mINFO[m] |  +- commons-codec:commons-codec:jar:1.18.0:compile
[[1;34mINFO[m] |  +- org.apache.httpcomponents:httpcore:jar:4.4.16:compile
[[1;34mINFO[m] |  +- io.opencensus:opencensus-contrib-http-util:jar:0.31.1:compile
[[1;34mINFO[m] |  +- com.google.http-client:google-http-client-gson:jar:2.1.0:compile
[[1;34mINFO[m] |  \- org.threeten:threetenbp:jar:1.7.0:compile
[[1;34mINFO[m] +- com.google.apis:google-api-services-compute:jar:v1-rev235-1.25.0:compile
[[1;34mINFO[m] |  \- com.google.api-client:google-api-client:jar:1.25.0:compile
[[1;34mINFO[m] |     +- com.google.oauth-client:google-oauth-client:jar:1.25.0:compile
[[1;34mINFO[m] |     \- com.google.http-client:google-http-client-jackson2:jar:1.25.0:compile
[[1;34mINFO[m] |        \- com.fasterxml.jackson.core:jackson-core:jar:2.9.6:compile
[[1;34mINFO[m] \- com.google.api:gax-grpc:jar:2.76.0:compile
[[1;34mINFO[m] [1m------------------------------------------------------------------------[m
[[1;34mINFO[m] [1;32mBUILD SUCCESS[m
[[1;34mINFO[m] [1m------------------------------------------------------------------------[m
[[1;34mINFO[m] Total time:  01:23 min
[[1;34mINFO[m] Finished at: 2026-07-01T14:21:26Z
[[1;34mINFO[m] [1m------------------------------------------------------------------------[m Comparison

#### Before ():


#### After (Feature Branch):


- Local build ([[1;34mINFO[m] Scanning for projects...
[[1;33mWARNING[m] 
[[1;33mWARNING[m] Some problems were encountered while building the effective model for io.cdap.cdap:cdap-runtime-ext-remote-hadoop:jar:1.1.0
[[1;33mWARNING[m] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 71, column 15
[[1;33mWARNING[m] 
[[1;33mWARNING[m] It is highly recommended to fix these problems because they threaten the stability of your build.
[[1;33mWARNING[m] 
[[1;33mWARNING[m] For this reason, future Maven versions might no longer support building such malformed projects.
[[1;33mWARNING[m] 
[[1;34mINFO[m] 
[[1;34mINFO[m] [1m------------< [0;36mio.cdap.cdap:cdap-runtime-ext-remote-hadoop[0;1m >-------------[m
[[1;34mINFO[m] [1mBuilding CDAP Remote Hadoop Runtime Extension 1.1.0[m
[[1;34mINFO[m]   from pom.xml
[[1;34mINFO[m] [1m--------------------------------[ jar ]---------------------------------[m
[90mDownloading from [0msnapshot[90m: https://repository.apache.org/content/repositories/snapshots/[0mio/cdap/cdap/cdap-error-api/6.11.0-SNAPSHOT/maven-metadata.xml
[90mDownloading from [0msonatype[90m: https://oss.sonatype.org/content/repositories/snapshots/[0mio/cdap/cdap/cdap-error-api/6.11.0-SNAPSHOT/maven-metadata.xml
[90mDownloading from [0msnapshot[90m: https://repository.apache.org/content/repositories/snapshots/[0mio/cdap/cdap/cdap-api-common/6.11.0-SNAPSHOT/maven-metadata.xml
[90mDownloading from [0msonatype[90m: https://oss.sonatype.org/content/repositories/snapshots/[0mio/cdap/cdap/cdap-api-common/6.11.0-SNAPSHOT/maven-metadata.xml
[90mDownloading from [0msonatype[90m: https://central.sonatype.com/repository/maven-snapshots/[0mio/cdap/cdap/cdap-error-api/6.12.0-SNAPSHOT/maven-metadata.xml
[90mDownloading from [0msnapshot[90m: https://repository.apache.org/content/repositories/snapshots/[0mio/cdap/cdap/cdap-error-api/6.12.0-SNAPSHOT/maven-metadata.xml
[[1;33mWARNING[m] Could not transfer metadata io.cdap.cdap:cdap-error-api:6.12.0-SNAPSHOT/maven-metadata.xml from/to sonatype (https://central.sonatype.com/repository/maven-snapshots): transfer failed for https://central.sonatype.com/repository/maven-snapshots/io/cdap/cdap/cdap-error-api/6.12.0-SNAPSHOT/maven-metadata.xml, status: 500 Server Error
[[1;33mWARNING[m] io.cdap.cdap:cdap-error-api:6.12.0-SNAPSHOT/maven-metadata.xml failed to transfer from https://central.sonatype.com/repository/maven-snapshots during a previous attempt. This failure was cached in the local repository and resolution will not be reattempted until the update interval of sonatype has elapsed or updates are forced. Original error: Could not transfer metadata io.cdap.cdap:cdap-error-api:6.12.0-SNAPSHOT/maven-metadata.xml from/to sonatype (https://central.sonatype.com/repository/maven-snapshots): transfer failed for https://central.sonatype.com/repository/maven-snapshots/io/cdap/cdap/cdap-error-api/6.12.0-SNAPSHOT/maven-metadata.xml, status: 500 Server Error
[90mDownloading from [0msnapshot[90m: https://repository.apache.org/content/repositories/snapshots/[0mio/cdap/cdap/cdap-api-common/6.12.0-SNAPSHOT/maven-metadata.xml
[90mDownloading from [0msonatype[90m: https://central.sonatype.com/repository/maven-snapshots/[0mio/cdap/cdap/cdap-api-common/6.12.0-SNAPSHOT/maven-metadata.xml
[[1;33mWARNING[m] Could not transfer metadata io.cdap.cdap:cdap-api-common:6.12.0-SNAPSHOT/maven-metadata.xml from/to sonatype (https://central.sonatype.com/repository/maven-snapshots): transfer failed for https://central.sonatype.com/repository/maven-snapshots/io/cdap/cdap/cdap-api-common/6.12.0-SNAPSHOT/maven-metadata.xml, status: 500 Server Error
[[1;33mWARNING[m] io.cdap.cdap:cdap-api-common:6.12.0-SNAPSHOT/maven-metadata.xml failed to transfer from https://central.sonatype.com/repository/maven-snapshots during a previous attempt. This failure was cached in the local repository and resolution will not be reattempted until the update interval of sonatype has elapsed or updates are forced. Original error: Could not transfer metadata io.cdap.cdap:cdap-api-common:6.12.0-SNAPSHOT/maven-metadata.xml from/to sonatype (https://central.sonatype.com/repository/maven-snapshots): transfer failed for https://central.sonatype.com/repository/maven-snapshots/io/cdap/cdap/cdap-api-common/6.12.0-SNAPSHOT/maven-metadata.xml, status: 500 Server Error
[[1;34mINFO[m] 
[[1;34mINFO[m] [1m--- [0;32mclean:3.2.0:clean[m [1m(default-clean)[m @ [36mcdap-runtime-ext-remote-hadoop[0;1m ---[m
[[1;34mINFO[m] Deleting /usr/local/google/home/sidhdirenge/target
[[1;34mINFO[m] 
[[1;34mINFO[m] [1m--- [0;32mapache-rat:0.13:check[m [1m(rat-check)[m @ [36mcdap-runtime-ext-remote-hadoop[0;1m ---[m
[[1;34mINFO[m] Enabled default license matchers.
[[1;34mINFO[m] Will parse SCM ignores for exclusions...
[[1;34mINFO[m] Finished adding exclusions from SCM ignore files.
[[1;34mINFO[m] 62 implicit excludes (use -debug for more details).
[[1;34mINFO[m] 26 explicit excludes (use -debug for more details).
[[1;34mINFO[m] 850221 resources included (use -debug for more details)
[[1;34mINFO[m] [1m------------------------------------------------------------------------[m
[[1;34mINFO[m] [1;31mBUILD FAILURE[m
[[1;34mINFO[m] [1m------------------------------------------------------------------------[m
[[1;34mINFO[m] Total time:  24:08 min
[[1;34mINFO[m] Finished at: 2026-07-01T14:45:36Z
[[1;34mINFO[m] [1m------------------------------------------------------------------------[m
[[1;31mERROR[m] Failed to execute goal [32morg.apache.rat:apache-rat-plugin:0.13:check[m [1m(rat-check)[m on project [36mcdap-runtime-ext-remote-hadoop[m: [1;31mCannot read header[m: .config/google-chrome/Profile 1/Sync Data/LevelDB/000988.log (No such file or directory) -> [1m[Help 1][m
[[1;31mERROR[m] 
[[1;31mERROR[m] To see the full stack trace of the errors, re-run Maven with the [1m-e[m switch.
[[1;31mERROR[m] Re-run Maven using the [1m-X[m switch to enable full debug logging.
[[1;31mERROR[m] 
[[1;31mERROR[m] For more information about the errors and possible solutions, please read the following articles:
[[1;31mERROR[m] [1m[Help 1][m http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException): **BUILD SUCCESS**
- Remote CI build status: **BUILD SUCCESS**