### PR TITLE
[🍒]  Ignore 409 Conflict on bucket creation retry in BigQuery plugin for release/0.24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>google-cloud</artifactId>
-  <version>0.24.6</version>
+  <version>0.24.7-SNAPSHOT</version>
   <name>Google Cloud Plugins</name>
   <packaging>jar</packaging>
   <description>Plugins for Google Big Query</description>

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySourceUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySourceUtils.java
@@ -87,28 +87,41 @@ public class BigQuerySourceUtils {
       // By default, this option is false, meaning the job can not delete the bucket. So enable it only when bucket name
       // is not provided.
       configuration.setBoolean("fs.gs.bucket.delete.enable", true);
-      GCPUtils.createBucket(storage, bucket, dataset.getLocation(), cmekKeyName);
+      createBucket(storage, bucket, dataset, cmekKeyName);
     } else if (storage != null && storage.get(bucket) == null) {
-      try {
-        GCPUtils.createBucket(storage, bucket, dataset.getLocation(), cmekKeyName);
-      } catch (StorageException e) {
-        if (e.getCode() == 409) {
-          // A conflict means the bucket already exists
-          // This most likely means multiple stages in the same pipeline are trying to create the same bucket.
-          // Ignore this and move on, since all that matters is that the bucket exists.
-          return bucket;
-        }
-        String errorMessage = String.format("Unable to create Cloud Storage bucket '%s' in the same "
-                + "location ('%s') as BigQuery dataset '%s'. " + "Please use a bucket "
-                + "that is in the same location as the dataset. For more details, see %s",
-            bucket, dataset.getLocation(), dataset.getDatasetId().getDataset(),
-            GCPUtils.GCS_SUPPORTED_DOC_URL);
-        throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN),
-          errorMessage, e.getMessage(), ErrorType.USER, true, ErrorCodeType.HTTP,
-            String.valueOf(e.getCode()), GCPUtils.GCS_SUPPORTED_DOC_URL, e);
-      }
+      createBucket(storage, bucket, dataset, cmekKeyName);
     }
     return bucket;
+  }
+
+  private static void createBucket(@Nullable Storage storage,
+                                   String bucket,
+                                   Dataset dataset,
+                                   @Nullable CryptoKeyName cmekKeyName) {
+    if (storage == null) {
+      return;
+    }
+    try {
+      GCPUtils.createBucket(storage, bucket, dataset.getLocation(), cmekKeyName);
+    } catch (StorageException e) {
+      if (e.getCode() == 409) {
+        // A conflict means the bucket already exists.
+        // This most likely means multiple stages in the same pipeline are trying to create the same bucket,
+        // or a retry occurred after a successful bucket creation.
+        // Ignore this and move on, since all that matters is that the bucket exists.
+        LOG.debug("Bucket '{}' already exists, ignoring 409 Conflict: {}", bucket, e.getMessage());
+        return;
+      }
+      String datasetName = dataset.getDatasetId() != null ? dataset.getDatasetId().getDataset() : "";
+      String errorMessage = String.format("Unable to create Cloud Storage bucket '%s' in the same "
+              + "location ('%s') as BigQuery dataset '%s'. " + "Please use a bucket "
+              + "that is in the same location as the dataset. For more details, see %s",
+          bucket, dataset.getLocation(), datasetName,
+          GCPUtils.GCS_SUPPORTED_DOC_URL);
+      throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN),
+        errorMessage, e.getMessage(), ErrorType.USER, true, ErrorCodeType.HTTP,
+          String.valueOf(e.getCode()), GCPUtils.GCS_SUPPORTED_DOC_URL, e);
+    }
   }
 
   /**

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySourceUtilsTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySourceUtilsTest.java
@@ -17,15 +17,18 @@
 package io.cdap.plugin.gcp.bigquery.source;
 
 import com.google.cloud.bigquery.Dataset;
+import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
+import io.cdap.cdap.api.exception.ProgramFailureException;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 
 public class BigQuerySourceUtilsTest {
 
@@ -49,5 +52,40 @@ public class BigQuerySourceUtilsTest {
     String bucket2 = BigQuerySourceUtils.getOrCreateBucket(configuration, st, config.getBucket(), ds,
                                                            "some-path", null);
     Assert.assertEquals("a-bucket", bucket2);
+  }
+
+  @Test
+  public void getOrCreateBucket_nullBucketConflict409_returnsBucketAndEnablesDelete() throws IOException {
+    Configuration configuration = new Configuration();
+    BigQuerySourceConfig config = BigQuerySourceConfig.builder().build();
+    Dataset ds = Mockito.mock(Dataset.class);
+    Storage st = Mockito.mock(Storage.class);
+    Mockito.when(st.create(Mockito.any(BucketInfo.class)))
+      .thenThrow(new StorageException(409, "Your previous request to create the named bucket succeeded "
+        + "and you already own it."));
+
+    String bucket = BigQuerySourceUtils.getOrCreateBucket(configuration, st, config.getBucket(), ds,
+                                                         "some-path", null);
+
+    Assert.assertEquals("bq-source-bucket-some-path", bucket);
+    Assert.assertTrue(configuration.getBoolean("fs.gs.bucket.delete.enable", false));
+  }
+
+  @Test
+  public void getOrCreateBucket_nullBucketNon409Error_throwsProgramFailureException() {
+    Configuration configuration = new Configuration();
+    BigQuerySourceConfig config = BigQuerySourceConfig.builder().build();
+    Dataset ds = Mockito.mock(Dataset.class);
+    DatasetId datasetId = DatasetId.of("project", "dataset");
+    Mockito.when(ds.getDatasetId()).thenReturn(datasetId);
+    Mockito.when(ds.getLocation()).thenReturn("US");
+    Storage st = Mockito.mock(Storage.class);
+    Mockito.when(st.create(Mockito.any(BucketInfo.class)))
+      .thenThrow(new StorageException(403, "Access denied"));
+
+    ProgramFailureException exception = Assert.assertThrows(ProgramFailureException.class, () ->
+      BigQuerySourceUtils.getOrCreateBucket(configuration, st, config.getBucket(), ds, "some-path", null));
+
+    Assert.assertTrue(exception.getMessage().contains("Access denied"));
   }
 }


### PR DESCRIPTION
[🍒]

🍒 [cherrypick](https://github.com/data-integrations/google-cloud/commit/27e0a2dadd9e7293ae2d830d9778cff0597ed6b3)

PR : (https://github.com/data-integrations/google-cloud/pull/1624)

## Summary
Fixes [PLUGIN-1787](https://cdap.atlassian.net/browse/PLUGIN-1787) / [b/539473185](https://buganizer.corp.google.com/issues/539473185) where BigQuery Source intermittently fails with `409 Conflict: Your previous request to create the named bucket succeeded and you already own it` when the GCS client retries temporary staging bucket creation after transient network timeouts.

## Changes
* Refactored bucket creation in `BigQuerySourceUtils.java` into a shared `createBucket` helper for both auto-generated and user-configured buckets.
* Caught `StorageException` and ignored `409 Conflict` so the pipeline proceeds normally when the bucket already exists.
* Non-409 errors (e.g. 403 Forbidden) continue to fail as expected.

## Testing
* **Unit Tests**: Updated `BigQuerySourceUtilsTest` following Google Unit Testing Best Practices (AAA pattern, `methodName_stateUnderTest_expectedBehavior`, and `Assert.assertThrows`).
  * `getOrCreateBucket_nullBucketConflict409_returnsBucketAndEnablesDelete`: Verifies 409 retry response returns the bucket and keeps delete enabled.
  * `getOrCreateBucket_nullBucketNon409Error_throwsProgramFailureException`: Verifies non-409 exceptions are properly propagated.
* Validated end-to-end on CDAP instance with pipeline `bq-409-conflict-resolution` (completed successfully).

[PLUGIN-1787]: https://cdap.atlassian.net/browse/PLUGIN-1787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ